### PR TITLE
Tentative attempt to fix the permalink refresh problem in IE

### DIFF
--- a/src/components/permalink/PermalinkService.js
+++ b/src/components/permalink/PermalinkService.js
@@ -53,9 +53,10 @@
     }
   }
 
-  function Permalink(b, p) {
+  function Permalink(b, p, r) {
     var base = b;
     var params = p;
+    var rootScope = r;
 
     this.getHref = function(p) {
       var newParams = angular.extend({}, params);
@@ -71,10 +72,12 @@
 
     this.updateParams = function(p) {
       angular.extend(params, p);
+      rootScope.$broadcast('gaPermalinkChange');
     };
 
     this.deleteParam = function(key) {
        delete params[key];
+       rootScope.$broadcast('gaPermalinkChange');
     };
   }
 
@@ -118,7 +121,9 @@
             loc.pathname;
 
         var permalink = new Permalink(
-            base, parseKeyValue(loc.search.substring(1)));
+            base,
+            parseKeyValue(loc.search.substring(1)),
+            $rootScope);
 
         if ($sniffer.history) {
           var lastHref = loc.href;
@@ -128,7 +133,6 @@
               $rootScope.$evalAsync(function() {
                 lastHref = newHref;
                 gaHistory.replaceState(null, '', newHref);
-                $rootScope.$broadcast('gaPermalinkChange');
               });
             }
           });


### PR DESCRIPTION
Currently, the issue is that the gaPermalinkEvent is broadcasted only if the history function is available.
This PR broadcasts now the event at every change of params.
Not sure it's a good idea to provide the rootscope to the Permalink function, but you have for sure better ideas ;-)
