### PR TITLE
No topic defaultBackgroundLayer property anymore

### DIFF
--- a/src/components/topic/TopicDirective.js
+++ b/src/components/topic/TopicDirective.js
@@ -74,7 +74,6 @@
                 value.label = value.id;
                 value.thumbnail = 'http://placehold.it/110x60';
                 value.langs = extendLangs(value.langs);
-                value.bgLayer = value.defaultBackgroundLayer;
               });
               initTopics();
             });


### PR DESCRIPTION
This should have been done in https://github.com/geoadmin/mf-geoadmin3/pull/393.

Please review and merge.
