### PR TITLE
6.7 FONTS: Widget content fonst to big

### DIFF
--- a/src/components/importwms/style/importwms.less
+++ b/src/components/importwms/style/importwms.less
@@ -16,7 +16,7 @@
 
   input[type=url], .tt-dropdown-menu {
     width: 610px;
-    padding-right: 30px; 
+    padding-right: 30px;
   }
 
   table {
@@ -30,7 +30,7 @@
 
     thead, th, td, tr {
       height: 35px;
-    } 
+    }
 
     th.add, td.add {
       width: 25px;
@@ -67,12 +67,12 @@
     border-collapse: separate;
     border-radius: 4px;
     z-index: 50;
-   
+
     th {
       border-bottom: none;
     }
   }
- 
+
   .table-content-container {
     width: 100%;
     height: 240px;
@@ -99,6 +99,7 @@
     height: 206px;
     cursor: auto;
     background-color: #ffffff;
+    font-size: 12px;
   }
 
   .bt-connect {


### PR DESCRIPTION
According to 6.7 spec "Anwendungen widget" fontsize widget content
should be 12px . Make sure we do not need scrollbar in default cases as in RE2.
This is the case as well for KML, WMS widget etc

-> Check fontsizes according to spec

![unbenannt](https://f.cloud.github.com/assets/4577727/1224107/f04a5742-273d-11e3-975c-cdf8804a5047.PNG)
