### PR TITLE
Send the style information of POINT geometries to the print service

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -76,13 +76,15 @@
     // Transform the result of createLiteral function to an object
     // usable by the print service
     var transformToPrintLiteral = function(type, literal) {
+
       if (type === ol.geom.GeometryType.LINESTRING ||
           type === ol.geom.GeometryType.MULTILINESTRING) {
         literal.strokeWidth = literal.width;
         literal.strokeColor = literal.color;
         literal.strokeOpacity = literal.opacity;
 
-      } else if (type == ol.geom.GeometryType.POINT) {
+      } else if (type === ol.geom.GeometryType.POINT ||
+          type === ol.geom.GeometryType.MULTIPOINT) {
         literal.externalGraphic = literal.url;
         literal.graphicHeight = literal.height;
         literal.graphicOpacity = literal.opacity;
@@ -147,7 +149,6 @@
                 }
               }
             } else {
-
               var style = layer.get('style') || ol.style.getDefault();
               var literals = style.createLiterals(feature);
               encStyle = transformToPrintLiteral(type, literals[0]);


### PR DESCRIPTION
Print correctly the external icons.

http://mf-geoadmin30t.bgdi.admin.ch/ltteo/prod/?lang=fr&topic=ech&X=158795.00&Y=510578.77&zoom=4&bgLayer=ch.swisstopo.pixelkarte-grau&layers=KML%7C%7Chttp:%2F%2Fwww.meteosuisse.admin.ch%2Fweb%2Ffr%2Fclimat%2Freseaux_de_mesures%2Fsurface%2Fgoogle_earth.Par.0006.DownloadFile.ext.tmp%2Fswissmetnet.kml,KML%7C%7Chttp:%2F%2Fopendata.utou.ch%2Furbanproto%2Fgeneva%2Fgeo%2Fkml%2FRoutes.kml
