### PR TITLE
No request to qrcode service when popover hidden

### DIFF
--- a/app/src/contextmenu/ContextMenuDirective.js
+++ b/app/src/contextmenu/ContextMenuDirective.js
@@ -24,6 +24,7 @@
               var view = map.getView();
 
               var coord21781;
+              var popoverShown = false;
 
               // Listen to contextmenu events from the map.
               map.on('contextmenu', function(event) {
@@ -65,26 +66,36 @@
                     updatePopupLinks();
 
                     view.once('change:center', function() {
-                      scope.popoverClose();
+                      hidePopover();
                     });
 
                     element.css('left', (pixel[0] - 150) + 'px');
                     element.css('top', pixel[1] + 'px');
-                    element.css('display', 'block');
+                    showPopover();
                   });
                 });
               });
 
               // Listen to permalink change events from the scope.
               scope.$on('gaPermalinkChange', function(event) {
-                if (angular.isDefined(coord21781)) {
+                if (angular.isDefined(coord21781) && popoverShown) {
                   updatePopupLinks();
                 }
               });
 
-              scope.popoverClose = function() {
-                element.css('display', 'none');
+              scope.hidePopover = function() {
+                hidePopover();
               };
+
+              function showPopover() {
+                element.css('display', 'block');
+                popoverShown = true;
+              }
+
+              function hidePopover() {
+                element.css('display', 'none');
+                popoverShown = false;
+              }
 
               function updatePopupLinks() {
                 var p = {

--- a/app/src/contextmenu/partials/menu.html
+++ b/app/src/contextmenu/partials/menu.html
@@ -1,6 +1,6 @@
 <div class="arrow"></div>
 <div class="popover-inner">
-    <h4 class="popover-title">Position<button type="button" class="close" ng-click="popoverClose()">&times;</button></h4>
+    <h4 class="popover-title">Position<button type="button" class="close" ng-click="hidePopover()">&times;</button></h4>
     <div class="popover-content">
         <table>
             <tbody>


### PR DESCRIPTION
As [discussed](https://groups.google.com/forum/#!msg/re3-dev/cxEFYRW6z9Q/RQxcRoYrTLwJ) on the re3-dev mailing list we want to avoid triggering requests to the qrcodegenerator service, and filling the DB, when it's not necessary. Currently, after the popup has been shown once, any state change (e.g. zoom) triggers a request to the qrcodegenerator service, even when the popup is hidden. That's bad. This PR fixes that by triggering requests only when the popup is actually visible.

Please review.
