### PR TITLE
Dev deploy branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /apache/app.conf
 /test/karma-conf-dev.js
 /test/karma-conf-prod.js
+/deploy/deploy-branch.cfg
 
 # FIXME
 # The following are developer-specific and should probably be in the

--- a/apache/branches.conf
+++ b/apache/branches.conf
@@ -1,0 +1,34 @@
+RewriteEngine On
+ExpiresActive On
+
+FileETag none
+
+AddType application/json .json
+
+AddOutputFilterByType DEFLATE text/css
+AddOutputFilterByType DEFLATE text/html
+AddOutputFilterByType DEFLATE text/plain
+AddOutputFilterByType DEFLATE application/javascript
+AddOutputFilterByType DEFLATE application/xml
+AddOutputFilterByType DEFLATE application/json
+
+Alias /branch /var/www/vhosts/mf-geoadmin3/private/branches
+
+# Cached resources
+RewriteRule ^/branch/(.*)/app-prod/[0-9]*/(.*)$ /var/www/vhosts/mf-geoadmin3/private/branches/$1/app-prod/$2
+<LocationMatch /branch/*/app-prod/[0-9]*/>   
+   ExpiresDefault "now plus 1 year"
+   Header merge Cache-Control "public"
+</LocationMatch>
+
+# proxy
+ProxyPassMatch /branch/*/(print|ogcproxy)(.*)   http://mf-chsdi30t.bgdi.admin.ch/$1$2
+ProxyPassReverse /branch   http://mf-chsdi30t.bgdi.admin.ch
+
+
+<LocationMatch /branch/*/(print|ogcproxy)>
+    Order allow,deny
+    Allow from all
+</LocationMatch>
+
+

--- a/deploy/deploy-branch.mako.cfg
+++ b/deploy/deploy-branch.mako.cfg
@@ -1,0 +1,21 @@
+[DEFAULT]
+project = geoadmin
+
+[files]
+active = false
+
+[databases]
+active = false
+
+[code]
+#ignore = *.pyc, .svn
+dir = /var/www/vhosts/mf-geoadmin3/private/branches/${git_branch}/
+
+[apache]
+dest = /var/www/vhosts/mf-geoadmin3/conf/00-branches.conf
+content = Include /var/www/vhosts/mf-geoadmin3/private/branches/${git_branch}/apache/branches.conf
+
+[remote_hosts]
+ab = ec2-176-34-206-103.eu-west-1.compute.amazonaws.com 
+# NO PRODUCTION FOR BRANCHES!
+


### PR DESCRIPTION
This PR will allow the deployment of any branch to a permanent place on both test and integration.

Note: this does _not_ replace or supersede our existing deployment process for official deployments. These are untouched by this PR.

Use `make deploybranch` _in your working directory_ to deploy your current branch to test and integration. The code for deployment, however, does not come from your working directory, but does get cloned (first time) or pulled (if done once) _directly from github_. So you'll likely use this command _after_ you push your branch to github.

Use `make deploybranch GIT_BRANCH=dev_other_branch` to deploy a different branch than the one you are currently working on. Make sure that the branch specified exists on github.

The first time you use the command will take some time to execute.

The code of the deployed branch is in a specific directory `/var/www/vhosts/mf-geoadmin3/private/branches` on both test and integration. The apache configuration for all branches is in apache/branches.conf, which should be the same accross all branches. It puts all branches under the url `/branch/`. The 00-branches.conf in the vhost configuration points to the latest deployed branch.

Sample path:
`http://mf-geoadmin30i.bgdi.admin.ch/branch/dev_bottombar/app-prod`

Overview of all deployed branches:
`http://mf-geoadmin30i.bgdi.admin.ch/branch`

Please only use integration url for external communication (including here on github), even though the exact same structure is also available on our test instances.

Please review.
