### PR TITLE
PRINT: Certains layers have separate pdf Legends

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -396,8 +396,7 @@
           enc.classes.push({
             name: '',
             icon: location.protocol + $scope.options.serviceUrl +
-                $scope.options.baseUrlPath +
-                '/wsgi/static/images/legends/' +
+                '/static/images/legends/' +
                 layer.bodId + '_' + $translate.uses() + format
           });
           return enc;


### PR DESCRIPTION
This PR adresses #825. Note: I consider this a dirty hack. We should find a better solution, the information which layers are concerned should not be hardcode in the source code
