### PR TITLE
Use pointer on catalog info button

### DIFF
--- a/src/components/catalogtree/style/catalogtree.less
+++ b/src/components/catalogtree/style/catalogtree.less
@@ -38,6 +38,9 @@
   .icon-warning-sign {
     right: 1em;
   }
+  .icon-info-sign {
+    cursor: pointer;
+  }
 }
 
 .ga-catalogitem-entry {


### PR DESCRIPTION
In the catalog tree at the moment, when a layer is selected, the cursor is not a pointer.
This PR makes sure we always have a pointer on the info icon.
