### PR TITLE
Make sure that featuretree does not draw selected feature

### DIFF
--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -259,7 +259,7 @@
             var requestFeatures = function() {
               var layersToQuery = getLayersToQuery(),
                   req, searchExtent;
-              highlightLayer.getSource().clear();
+              scope.clearHighlight();
               if (layersToQuery.length &&
                   scope.dragBox.getGeometry()) {
                 searchExtent = ol.extent.boundingExtent(
@@ -379,7 +379,7 @@
               var recenterObject = {};
               evt.stopPropagation();
               recenterObject[f.layer] = [f.id];
-              gaRecenterMapOnFeatures(map, recenterObject);
+              gaRecenterMapOnFeatures(map, recenterObject, false);
             };
 
             scope.$on('gaTopicChange', function(event, topic) {
@@ -405,6 +405,7 @@
                 showSelectionRectangle();
                 triggerChange();
               } else {
+                scope.clearHighlight();
                 hideSelectionRectangle();
               }
             });

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -992,7 +992,7 @@
         }
       };
 
-      return function(map, featureIdsByBodId) {
+      return function(map, featureIdsByBodId, drawFeature) {
         getFeatures(featureIdsByBodId).then(function(results) {
           var vectorSource;
           var extent = [Infinity, Infinity, -Infinity, -Infinity];
@@ -1007,20 +1007,22 @@
                 map.getSize());
           }
           map.removeLayer(vector);
-          vectorSource = new ol.source.Vector({
-            features: parser.readFeatures({
-              type: 'FeatureCollection',
-              features: foundFeatures
-            })
-          });
-          vector = new ol.layer.Vector({
-            source: vectorSource,
-            styleFunction: gaStyleFunctionFactory('select')
-          });
-          gaDefinePropertiesForLayer(vector);
-          vector.highlight = true;
-          vector.invertedOpacity = 0.25;
-          map.addLayer(vector);
+          if (drawFeature) {
+            vectorSource = new ol.source.Vector({
+              features: parser.readFeatures({
+                type: 'FeatureCollection',
+                features: foundFeatures
+              })
+            });
+            vector = new ol.layer.Vector({
+              source: vectorSource,
+              styleFunction: gaStyleFunctionFactory('select')
+            });
+            gaDefinePropertiesForLayer(vector);
+            vector.highlight = true;
+            vector.invertedOpacity = 0.25;
+            map.addLayer(vector);
+          }
         });
       };
     };
@@ -1053,7 +1055,7 @@
             }
           }
           if (featureIdsCount > 0) {
-            gaRecenterMapOnFeatures(map, featureIdsByBodId);
+            gaRecenterMapOnFeatures(map, featureIdsByBodId, true);
           }
           deregister();
         });


### PR DESCRIPTION
This adresses #949.

Before, the feature was drawn twice when clicking on the zoom-to icon in the feature true:
- once by the tooltip
- once by the recenter service.

The second option did not clean up after the featuretree was closed.

This fix ommits the drawing of the feature by the recenter service by changing the service to allow for an optional parameter. Now the feature is only drawn by the tooltip directive, which is cleaned up when the tooltip is closed.
