### PR TITLE
6.6 Text with links: blue and underline 

### DIFF
--- a/src/style/app.less
+++ b/src/style/app.less
@@ -479,6 +479,12 @@ a .ga-icon-separator {
     max-height: inherit;
   }
 }
+.ga-popup-content, .contextpopup .popover-content {
+  a {
+    text-decoration: underline;
+    color: #069;
+  }
+}
 // ****** PULLDOWN’S LISTS
 .panel-subtitle() {
   border-bottom-width: 1px;


### PR DESCRIPTION
Set all text with URL (as in infobx) underline and blue as in eg 
http://api.geo.admin.ch/layers/ch.kantone.cadastralwebmap-farbe?mode=legend&lang=en&h=http%3A%2F%2Fapi.geo.admin.ch&print=true 
