### PR TITLE
Use sed command compatible with BSD sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-
 SRC_JS_FILES := $(shell find src/components src/js -type f -name '*.js')
-SRC_JS_FILES_FOR_COMPILER = $(shell sed -e :a -e 'N;s/\n/ --js /;ba' .build-artefacts/js-files | sed 's/^.*base\.js //')
+SRC_JS_FILES_FOR_COMPILER = $(shell sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/ --js /g' .build-artefacts/js-files | sed 's/^.*base\.js //')
 SRC_COMPONENTS_LESS_FILES := $(shell find src/components -type f -name '*.less')
 SRC_COMPONENTS_PARTIALS_FILES = $(shell find src/components -type f -path '*/partials/*' -name '*.html')
 BASE_URL_PATH ?= /$(shell id -un)


### PR DESCRIPTION
During the FOSS4G conference I figured that our Makefile did not work on OSX. This fixes it, by using a sed command that is compatible with both BSD sed and GNU sed.
