### PR TITLE
6.2.1 add an arrow to open topic

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -203,7 +203,10 @@
         <div class="panel">
 % if device == 'desktop':
           <div class="theme-toggle visible-lg visible-md">
-            <a class="dropdown-toggle" data-toggle="dropdown" href="#" translate>choose_theme</a>
+            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+              <span translate>choose_theme</span>
+              <i class="icon-chevron-sign-right"></i>
+            </a>
             <div class="dropdown-menu" ng-controller="GaTopicController">
               <div ga-topic ga-topic-ui="list" ga-topic-options="options" ga-topic-map="map"></div>
             </div>

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -431,6 +431,16 @@ a .ga-icon-separator {
     height: 40px;
     line-height: 40px;
   }
+  a i {
+    .transition(all .20s ease);
+    display: inline-block;
+    text-decoration: none;
+  }
+  &.open {
+    .icon-chevron-sign-right {
+      .rotate(180deg);
+    }
+  }
 }
 .dropdown-menu {
   top: 0;


### PR DESCRIPTION
as in spec

to make it more obvious that there is a topic selector add an arrow 

![unbenannt](https://f.cloud.github.com/assets/4577727/1248970/ab912f7a-2ad7-11e3-91e3-c43cb38582f9.png)

I propose to use
http://fortawesome.github.io/Font-Awesome/icon/external-link-sign/
and rotate it
