### PR TITLE
Add basic support to test the snapshot service

### DIFF
--- a/rc_ltjeg
+++ b/rc_ltjeg
@@ -1,3 +1,3 @@
 export BASE_URL_PATH=/ltjeg
-export SERVICE_URL=http://mf-chsdi3.dev.bgdi.ch
+export SERVICE_URL=http://mf-chsdi3.dev.bgdi.ch/ltjeg
 

--- a/src/components/seo/SeoDirective.js
+++ b/src/components/seo/SeoDirective.js
@@ -1,0 +1,30 @@
+(function() {
+  goog.provide('ga_seo_directive');
+
+  goog.require('ga_permalink_service');
+
+  var module = angular.module('ga_seo_directive', [
+    'ga_permalink_service'
+  ]);
+
+  module.directive('gaSeo',
+      function($timeout, gaPermalink) {
+        return {
+          restrict: 'A',
+          replace: true,
+          templateUrl: 'components/seo/partials/seo.html',
+          scope: {
+          },
+          link: function(scope, element, attrs) {
+
+            scope.showme = false;
+
+            if (gaPermalink.getParams().snapshot) {
+              $timeout(function() {
+                scope.showme = true;
+              }, 3000);
+            }
+         }
+       };
+      });
+})();

--- a/src/components/seo/SeoModule.js
+++ b/src/components/seo/SeoModule.js
@@ -1,0 +1,8 @@
+(function() {
+  goog.provide('ga_seo');
+  goog.require('ga_seo_directive');
+
+  angular.module('ga_seo', [
+    'ga_seo_directive'
+  ]);
+})();

--- a/src/components/seo/partials/seo.html
+++ b/src/components/seo/partials/seo.html
@@ -1,0 +1,3 @@
+<div>
+  <div id="seo-test" ng-if="showme"></div>
+</div>

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -36,7 +36,14 @@
     <script>
       (function(){
         var w = window, l = w.location, n = w.navigator, pathname, p = '${device}',
-          m = l.search.match(/(?:mobile=(true|false))/);
+          m = l.search.match(/(?:mobile=(true|false))/),
+          fromSnapshot = l.search.match(/(?:snapshot=true)/);
+
+        //We need this guard as it prevents constant re-loading when
+        //testing the snapshot service in the browser
+        if (fromSnapshot) {
+          return;
+        }
 
         if (!l.origin) { l.origin = l.protocol + "//" + l.hostname } // IE fix
 
@@ -89,6 +96,7 @@
        })();
       </script>
     <![endif]-->
+    <div ga-seo></div>
     <div id="header" class="navbar navbar-fixed-top">
       <div id="logo" class="pull-left">
         <a ng-href="?topic={{topicId}}&lang={{langId}}">

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -25,6 +25,7 @@
   goog.require('ga_featuretree');
   goog.require('ga_measure');
   goog.require('ga_profile');
+  goog.require('ga_seo');
   goog.require('ga_modal_directive');
   goog.require('ga_draggable_directive');
   goog.require('ga_placeholder_directive');
@@ -71,6 +72,7 @@
     'ga_featuretree',
     'ga_measure',
     'ga_profile',
+    'ga_seo',
     'ga_modal_directive',
     'ga_draggable_directive',
     'ga_placeholder_directive',


### PR DESCRIPTION
This PR adds basic support to test the snapshort service https://github.com/geoadmin/mf-chsdi3/pull/418 done in mf-cshdi3.

It assures that unneede re-loads don't happen in the browser when testing the snapshot service.

When the page is called with `snapshot=true`, it will add a div with id `seo-test` after 3 seconds. This is used by the snapshort service to signify that the page-loading is done.

Of source, the seo directive will be extended in the future to do whatever we want and whatever satisfies the search engines cloaking guidelines.

This PR should be merged asap.

Note: bots are not re-directed yet (we need more testing before doing that).
