### PR TITLE
Use ng-init to initialize options in ga-popup

### DIFF
--- a/src/components/popup/PopupDirective.js
+++ b/src/components/popup/PopupDirective.js
@@ -10,7 +10,7 @@
            transclude: true,
            scope: {
              toggle: '=gaPopup',
-             optionsFunc: '&gaPopupOptions' // Options from directive
+             options: '=gaPopupOptions'
            },
            template:
              '<h4 class="popover-title ga-popup-title">' +
@@ -23,9 +23,6 @@
              '</div>',
 
            link: function(scope, element, attrs) {
-
-             // Get the popup options
-             scope.options = scope.optionsFunc();
 
              if (!scope.options) {
                scope.options = {

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -299,8 +299,9 @@
     </div>
 
     <!-- Popup: Import WMS -->
-    <div ga-popup="importWmsPopupShown"
-         ga-popup-options="{title:'import_wms'}"
+    <div ng-init="options = {title: 'import_wms'}"
+         ga-popup="importWmsPopupShown"
+         ga-popup-options="options"
          ga-draggable=".ga-popup-title"
          id="import-wms-popup" >
 	    <div ng-controller="GaImportWmsController">
@@ -314,8 +315,9 @@
     </div> <!-- end Import WMS -->
     
     <!-- Popup: Import KML -->
-    <div ga-popup="importKmlPopupShown"
-         ga-popup-options="{title:'import_kml'}"
+    <div ng-init="options = {title: 'import_kml'}"
+         ga-popup="importKmlPopupShown"
+         ga-popup-options="options"
          ga-draggable=".ga-popup-title"
          id="import-kml-popup" >
       <div ng-controller="GaImportKmlController">


### PR DESCRIPTION
We discussed this in the popup PR.

This PR streamlines the directive (replace & with = in the scope definitions), by using ng-init in the html part where needed.

It's more a POC for me, but if you like it, you can merge it.
