### PR TITLE
Geolocation activation button

### DIFF
--- a/src/components/geolocation/GeolocationDirective.js
+++ b/src/components/geolocation/GeolocationDirective.js
@@ -161,6 +161,11 @@
           e.preventDefault();
           var tracking = !geolocation.getTracking();
           geolocation.setTracking(tracking);
+          if (tracking) {
+            btnElt.addClass('tracking');
+          } else {
+            btnElt.removeClass('tracking');
+          }
 
           scope.$apply(function() {
             gaPermalink.updateParams({


### PR DESCRIPTION
The button turns red only after the discovery of the first position. It can take one or two seconds after the user clicks. It can lead the user to make a second click which obviously make no sense.
