### PR TITLE
Dev tooltip positioning

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -36,7 +36,6 @@
 
                 $scope.$apply(function() {
                   findFeatures($scope,
-                               evt.getPixel(),
                                evt.getCoordinate(),
                                size,
                                extent);
@@ -49,7 +48,7 @@
             }
           };
 
-          function findFeatures(scope, pixel, coordinate, size, extent) {
+          function findFeatures(scope, coordinate, size, extent) {
             var identifyUrl = scope.options.identifyUrlTemplate
                               .replace('{Topic}', currentTopic),
                 layersToQuery = getLayersToQuery(scope.map.getLayers());
@@ -75,19 +74,19 @@
                   callback: 'JSON_CALLBACK'
                 }
               }).success(function(features) {
-                showFeatures(scope, pixel, features.results);
+                showFeatures(scope, size, features.results);
               });
             }
 
             // htmls = [] would break the reference in the popup
-            htmls.splice(0, htmls.length);;
+            htmls.splice(0, htmls.length);
 
             if (popup) {
               popup.close();
             }
           }
 
-          function showFeatures(scope, pixel, foundFeatures) {
+          function showFeatures(scope, size, foundFeatures) {
             if (foundFeatures && foundFeatures.length > 0) {
               angular.forEach(foundFeatures, function(value) {
                 var htmlUrl = scope.options.htmlUrlTemplate
@@ -105,15 +104,20 @@
                   if (htmls.length === 0) {
                     if (!popup) {
                       popup = gaPopup.create({
+                        className: 'ga-tooltip',
                         destroyOnClose: false,
                         title: 'object_information',
                         content: popupContent,
-                        htmls: htmls,
-                        x: pixel[0],
-                        y: pixel[1]
+                        htmls: htmls
                       }, scope);
                     }
                     popup.open();
+                    //always reposition element when newly opened
+                    popup.element.css({
+                      top: 89,
+                      left: ((size[0] / 2) -
+                             (parseFloat(popup.element.css('max-width')) / 2))
+                    });
                   }
                   // Add result to array. ng-repeat will take care of the rest
                   htmls.push($sce.trustAsHtml(html));

--- a/src/components/tooltip/style/tooltip.less
+++ b/src/components/tooltip/style/tooltip.less
@@ -1,8 +1,27 @@
-.tooltip-separator {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  margin-top: 4px;
-  margin-bottom: 4px;
-  border-bottom-color: #c7c7c7;
+@tooltip-width: 450;
+@tooltip-height: 600;
+
+.ga-tooltip {
+  width: unit(@tooltip-width, px);
+  max-width: unit(@tooltip-width, px);
+  max-height: unit(@tooltip-height, px);
+
+  .popover-content {
+    padding-right: 0px;
+  }
+
+  td {
+    padding-right: 14px;
+  }
+
+
+  .tooltip-separator {
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    margin-top: 4px;
+    margin-bottom: 4px;
+    border-bottom-color: #c7c7c7;
+  }
 }
+
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -70,9 +70,6 @@
 
     <div id="map" class="map" ga-map ga-map-map="map">
       <div ga-geolocation ga-geolocation-map="map"></div>
-      <div ng-controller="GaTooltipController">
-        <div ga-tooltip ga-tooltip-map="map" ga-tooltip-options="options"></div>
-      </div>
       <div id="copyrightsdata">
         <div>
           <span >&copy;&nbsp;</span>
@@ -111,6 +108,9 @@
       <div ga-context-popup ga-context-popup-map="map" ga-context-popup-options="options"></div>
     </div>
 
+    <div ng-controller="GaTooltipController">
+      <div ga-tooltip ga-tooltip-map="map" ga-tooltip-options="options"></div>
+    </div>
 
     <div id="pulldown">
       <div id="pulldown-content" class="panel-group content ${"in" if device == "desktop" else "collapse"}">

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -386,10 +386,6 @@ a .ga-icon-separator {
   }
 }
 
-.tooltip-inner {
-  text-align: left;
-}
-
 // ****** MODAL
 .modal {
   overflow: auto;
@@ -602,3 +598,17 @@ ul.panel-body-wide {
 .tt-hint {
   display: none !important;
 }
+
+.ga-tooltip {
+  @media (max-height: @screen-phone) {
+    width: 300px;
+    max-height: 450px;
+    max-width: 300px;
+  }
+}
+
+.tooltip-inner {
+  text-align: left;
+}
+
+


### PR DESCRIPTION
This PR addresses the following:
- Re-use existing popup for tooltip (there can only be one at a time, as in RE2)
- Position the popup always at the same place (like RE2)
- Positioning and size of popup on mobile devices should be better now

Maybe another round of a CSS specialist might be needed. But this PR should render the tooltip usable on mobile devices.
