### PR TITLE
Make catalogtree work with language depending layers sorting

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -27,19 +27,35 @@
             var currentTopic;
 
             // This assumes that both trees contain the same
-            // elements, but with different values
+            // elements, categories are in the same order and
+            // contain the same layers, but layers can have
+            // a different order (sorted by language)
+            // FIXME being aware that layers can have different
+            // order can change in the back-end (remove relevant code)
             var retainTreeState = function(oldAndNewTrees) {
               var oldTree = oldAndNewTrees.oldTree;
               var newTree = oldAndNewTrees.newTree;
-              var i;
+              var i, oldChild, newChild, oldMap = {}, newMap = {};
               newTree.selectedOpen = oldTree.selectedOpen;
               if (newTree.children) {
                 for (i = 0; i < newTree.children.length; i++) {
-                  retainTreeState({
-                    oldTree: oldTree.children[i],
-                    newTree: newTree.children[i]
-                  });
+                  oldChild = oldTree.children[i];
+                  newChild = newTree.children[i];
+                  // If no idBod, then it's a node (category)
+                  if (!angular.isDefined(oldChild.idBod)) {
+                    retainTreeState({
+                      oldTree: oldChild,
+                      newTree: newChild
+                    });
+                  } else {
+                    oldMap[oldChild.idBod] = oldChild;
+                    newMap[newChild.idBod] = newChild;
+                  }
                 }
+                angular.forEach(oldMap, function(value, key) {
+                  newMap[key].selectedOpen = value.selectedOpen;
+                  newMap[key].errorLoading = value.errorLoading;
+                });
               }
             };
 


### PR DESCRIPTION
This adresses the bug discussed in [1]. It handles language correctly to keep state of the catalog tree (layers are sorted by name in the catalog returned by the service).

If we decide to adapt the service, then this would need to be addressed differently. So this can/should be considered a temporary hack.

[1] https://groups.google.com/forum/#!topic/re3-dev/GxN8EZOrESM
