### PR TITLE
Makes the feature tree work again on Macs

### DIFF
--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -52,7 +52,6 @@
             var projection = view.getProjection();
             var parser = new ol.format.GeoJSON();
             var highlightLayer = createVectorLayer('highlight');
-            var macEnv = gaBrowserSniffer.mac && gaBrowserSniffer.webkit;
             var selectionRecFeature = new ol.Feature();
             var selectionRecOverlay = new ol.render.FeaturesOverlay({
               map: map,
@@ -67,7 +66,7 @@
                 //We have to use the apple key on those devices
                 return scope.options.active &&
                        (evt.getBrowserEvent().ctrlKey ||
-                        (macEnv && evt.getBrowserEvent().metaKey));
+                       (gaBrowserSniffer.mac && evt.getBrowserEvent().metaKey));
               },
               style: new ol.style.Style({
                 stroke: new ol.style.Stroke({


### PR DESCRIPTION
Vector-api branch killed the feature tree feature because ctlr-click is not usable on Macs (see snipped at [1])

This PR adresses the issue. We are now using the mac Key instead of the ctlr Key on Max (as in RE2).

[1] http://docs.closure-library.googlecode.com/git/closure_goog_events_browserevent.js.source.html#line340
