### PR TITLE
Avoid conflicts between keyboard event listener from time selector and map

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -117,7 +117,7 @@
 % endif
     </div> <!-- #header -->
 
-    <div id="map" class="map" ga-map ga-map-map="map">
+    <div id="map" class="map" tabindex="1" ga-map ga-map-map="map">
       <div ga-geolocation ga-geolocation-map="map"></div>
       <div id="copyrightsdata">
         <div>

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -24,7 +24,8 @@
       }),
       interactions: ol.interaction.defaults({
         altShiftDragRotate: true,
-        touchRotate: false
+        touchRotate: false,
+        keyboard: false
       }).extend([
         new ol.interaction.DragZoom()
       ]),
@@ -38,7 +39,7 @@
       }),
       ol3Logo: false
     });
-    
+   
     var dragClass = 'ga-dragging';
     var viewport = $(map.getViewport());
     map.on('dragstart', function() {
@@ -70,6 +71,16 @@ module.controller('GaMainController',
       // The main controller creates the OpenLayers map object. The map object
       // is central, as most directives/components need a reference to it.
       $scope.map = createMap();
+      
+      // We add manually the keyboard interactions to have the possibility to
+      // specify a condition
+      var keyboardPan = new ol.interaction.KeyboardPan({
+        condition: function() {
+          return (!$scope.isTimeSelectorActive);
+        }
+      });
+      $scope.map.addInteraction(keyboardPan);
+      $scope.map.addInteraction(new ol.interaction.KeyboardZoom());
 
       // Activate the "layers" parameter permalink manager for the map.
       gaLayersPermalinkManager($scope.map);


### PR DESCRIPTION
This PR allows chrome to work with keyboard interactions adding tabindex attribute to the map

This PR also add manually keyboard interactions to add the possibility to deactivate keyboard pan events when time selector is active.

Fix https://github.com/geoadmin/mf-geoadmin3/issues/1092
