### PR TITLE
Fix geolocation error

### DIFF
--- a/src/components/geolocation/GeolocationDirective.js
+++ b/src/components/geolocation/GeolocationDirective.js
@@ -16,7 +16,7 @@
       template: '<a href="#geolocation" class="geolocation">',
       replace: true,
       link: function(scope, element, attrs) {
-        if (!ol.Geolocation.SUPPORTED) {
+        if (!('geolocation' in window.navigator)) {
           element.addClass('error');
           return;
         }


### PR DESCRIPTION
In prod mode, ol.Geolocation.SUPPORTED doesn't seem to be available
Related to https://github.com/geoadmin/mf-geoadmin3/issues/469

Not nice, but at least, it works.Any idea why ol.Geolocation.SUPPORTED is not available ?
