### PR TITLE
prefetch chsdi’s dns 

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -6,6 +6,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="dns-prefetch" href="${service_url}" />
 
     <link rel="apple-touch-icon" sizes="76x76" href="img/touch-icon-bund-76x76.png" />
     <link rel="apple-touch-icon" sizes="120x120" href="img/touch-icon-bund-120x120.png" />


### PR DESCRIPTION
not sure how to add this to current Makefile & mako, but adding

``` diff
   <head>
     <title translate="{{topicId + '_page_title'}}">map.geo.admin.ch</title>
     <meta charset="utf-8">
+
+    <link rel="dns-prefetch" href="http://mf-chsdi30t.bgdi.admin.ch"></script>
+
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
```

to dev instance has a pretty good effect.

![capture decran 2013-09-27 a 15 01 38](https://f.cloud.github.com/assets/21686/1225858/13e8cf62-2775-11e3-8b3d-8c8cb7905977.png)
vs
![capture decran 2013-09-27 a 15 05 55](https://f.cloud.github.com/assets/21686/1225877/9dc94400-2775-11e3-8719-1cf4096a1137.png)

For the record…
