### PR TITLE
Lazy loading of d3

### DIFF
--- a/src/components/profile/ProfileDirective.js
+++ b/src/components/profile/ProfileDirective.js
@@ -17,28 +17,35 @@
             options: '=gaProfileOptions'
           },
           link: function(scope, element, attrs) {
+            var profile;
             var options = scope.options;
             var tooltipEl = element.find('.profile-tooltip');
             scope.coordinates = [0, 0];
             scope.unitX = '';
 
-            var profile = gaProfileService(options);
-
             $rootScope.$on('gaProfileDataLoaded', function(ev, data) {
-              var d3 = window.d3;
-              var profileEl = angular.element(
-                  profile.create(data)
-              );
-              $compile(profileEl)(scope);
-              scope.unitX = profile.unitX;
-              var previousProfileEl = element.find('.profile-inner');
-              if (previousProfileEl.length > 0) {
-                previousProfileEl.replaceWith(profileEl);
+              var loadData = function() {
+                var d3 = window.d3;
+                var profileEl = angular.element(
+                    profile.create(data)
+                );
+                $compile(profileEl)(scope);
+                scope.unitX = profile.unitX;
+                var previousProfileEl = element.find('.profile-inner');
+                if (previousProfileEl.length > 0) {
+                  previousProfileEl.replaceWith(profileEl);
+                } else {
+                  element.append(profileEl);
+                }
+                var areaChartPath = d3.select('.profile-area');
+                attachPathListeners(areaChartPath);
+              };
+
+              if (!angular.isDefined(profile)) {
+                profile = gaProfileService(options, loadData);
               } else {
-                element.append(profileEl);
+                loadData();
               }
-              var areaChartPath = d3.select('.profile-area');
-              attachPathListeners(areaChartPath);
             });
 
             $rootScope.$on('gaProfileDataUpdated', function(ev, data) {

--- a/src/components/profile/ProfileService.js
+++ b/src/components/profile/ProfileService.js
@@ -10,7 +10,7 @@
 
   module.provider('gaProfileService', function() {
 
-    function ProfileChart(options) {
+    function ProfileChart($timeout, options, lazyLoadCB) {
       var marginHoriz = options.margin.left + options.margin.right;
       var marginVert = options.margin.top + options.margin.bottom;
       var elevationModel = options.elevationModel || 'DTM25';
@@ -23,12 +23,13 @@
         d3 = window.d3;
         x = d3.scale.linear().range([0, width]);
         y = d3.scale.linear().range([height, 0]);
+        lazyLoadCB();
       };
 
       if (!window.d3) {
         $.getScript(versionPath + 'lib/d3-3.3.1.min.js', onD3Loaded);
       } else {
-        onD3Loaded();
+        $timeout(onD3Loaded, 0);
       }
 
       var createArea = function(domain) {
@@ -235,10 +236,10 @@
       };
     }
 
-    this.$get = function(gaGlobalOptions) {
-      return function(options) {
+    this.$get = function($timeout, gaGlobalOptions) {
+      return function(options, lazyLoadCB) {
         options.version = gaGlobalOptions.version;
-        var chart = new ProfileChart(options);
+        var chart = new ProfileChart($timeout, options, lazyLoadCB);
         return chart;
       };
     };


### PR DESCRIPTION
This PR lazy loads the d3 source file, meaning, it's only loaded when the user wants to display the profile.

This safes 50KB of data transferred on initial loading of app, particularly useful on mobile devices, where profile is never used anyway.

Drawback: first drawing of profile has to wait for the 50KB to be loaded first.
