### PR TITLE
Adjustments to context menu directive

### DIFF
--- a/app/src/contextmenu/ContextMenuDirective.js
+++ b/app/src/contextmenu/ContextMenuDirective.js
@@ -27,6 +27,11 @@
           var epsg4326 = ol.proj.transform(epsg21781,
               'EPSG:21781', 'EPSG:4326');
 
+          // The $http service does not send requests immediately but
+          // wait for the "nextTick". Not sure this is bug in Angular.
+          // https://github.com/angular/angular.js/issues/2442 reports
+          // it a bug. As a workaround we call $http in an $apply
+          // callback.
           scope.$apply(function() {
             $q.all({
               height: $http.jsonp(heightURL, {


### PR DESCRIPTION
Based on discussions with @fred I've made two adjustments to the context menu directive:
- It is recommended to provide a callback function to $apply instead of changing states and then call $apply. This is related to error handling in Angular.
- If a change:center event occurs before the popup gets displayed then the popup cannot be hidden anymore. This is now fixed by registering the change:center event right before displaying the popup.
