### PR TITLE
Deploybranch: Assure force-pushed branches update correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,10 @@ apache: apache/app.conf
 .PHONY: deploybranch
 deploybranch: deploy/deploy-branch.cfg $(DEPLOY_ROOT_DIR)/$(GIT_BRANCH)/.git/config
 	cd $(DEPLOY_ROOT_DIR)/$(GIT_BRANCH); \
-	git checkout $(GIT_BRANCH); \
+	git checkout master; \
+	git branch -D $(GIT_BRANCH); \
 	git pull; \
+	git checkout $(GIT_BRANCH); \
 	make preparebranch; \
 	cp scripts/00-$(GIT_BRANCH).conf /var/www/vhosts/mf-geoadmin3/conf; \
 	bash -c "source rc_branch && make all";


### PR DESCRIPTION
When deploybranching a branch that was force-pushed to github (because of rebase or otherwise re-written history), it was possible to have merge conflicts, resulting in the update not working correctly.

This PR adresses this issue by deleting the local branch before pulling in the changes from remote.
