### PR TITLE
Use ogcproxy to get KML icons

### DIFF
--- a/src/components/importkml/ImportKmlDirective.js
+++ b/src/components/importkml/ImportKmlDirective.js
@@ -44,7 +44,7 @@
         // Handle fileURL
         $scope.handleFileUrl = function() {
           if ($scope.fileUrl) {
-            var proxyUrl = $scope.options.proxyUrl +
+            var proxyUrl = gaKml.proxyUrl +
                 encodeURIComponent($scope.fileUrl);
             $scope.cancel();// Kill the current uploading
             $scope.fileContent = null;

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -460,6 +460,7 @@
             addKmlLayer(map, data, layerOptions, index);
           });
         };
+        this.proxyUrl = proxyUrl;
       };
       return new Kml(this.proxyUrl);
     };

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -521,7 +521,7 @@
         }]);
         
         module.config(['gaKmlProvider', function(gaKmlProvider) {
-          gaKmlProvider.proxyUrl = '${base_url_path}/ogcproxy?url=';
+          gaKmlProvider.proxyUrl = location.protocol + '${service_url}${base_url_path}/ogcproxy?url='; 
         }]);
 
         module.config(['$sceDelegateProvider', function($sceDelegateProvider) {

--- a/src/js/ImportKmlController.js
+++ b/src/js/ImportKmlController.js
@@ -4,10 +4,9 @@
   var module = angular.module('ga_importkml_controller', []);
 
   module.controller('GaImportKmlController',
-      function($scope, gaGlobalOptions) {
+      function($scope) {
          $scope.options = {
            maxFileSize: 20000000, //20mo
-           proxyUrl: gaGlobalOptions.baseUrlPath + '/ogcproxy?url=',
            validationServiceUrl: 'http://www.kmlvalidator.org/validate.htm'
          };
   });


### PR DESCRIPTION
This PR replaces `<href> http......</href>`, in KML file, by `<href>{ogcproxyUrl}http...`.
This allow non-CORS image to be used.

Must be merged after https://github.com/openlayers/ol3/issues/1603 and https://github.com/geoadmin/mf-chsdi3/pull/373
