### PR TITLE
Make sure context popup works

### DIFF
--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -23,8 +23,9 @@
               var heightUrl = gaUrlUtils.append(scope.options.heightUrl,
                   'callback=JSON_CALLBACK');
               var qrcodeUrl = scope.options.qrcodeUrl;
+              // Specifying 'callback' instead of 'cb' leads to error (#754)
               var lv03tolv95Url = gaUrlUtils.append(scope.options.lv03tolv95Url,
-                  'callback=JSON_CALLBACK');
+                  'cb=JSON_CALLBACK');
 
               // The popup content is updated (a) on contextmenu events,
               // and (b) when the permalink is updated.

--- a/test/specs/contextpopup/ContextPopupDirective.spec.js
+++ b/test/specs/contextpopup/ContextPopupDirective.spec.js
@@ -54,7 +54,7 @@ describe('ga_contextpopup_directive', function() {
         '?callback=JSON_CALLBACK&easting=661473&elevation_model=COMB' +
         '&northing=188192';
     var expectedReframeUrl = 'http://api.example.com/reframe/' +
-        'lv03tolv95?callback=JSON_CALLBACK&easting=661473&northing=188192';
+        'lv03tolv95?cb=JSON_CALLBACK&easting=661473&northing=188192';
 
     beforeEach(inject(function($injector) {
       contextmenuEvent = {


### PR DESCRIPTION
This fixes #754.

If anyone knows why `callback` leads to the error in #754, and `cb` does not, I would like to know. Not the both URL return exactly the same results and that everywhere else we use angulars jsonp, we use `callback`...
