### PR TITLE
ol.layer.ImageLayer is now ol.layer.Image

### DIFF
--- a/src/components/importwms/ImportWmsDirective.js
+++ b/src/components/importwms/ImportWmsDirective.js
@@ -228,7 +228,7 @@
                   ratio: 1
                 });
 
-                var olLayer = new ol.layer.ImageLayer({
+                var olLayer = new ol.layer.Image({
                   label: layer.title,
                   source: olSource
                 });


### PR DESCRIPTION
The name of the image layer class has changed in ol3. This PR accommodates for that.
