### PR TITLE
Fix #1126: Set a default value if a wrong bglayer name is provided

### DIFF
--- a/src/components/backgroundlayerselector/BackgroundLayerSelectorDirective.js
+++ b/src/components/backgroundlayerselector/BackgroundLayerSelectorDirective.js
@@ -30,7 +30,7 @@
                       layers.getAt(0).background === true) {
                     layers.removeAt(0);
                   }
-                } else {
+                } else if (gaLayers.getLayer(newVal)) {
                   var layer = gaLayers.getOlLayerById(newVal);
                   layer.background = true;
                   if (!oldVal || oldVal == 'voidLayer') {
@@ -39,6 +39,8 @@
                   } else {
                     layers.setAt(0, layer);
                   }
+                } else {
+                  scope.currentLayer = scope.backgroundLayers[0].id;
                 }
                 gaPermalink.updateParams({bgLayer: newVal});
               }

--- a/test/specs/backgroundlayerselector/BackgroundLayerSelectorDirective.spec.js
+++ b/test/specs/backgroundlayerselector/BackgroundLayerSelectorDirective.spec.js
@@ -16,6 +16,9 @@ describe('ga_backgroundlayerselector_directive', function() {
 
     module(function($provide) {
       $provide.value('gaLayers', {
+        getLayer: function(id) {
+          return {}; 
+        },
         getOlLayerById: function(id) {
           return id == 'foo' ? layer1 : layer2;
         },


### PR DESCRIPTION
Fix #1126 
