### PR TITLE
6.3.1: Share email does not work when started from homescreen icon

### DIFF
--- a/src/components/share/ShareDirective.js
+++ b/src/components/share/ShareDirective.js
@@ -9,7 +9,7 @@
   ]);
 
   module.directive('gaShare',
-      function($http, gaPermalink, gaUrlUtils) {
+      function($http, $window, gaPermalink, gaUrlUtils) {
           return {
             restrict: 'A',
             scope: {
@@ -71,6 +71,9 @@
               scope.selectOnClick = function(e) {
                 e.target.select();
               };
+
+              // Be able to disable some widgets on homescreen
+              scope.homescreen = $window.navigator.standalone;
             }
           };
         });

--- a/src/components/share/partials/share.html
+++ b/src/components/share/partials/share.html
@@ -25,7 +25,7 @@
 
   <a class="share-icon" target="_blank"
     data-original-title="{{'mail_tooltip' | translate}}"
-    ng-href="mailto:?body={{encodedPermalinkHref}}">
+    ng-href="mailto:?body={{encodedPermalinkHref}}" ng-if="!homescreen">
     <i class="icon-envelope-alt"></i>
   </a>
 </div>


### PR DESCRIPTION
IOS / All Browsers 
http://mf-geoadmin30i.bgdi.admin.ch/
delete Cache
delete icons on homescreen
Start application 
Save link to homescreen
Start application from homescreen
-> Share
tap Share email

RESULT
only hint appears

EXPECTED RESULT
email client is opening

Workaround:
open application in Safari
