### PR TITLE
Add pointer events management for the draggable directive

### DIFF
--- a/src/components/DraggableDirective.js
+++ b/src/components/DraggableDirective.js
@@ -33,12 +33,20 @@
           start: 'touchstart',
           move: 'touchmove',
           end: 'touchend'
+        },
+        pointer: {
+          start: 'pointerdown',
+          move: 'pointermove',
+          end: 'pointerup'
         }
+
       };
 
       var eventKey = events.mouse;
       if (!gaBrowserSniffer.msie && gaBrowserSniffer.touchDevice) {
         eventKey = events.touch;
+      } else if (gaBrowserSniffer.msie >= 11) {
+        eventKey = events.pointer;
       }
 
       // Firefox doesn't like transition during drag


### PR DESCRIPTION
That fixes the draggable directive on IE11 but not completly the swipe.

Fix #976 
