### PR TITLE
Adding layer definition to olLayer

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -77,12 +77,13 @@
           var olLayer = layer.olLayer;
           var attribution = '&copy; Data: ' + layer.attribution;
           if (!angular.isDefined(olLayer)) {
+            layer.id = id;
             if (layer.type == 'wmts') {
               var wmtsUrl = wmtsGetTileUrl.replace('{Layer}', id).
                             replace('{Format}', layer.format);
 
               olLayer = new ol.layer.TileLayer({
-                id: id,
+                gaLayer: layer,
                 source: new ol.source.WMTS({
                   attributions: [
                     new ol.Attribution(attribution)


### PR DESCRIPTION
I think it makes sense to have the complete layer definition as property of the olLayer. Depending on the LayerManager (to be done), it might be removed.

But for now, it's valuable so different components get their information directly from the olLayer.
