### PR TITLE
Map directive adds ZoomToExtent control

### DIFF
--- a/src/components/map/MapDirective.js
+++ b/src/components/map/MapDirective.js
@@ -53,6 +53,8 @@
               updatePermalink();
 
               map.addControl(new ol.control.ZoomSlider());
+              map.addControl(new ol.control.ZoomToExtent());
+
               map.setTarget(element[0]);
             }
           };

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -27,8 +27,6 @@
       })
     });
 
-    map.addControl(new ol.control.ZoomToExtent());
-
     return map;
   }
 


### PR DESCRIPTION
https://github.com/geoadmin/mf-geoadmin3/commit/753cacc0e8a0e8bbc080a63216a3b50bc408cf12 added a ZoomToExtent control to the map. The call to addControl is done at the application level, by the map controller. For the zoom slider, the map directive, as opposed to the map controller, does the addControl. I'd suggest that we are consistent, and treat both controls the same way. This PR makes the map directive add the ZoomToExtent control.

Please review.
