### PR TITLE
For WMS, resolutions is per default the whole map resolution

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -19,7 +19,9 @@
         return new ol.tilegrid.TileGrid({
           tileSize: 512,
           origin: origin,
-          resolutions: resolutions
+          resolutions: [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250,
+                        2000, 1750, 1500, 1250, 1000, 750, 650, 500, 250,
+                        100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5, 0.25, 0.1]
         });
       } else {
         return new ol.tilegrid.WMTS({


### PR DESCRIPTION
Fix issue with Cadastral Web Map ( @ltclm )

In other words, there are no resolutions config for wms layer in layersconfig
