### PR TITLE
misplaced clear icon

### DIFF
--- a/src/components/search/style/search.less
+++ b/src/components/search/style/search.less
@@ -56,7 +56,7 @@
   .deleteicon {
     position: absolute;
     right: 0.6em;
-    top: 0.6em;
+    bottom: 0.6em;
     cursor: pointer;
   }
   .search-footer {


### PR DESCRIPTION
The clear icon in the search input is misplaced, only if desktop mode (> 768px)
