### PR TITLE
Run tests both in dev and prod modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /app-prod
 /.build-artefacts
 /apache/app.conf
+/test/karma-conf-dev.js
+/test/karma-conf-prod.js
 
 # FIXME
 # The following are developer-specific and should probably be in the

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ help:
 	@echo
 
 .PHONY: all
-all: prod dev lint test apache
+all: prod dev lint test apache test/karma-conf-prod.js
 
 .PHONY: prod
 prod: app-prod/lib/build.js app-prod/style/app.css app-prod/index.html app-prod/info.json app-prod/WMTSCapabilities.xml $(APP_TEMPLATES_DEST) app-prod/img/
@@ -40,8 +40,8 @@ dev: app/src/deps.js app/style/app.css app/index.html
 lint: .build-artefacts/lint.timestamp
 
 .PHONY: test
-test: .build-artefacts/app-whitespace.js node_modules
-	npm test
+test: .build-artefacts/app-whitespace.js test/karma-conf-dev.js node_modules
+	./node_modules/.bin/karma start test/karma-conf-dev.js --single-run
 
 .PHONY: apache
 apache: apache/app.conf
@@ -85,6 +85,12 @@ app/index.html: app/index.mako.html .build-artefacts/python-venv/bin/mako-render
 
 apache/app.conf: apache/app.mako-dot-conf app-prod/lib/build.js app-prod/style/app.css .build-artefacts/python-venv/bin/mako-render
 	.build-artefacts/python-venv/bin/mako-render --var "version=$(VERSION)" --var "base_url_path=$(BASE_URL_PATH)" --var "service_url=$(SERVICE_URL)" --var "base_dir=$(CURDIR)" $< > $@
+
+test/karma-conf-dev.js: test/karma-conf.mako.js .build-artefacts/python-venv/bin/mako-render
+	.build-artefacts/python-venv/bin/mako-render $< > $@
+
+test/karma-conf-prod.js: test/karma-conf.mako.js .build-artefacts/python-venv/bin/mako-render
+	.build-artefacts/python-venv/bin/mako-render --var "mode=prod" $< > $@
 
 node_modules:
 	npm install

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "karma": "0.8.5"
   },
   "scripts": {
-    "test": "./node_modules/.bin/karma start test/karma_conf.js --single-run"
+    "test": "./node_modules/.bin/karma start test/karma-conf-prod.js --single-run"
   }
 }
 

--- a/test/karma-conf.mako.js
+++ b/test/karma-conf.mako.js
@@ -1,12 +1,19 @@
 // Karma configuration
 
 // base path, that will be used to resolve files and exclude
+% if mode == 'prod':
+basePath = '../app-prod';
+% else:
 basePath = '../app';
+% endif
 
 // list of files / patterns to load in the browser
 files = [
   MOCHA,
   MOCHA_ADAPTER,
+% if mode == 'prod':
+  'lib/build.js',
+% else:
   'lib/jquery-2.0.2.js',
   'lib/angular-1.1.5.js',
   'lib/bootstrap-3.0.0.js',
@@ -15,6 +22,7 @@ files = [
   '../test/closure-loader-globals.js',
   'lib/ol-whitespace.js',
   '../.build-artefacts/app-whitespace.js',
+% endif
   '../test/angular/angular-mocks.js',
   '../test/expect-0.2.0/expect.js',
   '../test/sinon-1.7.3/sinon.js',
@@ -79,4 +87,3 @@ captureTimeout = 5000;
 // Continuous Integration mode
 // if true, it capture browsers, run tests and exit
 singleRun = false;
-


### PR DESCRIPTION
With this PR we can run the tests both with build.js and the non-minified scripts. `make test` runs the tests against the non-minified scripts, so it should be used for development. And Travis runs both the development and production tests.

Please review.
