### PR TITLE
Custom checkboxes

### DIFF
--- a/src/style/app.less
+++ b/src/style/app.less
@@ -874,7 +874,7 @@ ul.panel-body-wide {
   }
 }
 
-// ***** IE10 input range
+// ***** IE10 INPUT RANGE
 input[type=range] {
   &::-ms-fill-upper {
     background: #fff;
@@ -895,5 +895,22 @@ input[type=range] {
   }
   &::-ms-tooltip {
     display: none;
+  }
+}
+
+// ***** CUSTOM CHECKBOXES
+input[type=checkbox] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  border: 0;
+  background: white;
+  &:after {
+    font-size: 14px;
+    content: "\f096";
+    font-family: FontAwesome;
+  }
+  &:checked:after {
+    content: "\f046";
   }
 }


### PR DESCRIPTION
- Use custom input on webkit
- _un_style checkboxes on gecko

This won’t work unless a new FontAwesome build is made with `icon-check` & `icon-check-empty`.

Interesting reading on why this won’t work in others browsers: http://stackoverflow.com/a/4660434/29655
