### PR TITLE
6.2.12 MOBILE Can't copy permalink

### DIFF
--- a/src/components/share/ShareDirective.js
+++ b/src/components/share/ShareDirective.js
@@ -24,6 +24,19 @@
               $('.share-icon').tooltip({
                 placement: 'bottom'
               });
+              $('.share-permalink input').on({
+                focus: function() {
+                  this.setSelectionRange(0, 9999);
+                },
+                mouseup: function(e) {
+                  // prevent unselection on blur
+                  e.preventDefault();
+                },
+                touchend: function(e) {
+                  // prevent unselection on blur
+                  e.preventDefault();
+                }
+              });
               // Store in the scope the permalink value which is bound to
               // the input field
               scope.permalinkValue = gaPermalink.getHref();

--- a/src/components/share/partials/share.html
+++ b/src/components/share/partials/share.html
@@ -31,7 +31,7 @@
 </div>
 
 <div class="input-group input-group-sm share-permalink">
-  <input type="text" ng-model="permalinkValue" ng-click="selectOnClick($event)" class="form-control" readonly>
+  <input type="text" ng-model="permalinkValue" ng-click="selectOnClick($event)" class="form-control">
   <span class="input-group-btn">
     <button class="btn btn-default" ng-disabled="urlShortened"
             ng-click="shortenUrl()" translate>shorten_url</button>


### PR DESCRIPTION
OS/Browser/device: iOS 5, 6, 7 / Safari / iphone 4S and Android 4.2.2 / Chrome / Nexus 7
Use case: open application, zoom somewhere, go to the "Share" section, try to Copy + Paste the permalink out of the textbox
Result: The link can not be copied
Expected: the link text can be marked and copied

I'm not sure, if this is an app issue. Could be an issue of iOS?

![permalink_copy](https://f.cloud.github.com/assets/4577749/1243169/dfcdc230-2a5f-11e3-9192-d55d1a4a64ef.png)
