### PR TITLE
WORK IN PROGRESS: Add a link in the attribution.

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -84,7 +84,9 @@
         if (key in attributions) {
           return attributions[key];
         } else {
-          var a = new ol.Attribution({html: text});
+          var a = new ol.Attribution(
+            {html: '<a href="' + $translate(text + '.url') +
+              '" target="_blank">' + $translate(text) + '</a>'});
           attributions[key] = a;
           return a;
         }


### PR DESCRIPTION
The same principle like in RE2 is followed. 
For now, this doesn't work, since the layerconfig service needs to be updated. See https://github.com/geoadmin/mf-chsdi3/issues/53
But, I don't think it's needed to wait for this fix.
