### PR TITLE
Up and down arrows functional in layer manager

### DIFF
--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -49,6 +49,13 @@
               map.removeLayer(layer);
             };
 
+            scope.moveLayer = function(layer, delta) {
+              var index = scope.layers.indexOf(layer);
+              var layersCollection = scope.map.getLayers();
+              layersCollection.removeAt(index);
+              layersCollection.insertAt(index + delta, layer);
+            };
+
           }
         };
       }]

--- a/src/components/layermanager/partials/layermanager.html
+++ b/src/components/layermanager/partials/layermanager.html
@@ -10,8 +10,10 @@
       <span translate>transparency</span>&nbsp; <input type="range" />
     </label>
     <div class="ordering">
-      <a href="#" class="icon-arrow-up"></a>
-      <a href="#" class="icon-arrow-down"></a>
+      <a href="#" class="icon-arrow-up" ng-if="!$first" ng-click="moveLayer(layer, -1)"></a>
+      <i class="icon-arrow-up" ng-if="$first"></i>
+      <a href="#" class="icon-arrow-down" ng-if="!$last" ng-click="moveLayer(layer, 1)"></a>
+      <i class="icon-arrow-down" ng-if="$last"></i>
     </div>
   </li>
 </ul>


### PR DESCRIPTION
This PR makes the up and down arrows operational in the layer manager.

The markup is also changed so that `<i>` is used instead of `<a>` for the the first "up" arrow and the last "down" arrow, as suggested in https://github.com/geoadmin/mf-geoadmin3/pull/348#issuecomment-23412946.

Please review.

Currently the layer to the top in the map is at the bottom in the layer manager, and it looks like re2 has a different behavior. Should the behavior of re2 be retained? If so I change work on the required modifications, and create a new PR for that.
