### PR TITLE
Centralize legend getter in a service

### DIFF
--- a/src/components/LayerMetadataPopupService.js
+++ b/src/components/LayerMetadataPopupService.js
@@ -1,0 +1,34 @@
+(function() {
+  goog.provide('ga_layer_metadata_popup_service');
+
+  goog.require('ga_map_service');
+  goog.require('ga_popup_service');
+
+  var module = angular.module('ga_layer_metadata_popup_service', [
+    'ga_map_service',
+    'ga_popup_service',
+    'pascalprecht.translate'
+  ]);
+
+  module.provider('gaLayerMetadataPopup', function() {
+    this.$get = ['$translate', 'gaPopup', 'gaLayers',
+        function($translate, gaPopup, gaLayers) {
+          return function(bodid) {
+            gaLayers.getMetaDataOfLayer(bodid)
+            .success(function(data) {
+              gaPopup.create({
+                title: $translate('metadata_window_title'),
+                content: data,
+                x: 400,
+                y: 200
+              }).open();
+            })
+            .error(function() {
+              //FIXME: better error handling
+              var msg = 'Could not retrieve information for ' + bodid;
+              alert(msg);
+            });
+          };
+    }];
+  });
+})();

--- a/src/components/catalogtree/CatalogitemDirective.js
+++ b/src/components/catalogtree/CatalogitemDirective.js
@@ -1,8 +1,8 @@
 (function() {
   goog.provide('ga_catalogitem_directive');
 
+  goog.require('ga_layer_metadata_popup_service');
   goog.require('ga_map_service');
-  goog.require('ga_popup_service');
 
   //static functions
   function getMapLayer(map, id) {
@@ -44,16 +44,16 @@
   }
 
   var module = angular.module('ga_catalogitem_directive', [
-    'ga_map_service',
-    'ga_popup_service'
+    'ga_layer_metadata_popup_service',
+    'ga_map_service'
   ]);
 
   /**
    * See examples on how it can be used
    */
   module.directive('gaCatalogitem',
-      ['$compile', 'gaLayers', 'gaPopup',
-      function($compile, gaLayers, gaPopup) {
+      ['$compile', 'gaLayers', 'gaLayerMetadataPopup',
+      function($compile, gaLayers, gaLayerMetadataPopup) {
         return {
           restrict: 'A',
           templateUrl: 'components/catalogtree/partials/catalogitem.html',
@@ -116,21 +116,7 @@
         }
 
         function getLegend(ev, bodid) {
-          var scope = this;
-          scope.gaLayers.getMetaDataOfLayer(bodid)
-          .success(function(data) {
-            gaPopup.create({
-              title: 'metadata_window_title',
-              content: data,
-              x: 400,
-              y: 200
-            }).open(scope);
-          })
-          .error(function() {
-            //FIXME: better error handling
-            var msg = 'Could not retrieve information for ' + bodid;
-            alert(msg);
-          });
+          gaLayerMetadataPopup(bodid);
           ev.stopPropagation();
         }
       }]

--- a/src/components/popup/PopupService.js
+++ b/src/components/popup/PopupService.js
@@ -5,7 +5,7 @@
 
   module.provider('gaPopup', function() {
 
-    this.$get = ['$compile', function($compile) {
+    this.$get = ['$compile', '$rootScope', function($compile, $rootScope) {
 
       var Popup = function(options) {
 
@@ -31,7 +31,7 @@
 
         // We create a new scope then compile the element
         if (!this.scope) {
-          this.scope = scope.$new();
+          this.scope = (scope || $rootScope).$new();
           this.scope.options = this.options;
           $compile(this.element)(this.scope);
         }


### PR DESCRIPTION
This is an attempt to avoid code duplication.

The function getLegend was used in both the catalog directive and the search directive.

The getLegend function would now be centralized in gaLegend.

This PR also includes:
1) As SuggestionRendered event is fired multiple times for each query, the html elements were compiled several times as well. As a result, ng-click was fired twice. Now, we make sure we compile only when all the suggestions are ready for a given query.

2) In PopupService a child scope is created if no scope is in the method "open"

3) CatalogitemDirective has been adapted to the new LegendService
