### PR TITLE
Change "is defined" test expression

### DIFF
--- a/src/components/backgroundlayerselector/BackgroundLayerSelectorDirective.js
+++ b/src/components/backgroundlayerselector/BackgroundLayerSelectorDirective.js
@@ -71,7 +71,7 @@
                 if (!currentLayer && !data.labelsOnly) {
                   currentLayer = backgroundLayers[0].id;
                 }
-                if (angular.isDefined(currentLayer)) {
+                if (currentLayer) {
                   scope.currentLayer = currentLayer;
                 }
               });


### PR DESCRIPTION
angular.isDefined returns true if currentLayer is the empty string. Here wen don't want to change the current layer if currentLayer is the empty string so we should not use angular.isDefined.

We should use angular.isDefined when what we really want to test is that the value is defined or undefined.
