### PR TITLE
Fix Map Example

### DIFF
--- a/src/components/map/example/index.html
+++ b/src/components/map/example/index.html
@@ -112,7 +112,7 @@
 
             $scope.map = map;
             gaLayers.loadForTopic('inspire', 'en').then(function() {
-              $scope.layer = gaLayers.getOlLayerById('ch.swisstopo.swissimage');
+              $scope.layer = gaLayers.getOlLayerById('ch.swisstopo.pixelkarte-farbe');
               map.addLayer($scope.layer);
             });
           }]);


### PR DESCRIPTION
For some reason, we can't use swissimage in our examples. This fixes the example using it.

Does anybody know why we can't use in the examples? (Maybe because I'm outside bund network?)
