### PR TITLE
IE mode troubles

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -26,6 +26,10 @@ Alias ${base_url_path}/prod ${base_dir}/prd
 RewriteRule ^/(index.html|mobile.html|info.json|checker)(.*) /var/www/vhosts/mf-geoadmin3/private/geoadmin/prd/$1
 RewriteRule ^/[0-9]+/(img|lib|style|rest|locales)(.*) /var/www/vhosts/mf-geoadmin3/private/geoadmin/prd/$1$2
 
+<IfModule mod_headers.c>
+  Header set X-UA-Compatible "IE=Edge"
+</IfModule>
+
 <LocationMatch /[0-9]+/>
    ExpiresDefault "now plus 1 year"
    Header merge Cache-Control "public"

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
+<!--[if HTML5]><![endif]-->
 <!DOCTYPE html>
-<html ng-app="ga" ng-controller="GaMainController">
+<!--[if lt IE 7]>      <html ng-app="ga" ng-controller="GaMainController" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html ng-app="ga" ng-controller="GaMainController" class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html ng-app="ga" ng-controller="GaMainController" class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html ng-app="ga" ng-controller="GaMainController" class="no-js"> <!--<![endif]-->
   <head>
+    <!--[if !HTML5]>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <![endif]-->
 % if device == 'desktop':
     <title translate="{{topicId + '_page_title'}}">map.geo.admin.ch</title>
 % else:
@@ -9,7 +16,6 @@
 % endif
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
-    <meta http-equiv="X-UA-Compatible" content="IE=9;IE=10; IE=EDGE" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="msapplication-TileImage" content="${version}img/touch-icon-bund-144x144.png">


### PR DESCRIPTION
We apply the exact same code for the IE stuff in our html and apache configuration. This should solve:
#718 #663.

Here is some cool documentation about this issue:
http://xn--mlform-iua.no/blog/html5-boiler-plate-prevents-x-ua-compatible
http://stackoverflow.com/questions/6156639/x-ua-compatible-is-set-to-ie-edge-but-it-still-doesnt-stop-compatibility-mode
http://emological.com/ie/

It's hard to assume that there are actual human beings working @ Microsoft IE compatibility stuff.
