### PR TITLE
6.2.14 mobile: on tap: "jumping" swiss logo

### DIFF
--- a/src/style/app.less
+++ b/src/style/app.less
@@ -788,12 +788,12 @@ ul.panel-body-wide {
 #loader {
   display: none;
   @media (max-width: @screen-tablet) {
-    .transition(top .20s ease);
+    .transition(opacity .20s ease);
     display: block;
     content: "\f021";
     font-family: FontAwesome;
     position: absolute;
-    top: -44px;
+    top: 2px;
     left: 0;
     font-size: 26px;
     color: red;
@@ -804,6 +804,7 @@ ul.panel-body-wide {
     z-index: 5000;
     text-align: center;
     border-radius: 44px;
+    opacity: 0;
   }
   @media (max-width: @screen-phone) {
     width: 32px;
@@ -811,16 +812,14 @@ ul.panel-body-wide {
     line-height: 32px;
     font-size: 20px;
     left: 6px;
+    top: 8px;
   }
 }
 
 .ga-tooltip-wait, .metadata-popup-wait {
   #loader {
     @media (max-width: @screen-tablet) {
-      top: 2px;
-    }
-    @media (max-width: @screen-phone) {
-      top: 8px;
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
on iphone ios 7.02

open
http://mf-geoadmin30i.bgdi.admin.ch/main/prod/mobile.html?lang=de&X=190000.00&Y=660000.00&zoom=1&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&mobile=true

tap

result:

the logo disappears and above the loading circle appears: impression that the swiss logo jumps

expected result:

the loading circle appears at the same position as the swiss logo
