### PR TITLE
fixes ios orientation bug

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 <!DOCTYPE html>
 <html ng-app="ga" ng-controller="GaMainController">
   <head>
@@ -465,6 +466,10 @@
     </div>
 % endif
     <script>
+## Workaround for iOS 6.x bug: content shifted after orientation change
+## As we can’t use css fix ( see http://stackoverflow.com/a/12518946/29655 )
+## we force a redraw on orientation change
+## ( see http://stackoverflow.com/a/13235711/29655 )
         (function(){
             window.addEventListener("orientationchange", function(){
                 document.documentElement.style.display = 'none';


### PR DESCRIPTION
Seems that there’s 2 fixs for this bug:
- having a `overflow: hidden` on one of the search input’s parent
- force redraw on `orientationchange`

As we can’t use the first fix because of the search typeahead, I propose to use this.
