### PR TITLE
Add fix for search results. Temp only

### DIFF
--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -173,6 +173,18 @@
                     }
                   }
 
+                  //Temporary fix as long as indices are not updated
+                  if (result.attrs.layer ==
+                      'ch.bfs.arealstatistik-bodennutzung') {
+                    result.attrs.layer = 'ch.bfs.arealstatistik-bodenbedeckung';
+                  }
+
+                  if (result.attrs.layer ==
+                    'ch.bfs.arealstatistik-bodennutzung-1985') {
+                    result.attrs.layer =
+                    'ch.bfs.arealstatistik-bodenbedeckung-1985';
+                  }
+
                   layerId = result.attrs.layer;
                   newNode = tree[layerId];
                   oldNode = scope.tree[layerId];


### PR DESCRIPTION
This adds a temporary fix needed for today's deploy. It makes sure the sphinx indices work with 2 layers that we are unable to re-created for some reason.

Please quickly review and merge.
