### PR TITLE
Make sure that GIT_LAST_BRANCH is always set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BASE_URL_PATH ?= /$(shell id -un)
 SERVICE_URL ?= http://mf-chsdi30t.bgdi.admin.ch
 VERSION := $(shell date '+%s')/
 GIT_BRANCH := $(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD)
-GIT_LAST_BRANCH := $(shell cat .build-artefacts/last-git-branch 2> /dev/null)
+GIT_LAST_BRANCH := $(shell if [ -f .build-artefacts/last-git-branch ]; then cat .build-artefacts/last-git-branch 2> /dev/null; else echo 'dummy'; fi)
 DEPLOY_ROOT_DIR := /var/www/vhosts/mf-geoadmin3/private/branches
 
 


### PR DESCRIPTION
If last-git-branch file does not exist, the `test ...` failes and the file is never written, making the deploybranch target fail.

This assures that the variable is set to something, even if last-git-branch does not exist.

I'm sorry Eric, I didn't test your last PR good enough.
