### PR TITLE
Initialize layers to the actual layers in the map

### DIFF
--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -105,7 +105,7 @@
               $compile(layerHeaderTemplate)(scope);
               scope.query = '';
 
-              scope.layers = [];
+              scope.layers = map.getLayers().getArray();
 
               scope.overlay = undefined;
 


### PR DESCRIPTION
The problem was coming from the fact that scope.layers was initially empty.
#1058
