### PR TITLE
Forcing supported IE version not to use compatibility mode

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -9,6 +9,7 @@
 % endif
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+    <meta http-equiv="X-UA-Compatible" content="IE=9;IE=10; IE=EDGE" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="msapplication-TileImage" content="${version}img/touch-icon-bund-144x144.png">


### PR DESCRIPTION
This PR tries to fix #663

To test:

Open IE and in the Menu > Tools > Compatibility View Setting 
Add _admin.ch_ to the _Compatiblity View List_

Tested with IE8, IE9, IE10 and IE11 with _admin.ch_ added to the compatibility list

Only IE8 will display the _old browser warning_
