### PR TITLE
gaCatalogtree and gaLayers depend on pascalprecht.translate

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -1,10 +1,8 @@
 (function() {
   goog.provide('ga_catalogtree_directive');
 
-  goog.require('ga_translation');
-
   var module = angular.module('ga_catalogtree_directive', [
-    'ga_translation'
+    'pascalprecht.translate'
   ]);
 
   /**
@@ -48,7 +46,6 @@
               currentTopic = topic.id;
               updateCatalogTree();
            });
-
 
           }
         };

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1,11 +1,10 @@
 (function() {
   goog.provide('ga_map_service');
 
-  goog.require('ga_translation');
   goog.require('ga_urlutils_service');
 
   var module = angular.module('ga_map_service', [
-    'ga_translation',
+    'pascalprecht.translate',
     'ga_urlutils_service'
   ]);
 


### PR DESCRIPTION
The catalog tree directive and the layers service just use the `$translate` service, so, really, they don't depend on the ga_translation module but just on the pascalprecht.translate module (recall that the ga_translation pulls the lang selector directive). The importwms and importkml got this [right](https://github.com/geoadmin/mf-geoadmin3/blob/master/src/components/importkml/ImportKmlDirective.js#L10) already, so this PR suggests to do the same for the catalog tree directive and the layers service.

Please review, and merge.
