### PR TITLE
JavaScript error in catalog tree component

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -78,7 +78,11 @@
 
             scope.$on('$translateChangeEnd', function() {
               if (angular.isDefined(currentTopic)) {
-                updateCatalogTree().then(retainTreeState);
+                updateCatalogTree().then(function(oldAndNewTrees) {
+                  if (angular.isDefined(oldAndNewTrees.oldTree)) {
+                    retainTreeState(oldAndNewTrees);
+                  }
+                });
               }
             });
 


### PR DESCRIPTION
Just got a js error in the catalog tree directive. This is the exception:

```
TypeError: Cannot read property 'selectedOpen' of undefined
    at retainTreeState (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/components/catalogtree/CatalogtreeDirective.js:38:45)
    at wrappedCallback (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:9106:81)
    at http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:9192:26
    at Scope.$eval (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:10034:28)
    at Scope.$digest (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:9882:23)
    at Scope.$apply (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:10137:24)
    at done (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:6576:45)
    at completeRequest (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:6760:7)
    at http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:6673:11
    at HTMLScriptElement.doneWrapper (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/src/lib/angular-1.2.0rc2.js:6772:21) 
```
