### PR TITLE
gaPermalink deleteKey renamed to deleteParam

### DIFF
--- a/src/components/map/MapDirective.js
+++ b/src/components/map/MapDirective.js
@@ -38,7 +38,7 @@
                   element: crosshair.get(0),
                   position: view.getCenter()
                 });
-                gaPermalink.deleteKey('crosshair');
+                gaPermalink.deleteParam('crosshair');
               }
 
               // Update permalink based on view states. We use a timeout

--- a/src/components/permalink/PermalinkService.js
+++ b/src/components/permalink/PermalinkService.js
@@ -73,8 +73,8 @@
       angular.extend(params, p);
     };
 
-    this.deleteKey = function(id) {
-       delete params[id];
+    this.deleteParam = function(key) {
+       delete params[key];
     };
   }
 
@@ -99,9 +99,11 @@
    * - getHref Get full permalink.
    * - getParams Get the search params.
    * - updateParams Update the search params.
+   * - deleteParam Delete a search param.
    *
-   * updateParams should be called during a digest cycle. If the browser
-   * supports the history API the link in the address bar is updated.
+   * updateParams and deleteParam should be called during a digest cycle.
+   * If the browser supports the history API the link in the address bar
+   * is updated.
    */
   module.provider('gaPermalink', function() {
     this.$get = ['$window', '$rootScope', '$sniffer', 'gaHistory',


### PR DESCRIPTION
This follows up on #401.
