### PR TITLE
"homescreen" tip is meaningless in iOS Chrome

### DIFF
--- a/src/components/BrowserSnifferService.js
+++ b/src/components/BrowserSnifferService.js
@@ -13,6 +13,7 @@
       var ua = $window.navigator.userAgent;
       var msie = +((/msie (\d+)/.exec(ua.toLowerCase()) || [])[1]);
       var ios = /(iPhone|iPad)/.test(ua);
+      var ios_chrome = /CriOS/.test(ua);
       var testSize = function(size) {
         var m = $window.matchMedia;
         return m && m('(max-width: ' + size + 'px)').matches;
@@ -26,6 +27,7 @@
       return {
         msie: msie,
         ios: ios,
+        ios_chrome: ios_chrome,
         mobile: mobile,
         phone: mobile && testSize(480)
       };

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -77,6 +77,7 @@ module.controller('GaMainController',
 
       $timeout(function() {
         $scope.globals.homescreen = gaBrowserSniffer.ios &&
+          !gaBrowserSniffer.ios_chrome &&
           !($window.localStorage.getItem('homescreen') == dismiss) &&
           !$window.navigator.standalone;
         $scope.$watch('globals.homescreen', function(newVal) {


### PR DESCRIPTION
The "homescreen" tip refers to a browser button that doesn't exist in iOS Chrome. Our agent detection need be more accurate.

@cedricmoullet I'm making this a P2 but feel free to change the priority if you think P2 is not appropriate. (I even was about to make it a P1.)
