### PR TITLE
Adding language change broadcast

### DIFF
--- a/src/components/backgroundlayerselector/BackgroundLayerSelectorDirective.js
+++ b/src/components/backgroundlayerselector/BackgroundLayerSelectorDirective.js
@@ -33,9 +33,8 @@
               });
              }
 
-             scope.$on('gaTopicChange', function(event, topic) {
-              gaLayers.loadForTopic(topic.id);
-              gaLayers.getBackgroundLayers().then(function(backgroundLayers) {
+             function onTriggeredChange() {
+               gaLayers.getBackgroundLayers().then(function(backgroundLayers) {
                 scope.backgroundLayers = backgroundLayers;
 
                 var queryParams = gaPermalink.getParams();
@@ -43,7 +42,16 @@
                    queryParams.bgLayer : backgroundLayers[0].id;
                 setCurrentLayer(scope.currentLayer);
                });
+            }
 
+             scope.$on('gaTopicChange', function(event, topic) {
+              gaLayers.loadForTopic(topic.id);
+              onTriggeredChange();
+             });
+
+             scope.$on('gaLanguageChange', function() {
+               gaLayers.reloadTopic();
+               onTriggeredChange();
              });
 
              scope.$watch('currentLayer', function(newVal, oldVal) {

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -70,6 +70,15 @@
         };
 
         /**
+         * Reload topics (e.g. for a language change)
+         */
+        this.reloadTopic = function() {
+          var loadedTopic = lastTopicId;
+          lastTopicId = '';
+          this.loadForTopic(loadedTopic);
+        };
+
+        /**
          * Return an ol.layer.Layer object for a layer id.
          */
         this.getOlLayerById = function(id) {

--- a/src/components/translation/TranslationDirective.js
+++ b/src/components/translation/TranslationDirective.js
@@ -7,7 +7,8 @@
   ]);
 
   module.directive('gaTranslationSelector',
-      ['$translate', 'gaPermalink', function($translate, gaPermalink) {
+      ['$rootScope', '$translate', 'gaPermalink',
+        function($rootScope, $translate, gaPermalink) {
         return {
           restrict: 'A',
           replace: true,
@@ -26,6 +27,7 @@
                 scope.lang = scope.options.fallbackCode;
               });
               gaPermalink.updateParams({lang: value});
+              $rootScope.$broadcast('gaLanguageChange', value);
             });
 
             var params = gaPermalink.getParams();


### PR DESCRIPTION
This adresses #173 

The Language directive now broadcasts a gaLanguageChange message
that other controllers/directives can listen to. This allows
directive that rely on outside source which are language
dependant to reload their resources. This is needed because
our services deliver translated things (like catalog entries,
layer names, etc) which are not translated on the client.

The only directive now depending on this is the
backgroundlayerselector. Before this, the language in the combobox
didn't change. Now it does.
