### PR TITLE
Clean up CSS in accordion tools

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -146,9 +146,10 @@
                 <!-- Import -->
                 <div class="accordion-group">
                   <div class="accordion-heading">
-                    <a class="accordion-toggle collapsed" data-toggle="collapse"
-                      data-parent="#tools-accordion" href="#import">
-                      <i class="icon-collapse-alt"></i><span translate>import</span>
+                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#tools-accordion" href="#import">
+                      <i class="visible-collapsed icon-expand-alt"></i>
+                      <i class="hidden-collapsed icon-collapse-alt"></i>
+                      <span translate>import</span>
                     </a>
                   </div>
                   <div id="import" class="accordion-body collapse">
@@ -172,9 +173,10 @@
                 <!-- Measure -->
                 <div class="accordion-group">
                   <div class="accordion-heading">
-                    <a class="accordion-toggle collapsed" data-toggle="collapse"
-                      data-parent="#tools-accordion" href="#measure" >
-                      <i class="icon-collapse-alt"></i><span translate>measure</span>
+                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#tools-accordion" href="#measure" >
+                      <i class="visible-collapsed icon-expand-alt"></i>
+                      <i class="hidden-collapsed icon-collapse-alt"></i>
+                      <span translate>measure</span>
                     </a>
                   </div>
                   <div id="measure" class="accordion-body collapse">
@@ -187,9 +189,10 @@
                 <!-- Drawing -->
                 <div class="accordion-group">
                   <div class="accordion-heading">
-                    <a class="accordion-toggle collapsed" data-toggle="collapse"
-                      data-parent="#tools-accordion" href="#drawing" >
-                      <i class="icon-collapse-alt"></i><span translate>drawing</span>
+                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#tools-accordion" href="#drawing" >
+                      <i class="visible-collapsed icon-expand-alt"></i>
+                      <i class="hidden-collapsed icon-collapse-alt"></i>
+                      <span translate>drawing</span>
                     </a>
                   </div>
                   <div id="drawing" class="accordion-body collapse">

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -305,10 +305,6 @@
               color: #000;
               font-weight: bold;
               border-bottom: none;
-
-              i.icon-collapse-alt::before {
-                  content: "\f116";
-              }
          }
   
          span {


### PR DESCRIPTION
Instead of changing the char code of the icon, use the same system
as in the main pulldown toggle. (visible-collapsed and hidden-collapsed
classes).
