### PR TITLE
6.2.9 tooltip: cn not copy link

### DIFF
--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -172,6 +172,10 @@
                     escape(contextPermalink);
                 }
               }
+
+              element.on('contextmenu', 'a', function(e) {
+                e.stopPropagation();
+              });
             }
           };
         });


### PR DESCRIPTION
ff 23.0.1 win 7

open http://mf-geoadmin3.bgdi.admin.ch/main/prod/?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1

right mouseclick
tooltip opens
right mousecklick on URLs in tool tip (coordinates or link with corsshair)

Result:
tooltip moves to point below mouse

expected result
context menu of browser opens to copy URL link (as in re2)
