### PR TITLE
Make sure not to reference inexistent element/scope

### DIFF
--- a/src/components/popup/PopupService.js
+++ b/src/components/popup/PopupService.js
@@ -32,38 +32,32 @@
         this.scope = (scope || $rootScope).$new();
         this.scope.options = options;
         this.element = $compile(element)(this.scope);
+        this.destroyed = false;
 
         // Attach popup to body element
         $(document.body).append(this.element);
       };
 
       Popup.prototype.open = function(scope) {
-        if (this.element) {
-          // Show the popup
-          this.element.show();
-        }
+        // Show the popup
+        this.element.show();
       };
 
       Popup.prototype.close = function() {
-        if (this.element) {
-          this.element.hide();
+        this.element.hide();
 
-          var destroyOnClose = this.scope.options.destroyOnClose;
-          if (destroyOnClose !== false) {
-            this.destroy();
-          }
+        var destroyOnClose = this.scope.options.destroyOnClose;
+        if (destroyOnClose !== false) {
+          this.destroy();
         }
       };
 
       Popup.prototype.destroy = function() {
-        if (this.scope) {
-          this.scope.$destroy();
-          this.scope = null;
-        }
-        if (this.element) {
-          this.element.remove();
-          this.element = null;
-        }
+        this.scope.$destroy();
+        this.scope = null;
+        this.element.remove();
+        this.element = null;
+        this.destroyed = true;
      };
 
       return {


### PR DESCRIPTION
Just make sure that not existing element might be used. Note: this kind of smells, I know.

Reason: close might be called on popup directly (user clicks cross) or by the application. Anyhow, application does not know if popup still exists. This renders it a little more robust.
