### PR TITLE
Using topicId (translated) for catalog heading

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -212,7 +212,7 @@
           <a class="panel-heading accordion-toggle light collapsed" data-toggle="collapse" href="#catalog">
             <i class="visible-collapsed icon-caret-right"></i>
             <i class="hidden-collapsed icon-caret-down"></i>
-            <span translate>catalog</span>
+            <span translate={{topicId}}></span>
           </a>
           <div id="catalog" class="collapse" ng-controller="GaCatalogtreeController">
 % if device == 'mobile':


### PR DESCRIPTION
This should address #545.

I'm not sure to topicId is the right thing to use here (even though it works as expected). But it's strange to translate an id...but it's translated in other locations on the index too.

Maybe we should rename this to topicLabel (in separate PR).

Note: Probably not all topicId are already translated.
