### PR TITLE
Catalog Tree performance boost

### DIFF
--- a/src/components/catalogtree/partials/catalogitem.html
+++ b/src/components/catalogtree/partials/catalogitem.html
@@ -17,9 +17,9 @@
       <i ng-class="{'icon-minus': item.selectedOpen, 'icon-plus': !item.selectedOpen}"></i>
       {{item.label}}
     </a>
-    <ul ng-class="{closed: !item.selectedOpen}">
+    <ul ng-if="item.selectedOpen">
       <li ng-repeat="child in item.children">
-      <div ga-catalogitem ga-catalogitem-item="child" ga-catalogitem-map="map"></div>
+        <div ga-catalogitem ga-catalogitem-item="child" ga-catalogitem-map="map"></div>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
By using ng-if in node elements (categories), we can add/remove DOM elements (and their assiciated scopes/watches) based on if the node is open or not.

It's really nice how angular plays with this, as the state of the tree is kept in the model and when the elements are recreated (also the scope gets recreated), the new elements reflect the state of the existing model!

I'm quite sure this can be improved further, but for now this boosts performance extremely (when catalogtree is closed).
