### PR TITLE
Use topics selected layers array per default

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -529,6 +529,13 @@
         };
 
         /**
+         * Reurn an array of pre-selected bodId from current topic
+         */
+        this.getSelectedLayers = function() {
+          return currentTopic.selectedLayers;
+        };
+
+        /**
          * Return an array of ol.layer.Layer objects for the background
          * layers.
          */

--- a/test/specs/catalogtree/CatalogtreeDirective.spec.js
+++ b/test/specs/catalogtree/CatalogtreeDirective.spec.js
@@ -9,6 +9,9 @@ describe('ga_catalogtree_directive', function() {
 
     module(function($provide) {
       $provide.value('gaLayers', {
+        getSelectedLayers: function() {
+          return ['bar'];
+        },
         loadForTopic: function() {
         },
         getLayer: function() {
@@ -74,6 +77,15 @@ describe('ga_catalogtree_directive', function() {
   it('sends the catalog request', function() {
     $httpBackend.expectGET(expectedUrl);
     $httpBackend.flush();
+  });
+
+  it('adds preselected layers', function() {
+    $httpBackend.expectGET(expectedUrl);
+    $httpBackend.flush();
+    var layers = map.getLayers();
+    var numLayers = layers.getLength();
+    expect(numLayers).to.equal(1);
+    expect(layers.getAt(0).get('bodId')).to.equal('bar');
   });
 
   describe('layers already in the map', function() {


### PR DESCRIPTION
This adresses the issue https://github.com/geoadmin/mf-geoadmin3/issues/1061

Instead of catalog selectedOpen catalog, we now use the existing selectedLayers array of the topic definition to add default layers to the map. This assures that the order of the layers are correct.
