### PR TITLE
Fix singleclick conflicts storing measure directive state in the $rootScope

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -327,7 +327,7 @@
     });
 
     this.$get = function($http, gaPopup, gaDefinePropertiesForLayer,
-        gaMapClick, gaMapUtils) {
+        gaMapClick, gaMapUtils, $rootScope) {
       var Kml = function(proxyUrl) {
 
         /**
@@ -403,8 +403,9 @@
 
           // Display popup on mouse click
           var onMapClick = function(evt) {
-            evt.stopPropagation();
-            evt.preventDefault();
+            if ($rootScope.isMeasureActive) {
+              return;
+            }
             var pixel = (evt.originalEvent) ?
                 olMap.getEventPixel(evt.originalEvent) :
                 evt.getPixel();

--- a/src/components/measure/MeasureDirective.js
+++ b/src/components/measure/MeasureDirective.js
@@ -1,11 +1,7 @@
 (function() {
   goog.provide('ga_measure_directive');
 
-  goog.require('ga_map_service');
-
-  var module = angular.module('ga_measure_directive', [
-    'ga_map_service'
-  ]);
+  var module = angular.module('ga_measure_directive', []);
 
   module.filter('measure', function() {
     return function(floatInMeter, units) {
@@ -18,7 +14,7 @@
   });
 
   module.directive('gaMeasure',
-    function(gaMapClick) {
+    function($rootScope) {
       return {
         restrict: 'A',
         templateUrl: function(element, attrs) {
@@ -92,13 +88,6 @@
             isDblClick = true;
           });
 
-          gaMapClick.listen('singleclick', function(evt) {
-            if (scope.isActive) {
-              evt.stopPropagation();
-              evt.preventDefault();
-            }
-          });
-
           var activate = function() {
             scope.map.addInteraction(drawArea);
 
@@ -146,6 +135,7 @@
 
           // Watchers
           scope.$watch('isActive', function(active) {
+            $rootScope.isMeasureActive = active;
             scope.distance = 0;
             scope.surface = 0;
             if (active) {

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -16,7 +16,7 @@
   module.directive('gaTooltip',
     function($timeout, $document, $http, $q, $translate, $sce, gaPopup,
       gaLayers, gaBrowserSniffer, gaDefinePropertiesForLayer, gaMapClick,
-      gaStyleFunctionFactory)
+      gaStyleFunctionFactory, $rootScope)
       {
         var waitclass = 'ga-tooltip-wait',
             bodyEl = angular.element($document[0].body),
@@ -101,6 +101,9 @@
             }
 
             gaMapClick.listen(map, function(evt) {
+              if ($rootScope.isMeasureActive) {
+                return;
+              }
               var size = map.getSize();
               var mapExtent = map.getView().calculateExtent(size);
               var coordinate = (evt.originalEvent) ?


### PR DESCRIPTION
I really don't like but it's the only thing I succeed to make it work to fix the conflict
