### PR TITLE
6.2.1 language /BG switcher is missing for screensize between desktop and tablets

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -62,7 +62,7 @@
         <div ga-search ga-search-map="map" ga-search-options="options" ga-search-focused="globals.searchFocused"></div>
       </div>
 % if device == 'desktop':
-      <form class="navbar-form pull-right visible-lg visible-md">
+      <form class="navbar-form pull-right hidden-xs">
         <div ga-background-layer-selector
           ga-background-layer-selector-map="map"></div>
         <div id="toptools">


### PR DESCRIPTION
language /BG switcher is missing for screensize between desktop and tablets, 
proposal: as soon as we dont' see those 2 combos: add"setting" to the accordon/switch to tablet mode

![unbenannt](https://f.cloud.github.com/assets/4577727/1240355/63f1d12e-2a0a-11e3-86b7-ba8f28a7424f.png)
