### PR TITLE
Make less parameters configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SRC_COMPONENTS_LESS_FILES := $(shell find src/components -type f -name '*.less')
 SRC_COMPONENTS_PARTIALS_FILES = $(shell find src/components -type f -path '*/partials/*' -name '*.html')
 BASE_URL_PATH ?= /$(shell id -un)
 SERVICE_URL ?= http://mf-chsdi30t.bgdi.admin.ch
+LESS_PARAMETERS ?= '-ru'
 VERSION := $(shell date '+%s')/
 GIT_BRANCH := $(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 GIT_LAST_BRANCH := $(shell if [ -f .build-artefacts/last-git-branch ]; then cat .build-artefacts/last-git-branch 2> /dev/null; else echo 'dummy'; fi)
@@ -108,9 +109,8 @@ prod/info.json: src/info.json
 src/deps.js: $(SRC_JS_FILES) .build-artefacts/python-venv .build-artefacts/closure-library
 	.build-artefacts/python-venv/bin/python .build-artefacts/closure-library/closure/bin/build/depswriter.py --root_with_prefix="src/components components" --root_with_prefix="src/js js" --output_file=$@
 
-# WARNING: --line-numbers=mediaquery doesn't work on IE9, remove this option if you want debug RE3 in dev mode
 src/style/app.css: src/style/app.less src/style/ga_bootstrap.less src/style/ga_variables.less $(SRC_COMPONENTS_LESS_FILES) node_modules .build-artefacts/bootstrap
-	node_modules/.bin/lessc --line-numbers=mediaquery -ru $< $@
+	node_modules/.bin/lessc $(LESS_PARAMETERS) $< $@
 
 src/index.html: src/index.mako.html .build-artefacts/python-venv/bin/mako-render
 	.build-artefacts/python-venv/bin/mako-render --var "device=desktop" --var "version=" --var "base_url_path=$(BASE_URL_PATH)" --var "service_url=$(SERVICE_URL)" $< > $@


### PR DESCRIPTION
When you want to have css numbers in debug mode, you can specify the LESS_PARAMETERS variable in your rc_\* file as follows:

`export LESS_PARAMETERS='--line-numbers=mediaquery -ru'` 

and source it. Or directly export it on your console.

With this PR, the default behaviour works in IE.
