### PR TITLE
Rename service function

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -170,7 +170,7 @@
               });
             });
 
-            scope.layerFilter = gaLayerFilters.selectedLayersFilter;
+            scope.layerFilter = gaLayerFilters.selected;
 
             scope.$watchCollection('layers | filter:layerFilter',
                 function(layers) {

--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -42,7 +42,7 @@
 
             scope.layers = map.getLayers().getArray();
 
-            scope.layerFilter = gaLayerFilters.selectedLayersFilter;
+            scope.layerFilter = gaLayerFilters.selected;
 
             scope.removeLayerFromMap = function(layer) {
               map.removeLayer(layer);

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -666,7 +666,7 @@
          * were actively added by the user and that
          * appear in the layer manager
          */
-        selectedLayersFilter: function(layer) {
+        selected: function(layer) {
           return !layer.background &&
                  !layer.preview &&
                  !layer.highlight;
@@ -767,7 +767,7 @@
 
         scope.layers = map.getLayers().getArray();
 
-        scope.layerFilter = gaLayerFilters.selectedLayersFilter;
+        scope.layerFilter = gaLayerFilters.selected;
 
         scope.$watchCollection('layers | filter:layerFilter',
             function(layers) {

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -337,7 +337,7 @@
 
               scope.searchableLayersFilter = function(layer) {
                 var layerBodId = layer.bodId;
-                return gaLayerFilters.selectedLayersFilter(layer) &&
+                return gaLayerFilters.selected(layer) &&
                        angular.isDefined(layerBodId) &&
                        gaLayers.getLayerProperty(layerBodId, 'searchable');
               };


### PR DESCRIPTION
This is a simple renaming to increase readability.

`gaLayerFilters.selectedLayersFilter` -> `gaLayerFilters.selected`
