### PR TITLE
Improve css of profile

### DIFF
--- a/src/components/profile/ProfileDirective.js
+++ b/src/components/profile/ProfileDirective.js
@@ -70,9 +70,10 @@
                   var xCoord = profile.domain.X.invert(x);
                   var yCoord = profile.domain.Y.invert(pos.y);
                   // Get the tooltip position
-                  var heightOfArrow = 8;
-                  var positionX = profile.domain.X(xCoord);
-                  var positionY = profile.domain.Y(yCoord) - heightOfArrow;
+                  var positionX = profile.domain.X(xCoord) +
+                      scope.options.margin.left;
+                  var positionY = profile.domain.Y(yCoord) +
+                      scope.options.margin.top;
                   tooltipEl.css({
                     left: positionX + 'px',
                     top: positionY + 'px'

--- a/src/components/profile/example/index.html
+++ b/src/components/profile/example/index.html
@@ -36,12 +36,26 @@
     </script>
     <![endif]-->
     <link href="style/app.css" rel="stylesheet" media="screen">
+    <style>
+      #profile-popup {
+        overflow: visible;
+        max-height: none;
+        max-width: none; 
+      }
+
+      #profile-popup .ga-popup-content {
+        overflow: visible;
+        max-height: none;
+        max-width: none;
+      }     
+    </style>
   </head>
   <body ng-controller="MainController">
     <div ga-popup="show"
          ga-popup-options="options"
          ga-draggable=".ga-popup-title"
          id="profile-popup">
+      <div>This text to test tooltip position</div>
       <div ng-controller="ProfileController">
         <div ga-profile
              ga-profile-options="options">

--- a/src/components/profile/style/profile.less
+++ b/src/components/profile/style/profile.less
@@ -1,82 +1,88 @@
-#profile-popup {
-  overflow: visible;
-  max-height: none;
-  max-width: none;
-  .ga-popup-content {
+[ga-profile] {
+  position:relative;
+
+  .profile-inner {
     overflow: hidden;
-    max-height: inherit;
-    max-width: inherit;
-    .profile-inner {
-      overflow: hidden;
-      width: inherit;
-      .profile-svg {
-        display: block;
-        margin: 0;
-        .profile-grid-x,
-        .profile-grid-y {
-          stroke: lightgrey;
-          opacity: 0.8;
-          line {
-            stroke-width: 0.02em;
-          }
+    width: inherit;
+
+    .profile-svg {
+      display: block;
+      margin: 0;
+
+      .profile-grid-x,
+      .profile-grid-y {
+        stroke: lightgrey;
+        opacity: 0.8;
+        line {
+          stroke-width: 0.02em;
         }
-        .axis path,
-        .axis line {
-          fill: none;
-          stroke: #000;
-          shape-rendering: crispEdges;
+      }
+
+      .axis path,
+      .axis line {
+        fill: none;
+        stroke: #000;
+        shape-rendering: crispEdges;
+      }
+
+      .tick {
+        font-size: 11px;
+      }
+
+      .profile-area,
+      .profile-legend-rect {
+        fill: steelblue;
+        fill-opacity: 0.95;
+      }
+
+      .profile-area {
+        &:hover {
+          fill-opacity: 0.85;
         }
-        .tick {
-          font-size: 11px;
-        }
-        .profile-area,
-        .profile-legend-rect {
-          fill: steelblue;
-          fill-opacity: 0.95;
-        }
-        .profile-area {
-          &:hover {
-            fill-opacity: 0.85;
-          }
-        }
-        .profile-legend,
-        .profile-label {
-          font-weight: bold;
-          text-shadow: 1px 1px lightgrey;
-        }
+      }
+
+      .profile-legend,
+      .profile-label {
+        font-weight: bold;
+        text-shadow: 1px 1px lightgrey;
       }
     }
-    .profile-tooltip {
-      position: absolute;
-      height: 65px;
-      width: 150px;
-      display: none;
-      background-color: black;
-      color: white;
-      opacity: 0.8;
-      padding-top: 8px;
-      font-size: 13px;
-      -webkit-border-radius: 5px;
-      -moz-border-radius: 5px;
-      border-radius: 5px;
-      .profile-tooltip-inner {
-        top: -15px;
-        position: relative;
-        width: inherit;
-        height: inherit;
-        text-align: center;
-      }
-      &:before {
-        content: '';
-        border-color: black transparent transparent;
-        border-style: solid;
-        border-width: 10px;
-        height: 0;
-        width: 0;
-        position: relative;
-        top: 65px;
-        left: 65px;
-      }
+  }
+
+  .profile-tooltip {
+    position: absolute;
+    height: 65px;
+    width: 150px;
+    display: none;
+    background-color: black;
+    color: white;
+    opacity: 0.8;
+    margin-left: -75px;
+    margin-top: -73px;
+    padding-top: 8px;/*for the arrow*/
+    font-size: 13px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+    
+    .profile-tooltip-inner {
+      top: -15px;
+      position: relative;
+      width: inherit;
+      height: inherit;
+      text-align: center;
+    }
+    
+    &:before {
+      content: '';
+      border-color: black transparent transparent;
+      border-style: solid;
+      border-width: 10px;
+      height: 0;
+      width: 0;
+      position: relative;
+      top: 65px;
+      left: 65px;
     }
   }
 }


### PR DESCRIPTION
This PR remove  the use of  #  and popup classes in profile css.

This improves also the position of the tooltip when a text is above the profile.
