### PR TITLE
Closure compiler version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ $(addprefix .build-artefacts/annotated/, $(SRC_JS_FILES) src/TemplateCacheModule
 
 .build-artefacts/closure-compiler/compiler-latest.zip:
 	mkdir -p $(dir $@)
-	wget -O $@ http://closure-compiler.googlecode.com/files/compiler-latest.zip
+	wget -O $@ http://dl.google.com/closure-compiler/compiler-20131014.zip
 	touch $@
 
 $(DEPLOY_ROOT_DIR)/$(GIT_BRANCH)/.git/config:


### PR DESCRIPTION
The closure compiler linke was not working anymore. Also, the latest closure compiler is not compatible with the Java version we have on mf1lt.

Therefore, we have to fix the version of the compiler used to the last working one.

This PR adresses this.
