### PR TITLE
Window popups and vertical scroll

### DIFF
--- a/src/style/app.less
+++ b/src/style/app.less
@@ -26,6 +26,14 @@
   display: none;
 }
 
+html, body {
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
 #map {
   position: absolute;
   width: 100%;


### PR DESCRIPTION
When you drag an "import kml" or "import wms" window below the viewport the browser (FF and Chrome) adds a vertical scroll because of the extra content below the map. I think this is undesired.
