### PR TITLE
Add node package information

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,13 @@
 {
+  "name": "geoadmin3",
+  "version": "3.0.0",
+  "description": "GeoAdmin 3 Application",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/geoadmin/mf-geoadmin3"
+  },
+  "author": "Swisstopo",
+  "readmeFileName": "README.md",
   "devDependencies": {
     "less": "1.4.0"
   }


### PR DESCRIPTION
Adding "name" and "version" prevents the following error with old node version:

```
$ ./buildout/bin/buildout
Updating template.
Installing node-modules.
npm ERR! Couldn't read dependencies.
npm ERR! Error: No 'name' field found in package.json
npm ERR!     at
/home/elemoine/local/lib/node_modules/npm/lib/utils/read-json.js:220:13
npm ERR!     at
/home/elemoine/local/lib/node_modules/npm/lib/utils/read-json.js:134:32
npm ERR!     at P
(/home/elemoine/local/lib/node_modules/npm/lib/utils/read-json.js:110:40)
npm ERR!     at cb
(/home/elemoine/local/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:36:9)
npm ERR!     at [object Object].<anonymous> (fs.js:107:5)
npm ERR!     at [object Object].emit (events.js:61:17)
npm ERR!     at afterRead (fs.js:878:12)
npm ERR!     at wrapper (fs.js:245:17)
npm ERR! Report this *entire* log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
npm ERR!
npm ERR! System Linux 2.6.35-24-virtual
npm ERR! command "node" "/home/elemoine/local/bin/npm" "install"
npm ERR! cwd /home/elemoine/mf-geoadmin3
npm ERR! node -v v0.4.12
npm ERR! npm -v 1.0.103
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /home/elemoine/mf-geoadmin3/npm-debug.log
npm not ok
While:
  Installing node-modules.
```

@gjn, please merge if you agree with this change. Thanks.
