### PR TITLE
Missing print layers

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -349,8 +349,9 @@
               layers['Layer'].call(this, layer);
             var params = layer.getSource().getParams();
             var layers = params.LAYERS.split(',') || [];
-            var styles = new Array(layers.length).
-                join(',').split(',');
+            var styles = (params.STYLES !== undefined) ?
+                params.STYLES.split(',') :
+                new Array(layers.length).join(',').split(',');
             angular.extend(enc, {
               type: 'WMS',
               baseURL: config.wmsUrl || layer.url,


### PR DESCRIPTION
Fixes #939 
- Wrong number of styles paramters by WMS request
- Encoded group layers shall not replace already existing encoded layers.
