### PR TITLE
Get rid of hardcoded layers in MapService.js

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -38,13 +38,6 @@
     this.$get = ['$q', '$http', '$translate', '$rootScope', 'gaUrlUtils',
         'gaTileGrid',
         function($q, $http, $translate, $rootScope, gaUrlUtils, gaTileGrid) {
-
-      // not configurable at the moment, but could be, in the same way
-      // as layersConfigUrlTemplate
-      var wmtsGetTileUrlTemplate =
-          'http://wmts.geo.admin.ch/1.0.0/{Layer}/default/' +
-          '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
-
       var attributions = {};
       var getAttribution = function(text) {
         var key = text;
@@ -57,7 +50,8 @@
         }
       };
 
-      var Layers = function(layersConfigUrlTemplate, legendUrlTemplate) {
+      var Layers = function(wmtsGetTileUrlTemplate,
+          layersConfigUrlTemplate, legendUrlTemplate) {
         var currentTopicId;
         var layers;
 
@@ -210,7 +204,8 @@
         };
       };
 
-      return new Layers(this.layersConfigUrlTemplate, this.legendUrlTemplate);
+      return new Layers(this.wmtsGetTileUrlTemplate,
+          this.layersConfigUrlTemplate, this.legendUrlTemplate);
     }];
 
   });

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -409,6 +409,10 @@
             baseUrlPath: '${base_url_path}'});
 
           module.config(['gaLayersProvider', function(gaLayersProvider) {
+            gaLayersProvider.wmtsGetTileUrlTemplate =
+                'http://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
+                '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
+
             gaLayersProvider.layersConfigUrlTemplate =
                 '${service_url}/rest/services/{Topic}/MapServer/layersconfig' +
                 '?lang={Lang}';

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -9,6 +9,9 @@ beforeEach(function() {
   });
 
   module(function(gaLayersProvider) {
+    gaLayersProvider.wmtsGetTileUrlTemplate =
+        'http://wmts.com/foo/{Layer}/default/{Time}/21781/' +
+        '{TileMatrix}/{TileRow}/{TileCol}.{Format}';
     gaLayersProvider.layersConfigUrlTemplate =
         'http://example.com/{Topic}?lang={Lang}';
   });


### PR DESCRIPTION
There are 2 hardcoded urls in this services. We should get rid of them and configure them differently (read up on DI for services)
