### PR TITLE
Use wmsLayers for the wms layers

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -347,7 +347,7 @@
                 layer.wmsUrl, ['request', 'service', 'version'], true);
 
             var wmsParams = {
-              LAYERS: layer.serverLayerName,
+              LAYERS: layer.wmsLayers,
               FORMAT: 'image/' + layer.format
             };
 


### PR DESCRIPTION
This is because some wms layers can be composed of several layers (example cadastral web map)
