### PR TITLE
Support KML url in the search field

### DIFF
--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -19,7 +19,7 @@
   module.directive('gaSearch',
       function($compile, $translate, $timeout, gaMapUtils, gaLayers,
         gaLayerMetadataPopup, gaPermalink, gaUrlUtils, gaGetCoordinate,
-        gaBrowserSniffer, gaLayerFilters) {
+        gaBrowserSniffer, gaLayerFilters, gaKml) {
           var currentTopic,
               footer = [
             '<div class="search-footer clearfix">',
@@ -203,6 +203,14 @@
                        scope.$apply(function() {
                           scope.layers = map.getLayers().getArray();
                        });
+                       // Check url
+                       if (gaUrlUtils.isValid(scope.query)) {
+                         gaKml.addKmlToMapForUrl(map,
+                           scope.query, {
+                           attribution: gaUrlUtils.getHostname(scope.query)
+                         });
+                         return false;
+                       }
                        var position =
                          gaGetCoordinate(
                            map.getView().getProjection().getExtent(),


### PR DESCRIPTION
This allows the user to simply copy/paste a link in the search field. It avoids to open the tool menu.
There is no test about the validity of the URL/KML. 
