### PR TITLE
Adapt structure for #425

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -69,7 +69,7 @@ module.controller('GaMainController',
       var baseUrl = gaGlobalOptions.serviceUrl + '/rest/services';
 
       $scope.featureTreeOptions = {
-        identifyUrlTemplate: baseUrl + '/{Topic}/MapServer/identify',
+        searchUrlTemplate: baseUrl + '/{Topic}/SearchServer',
         htmlUrlTemplate: baseUrl + '/{Topic}/MapServer/{Layer}/{Feature}/htmlpopup'
       };
 


### PR DESCRIPTION
This is a proposition of structure modification for #425.
Just a few css tweaks at start, some changes after talking with @elemoine.

Multiples changes:
- As there’s interaction with featuretree’s toggler, make it part of the partial 
- remove controller that are only settings configuration uri, and move it to `featureTreeOptions` in MainController
- scope css with with attribute selector of the directive (`[ga-featuretree]` here)
- for object writing to MainController scope (such as importkml link), write into a globals property, to avoid an intermediate controller to break things

All these points would make sense to be applied in other components, imho.

Thanks for any review/opinions.

(as a side note, I wasn’t able to have data features after rebasing this, have you remove some testing stuff?)
