### PR TITLE
Only start tracking the position when needed

### DIFF
--- a/src/components/geolocation/GeolocationDirective.js
+++ b/src/components/geolocation/GeolocationDirective.js
@@ -4,6 +4,7 @@
   goog.require('ga_permalink');
 
   var module = angular.module('ga_geolocation_directive', [
+    'ga_permalink'
   ]);
 
   module.directive('gaGeolocation', ['$parse', 'gaPermalink',


### PR DESCRIPTION
Don't start tracking the position on page load but when the button is clicked or when the permalink has `geolocation=true`
