### PR TITLE
Adding robots file and make it deploy target dependant

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -23,7 +23,7 @@ Alias ${base_url_path}/prod ${base_dir}/prd
 % if 'main' in base_url_path:
 # Main webpage
 
-RewriteRule ^/(index.html|mobile.html|info.json|checker)(.*) /var/www/vhosts/mf-geoadmin3/private/geoadmin/prd/$1
+RewriteRule ^/(index.html|mobile.html|info.json|checker|robots.txt)(.*) /var/www/vhosts/mf-geoadmin3/private/geoadmin/prd/$1
 RewriteRule ^/[0-9]+/(img|lib|style|rest|locales)(.*) /var/www/vhosts/mf-geoadmin3/private/geoadmin/prd/$1$2
 
 <IfModule mod_headers.c>

--- a/rc_prod
+++ b/rc_prod
@@ -1,3 +1,4 @@
+export DEPLOY_TARGET=prod
 export BASE_URL_PATH=/main 
 export SERVICE_URL=//api3.geo.admin.ch
 

--- a/scripts/robots.mako-dot-txt
+++ b/scripts/robots.mako-dot-txt
@@ -1,0 +1,6 @@
+User-agent: *
+% if deploy_target == 'prod':
+Disallow: /main/src/
+% else:
+Disallow: /
+% endif


### PR DESCRIPTION
Currently, we serve a generic robots.txt file which prevents search bots from crawling our web page (see http://map.geo.admin.ch/robots.txt). This means that even if we search for the official site description in the the meta tag of the site, we won't get any results in google (see https://www.google.ch/?gws_rd=cr&ei=AJvwUri-FqmCyQPkzIGwAw#q=Maps+of+Switzerland+%3A+The+official+geoportal+of+the+Swiss+Confederation+provides+digital+data+which+can+be+viewed%2C+printed+out%2C+ordered+&safe=off)

This PR adds a custom robots.txt which will enable crawling. Note that if the deploy target is not prod, the robots file we serve still prevents the search engines to crawl it. This is in order to _not_ index our dev and int instances.
