### PR TITLE
Use proper view resolutions

### DIFF
--- a/app/index.mako
+++ b/app/index.mako
@@ -16,7 +16,7 @@
                x-ga-background-layer-selector-wmts-layers="wmtsLayers"></div>
         </form>
       </div>
-      <div class="map" x-ga-map="map"></div>
+      <div class="map" x-ga-map="map" x-ga-map-resolutions="resolutions"></div>
       <div class="footer navbar navbar-fixed-bottom">
         <div class="scaleline pull-left" x-ga-scale-line x-ga-scale-line-map="map"></div>
         <div class="attribution pull-left" x-ga-attribution x-ga-attribution-map="map"></div>

--- a/app/src/map/MapController.js
+++ b/app/src/map/MapController.js
@@ -11,6 +11,9 @@
       extent: swissExtent
     });
 
+    var resolutions = [650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0, 2.5,
+      2.0, 1.0, 0.5, 0.25, 0.1];
+
     var map = new ol.Map({
       controls: ol.control.defaults({
         attribution: false
@@ -19,11 +22,13 @@
       view: new ol.View2D({
         projection: swissProjection,
         center: ol.extent.getCenter(swissExtent),
-        zoom: 2
+        resolution: 500.0,
+        resolutions: resolutions
       })
     });
 
     $scope.map = map;
+    $scope.resolutions = resolutions;
 
   }]);
 

--- a/app/src/map/MapDirective.js
+++ b/app/src/map/MapDirective.js
@@ -9,6 +9,7 @@
           restrict: 'A',
           link: function(scope, element, attrs) {
             var map = $parse(attrs.gaMap)(scope);
+            var resolutions = $parse(attrs.gaMapResolutions)(scope);
             var view = map.getView();
 
             // set view states based on URL query string
@@ -17,11 +18,9 @@
               view.setCenter([+queryParams.Y, +queryParams.X]);
             }
             if (queryParams.zoom !== undefined) {
-              var projectionExtent = view.getProjection().getExtent();
-              var size = Math.max(
-               ol.extent.getHeight(projectionExtent),
-               ol.extent.getWidth(projectionExtent));
-              var resolution = size / (256 * Math.pow(2, queryParams.zoom));
+              var zoom = +queryParams.zoom;
+              zoom = Math.min(Math.max(zoom, 0), resolutions.length - 1);
+              var resolution = resolutions[zoom];
               view.setResolution(resolution);
             }
 


### PR DESCRIPTION
Things to note:
- The resolutions used are those provided by @cedricmoullet in #36.
- The resolutions are stored on the $scope for use by the map directive. (I'd like to add ol.View2D#zoomTo for that.)
- There's a bug in ol3 that triggers if you use zoom=11 and higher in the permalink. I'll fix it in ol3.

Please review.
