### PR TITLE
Use bootstrap css for the print directive

### DIFF
--- a/src/components/print/partials/print.html
+++ b/src/components/print/partials/print.html
@@ -1,16 +1,31 @@
-<form>
-  <div>
-    <label translate>print_layout</label>
-    <select ng-model="layout" ng-options="l.name for l in capabilities.layouts"></select>
-    <label translate>print_scale</label>
-    <select ng-model="scale" ng-options="l.name for l in capabilities.scales"></select>
+<form class="form-horizontal" >
+  <div class="form-group">
+    <label class="col-xs-4 control-label" translate>print_layout</label>
+    <div class="col-xs-8">
+      <select class="form-control" ng-model="layout" ng-options="l.name for l in capabilities.layouts"></select>
+    </div>
   </div>
-  <div class="ga-print-options checkbox">
-      <input ng-model="options.legend" type="checkbox" id="ga-print-legend" />
-      <label for="ga-print-legend" translate>legend</label>
-      <br/>
-      <input ng-model="options.graticule" type="checkbox" id="ga-print-graticule" />
-      <label for="ga-print-graticule" translate>graticule</label>
+  <div class="form-group">
+    <label class="col-xs-4 control-label" translate>print_scale</label>
+    <div class="col-xs-8">
+      <select class="form-control" ng-model="scale" ng-options="l.name for l in capabilities.scales"></select>
+    </div>
   </div>
-  <button type="submit" class="btn btn-primary" ng-click="submit()" translate>print_action</button>
+  <div class="form-group">
+    <div class="col-xs-4">
+      <div class="checkbox">
+        <label>
+          <input ng-model="options.legend" type="checkbox"/>{{'legend' | translate}}
+        </label>
+      </div>
+    </div>
+    <div class="col-xs-8">
+      <div class="checkbox">
+        <label>
+          <input ng-model="options.graticule" type="checkbox"/>{{'graticule' | translate}}
+        </label>
+      </div>
+    </div>
+  </div>
+  <button type="submit" class="btn btn-default col-xs-12" ng-click="submit()" translate>print_action</button>
 </form>

--- a/src/components/print/style/print.less
+++ b/src/components/print/style/print.less
@@ -1,22 +1,7 @@
 [ga-print] {
 
   input[type=checkbox] {
-    opacity: 0;
-  }
-
-  input[type=checkbox] + label:before {
-    font-family: FontAwesome;
-    display: inline-block;
-    letter-spacing: 10px;
-    content: "\f096";
-  }
-
-  input[type=checkbox]:checked + label:before {
-    content: "\f046";
-    letter-spacing: 10px;
-  }
-
-  .ga-print-options {
-    padding-left: 0;
+    margin-top: 2px;
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
This PR use bootstrap to make the print directive more compliant with the rest of the app.

This PR also remove the fontawesome stuff  for the checkboxes because it's redundant with boostrap style.

![map geo admin ch](https://f.cloud.github.com/assets/621420/2259646/7c5f7c24-9e37-11e3-8381-9ed99488f940.png)
