### PR TITLE
JavaScript error in catalog tree component (number 2)

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -88,8 +88,7 @@
 
             scope.$on('gaTopicChange', function(event, topic) {
               currentTopic = topic.id;
-              updateCatalogTree();
-           });
+            });
 
             scope.map.getLayers().on('remove', function(evt) {
               var layer = evt.getElement();


### PR DESCRIPTION
I can reproduce the bug using the kgs topic, but I don't think the problem is related to that topic, or any other topic.

I think the error occurs when the catalog tree configuration is received before the layers configuration.

This is the error:

```
TypeError: Cannot read property 'ch.babs.kulturgueter' of undefined
    at getLayer (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/components/map/MapService.js:173:24)
    at addLayer (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/components/catalogtree/CatalogitemDirective.js:81:42)
    at http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/components/catalogtree/CatalogitemDirective.js:52:21
    at nodeLinkFn (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:5121:13)
    at http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:5271:13
    at http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:6311:11
    at wrappedCallback (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:9106:81)
    at wrappedCallback (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:9106:81)
    at http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:9192:26
    at Scope.$eval (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:10034:28) <div class="ga-catalogitem-template" ng-switch="item.children" ga-catalogitem="" ga-catalogitem-item="child" ga-catalogitem-map="map"> 
```
