### PR TITLE
keep map rotation ?

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -18,6 +18,10 @@
       controls: ol.control.defaults({
         attribution: false
       }),
+      interactions: ol.interaction.defaults({
+        altShiftDragRotate: false,
+        touchRotate: false
+      }),
       renderer: ol.RendererHint.CANVAS,
       view: new ol.View2D({
         projection: swissProjection,


### PR DESCRIPTION
especially when the swissimage layer is active, it's very hard to navigate when the map  is rotated.

At least a 'compass' icon should be displayed when rotated.
