### PR TITLE
Search rendering/compile only once more robust

### DIFF
--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -266,9 +266,9 @@
               var viewDropDown = $(taElt).data('ttView').dropdownView;
               viewDropDown.on('suggestionsRendered', function(event) {
                 if (viewDropDown.isVisible()) {
-                  suggestionsRendered = suggestionsRendered + 1;
+                  suggestionsRendered += 1;
                   // Make sure the final html content is compiled once only
-                  if (typeAheadDatasets.length == suggestionsRendered) {
+                  if (typeAheadDatasets.length === suggestionsRendered) {
                     // Only for layer search at the moment
                     var elements = element.find('.tt-dataset-layers');
                     $compile(elements)(scope);


### PR DESCRIPTION
This makes the workaround to assure that the rendered results are compiled only once a little more robust and it increases code readability a little bit.

Now adding another dataset won't break the rendering/compile cycle.
