### PR TITLE
Make that the crosshair param is "cleanex"

### DIFF
--- a/src/components/map/MapDirective.js
+++ b/src/components/map/MapDirective.js
@@ -38,7 +38,7 @@
                   element: crosshair.get(0),
                   position: view.getCenter()
                 });
-                gaPermalink.deleteParam('crosshair');
+                gaPermalink.deleteKey('crosshair');
               }
 
               // Update permalink based on view states. We use a timeout

--- a/src/components/permalink/PermalinkService.js
+++ b/src/components/permalink/PermalinkService.js
@@ -73,7 +73,7 @@
       angular.extend(params, p);
     };
 
-    this.deleteParam = function(id) {
+    this.deleteKey = function(id) {
        delete params[id];
     };
   }


### PR DESCRIPTION
The crosshair is simply placed in the middle of the map, as in RE2.
This means that we can't keep this crosshair permalink parameter if the position of the map moves. This PR simply deletes the crosshair permalink parameter just after it's usage.
