### PR TITLE
Add google webmaster tools verification tag

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -15,6 +15,11 @@
     <title>geo.admin.ch</title>
 % endif
     <meta charset="utf-8">
+    <!-- verification for google webmaster tools for production site -->
+    <meta name="google-site-verification" content="ZAmW5d4_2X8xb5Yy_nYQbnTSe1EIeSqyhox9aXXwrws" />
+    <!-- this tag enables the search bot forwarding to _escaped_fragment_= urls for SEO. It can be used instead of the ugly hasbang -->
+    <meta name="fragment" content="!" />
+
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
@@ -28,9 +33,6 @@
 
     <meta name="description" content="Maps of Switzerland : The official geoportal of the Swiss Confederation provides digital data which can be viewed, printed out, ordered and supplied by means of the map viewer tool. Geoinformation is made available by public-sector organisations and is accessible to the general public."/>
     <meta name="keywords" content="maps Switzerland, map viewer, Confederation, geodata, public platform, geographical information, geoportal, orthophotos, geolocation, geoinformation, Geodaten, Geoinformation, Bund, Plattform, Karte, Kartendienst, Kartenviewer"/>
-    <!-- verifciation for integration/test site -->
-    <meta name="google-site-verification" content="RNivXmTBSXGqgzd9xZZGOJ41nCFoyp76fSvjUpX3mDk" />
-
     <script>
       (function(){
         var w = window, l = w.location, n = w.navigator, pathname, p = '${device}',


### PR DESCRIPTION
This PR adds 2 things:
- A meta tag to enable the crawling of our page by search bots (google, bing, etc). This meta tag can be used instead of the better known hasbang (we want to avoid hasbang if possible)
- A meta tag to be able to register our production page for google webmaster tools.
