### PR TITLE
Make sure layer is only added if not already in map

### DIFF
--- a/src/components/catalogtree/CatalogitemDirective.js
+++ b/src/components/catalogtree/CatalogitemDirective.js
@@ -40,7 +40,10 @@
               // Add active layer initially
               if (scope.item.children === undefined &&
                   scope.item.selectedOpen) {
-                addLayer(scope.map, scope.item);
+                var layer = getMapLayer(scope.map, scope.item.idBod);
+                if (!angular.isDefined(layer)) {
+                  addLayer(scope.map, scope.item);
+                }
               }
 
               compiledContent(scope, function(clone, scope) {


### PR DESCRIPTION
This fixes the bug mentioned by @elemoine in #359 where switching languages or topics adds existing maps multiple times to the map.
