### PR TITLE
Per default, layers in feature tree are opened

### DIFF
--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -195,7 +195,7 @@
                     newNode = {
                       label: '',
                       features: [],
-                      open: oldNode ? oldNode.open : false
+                      open: oldNode ? oldNode.open : true
                     };
                     tree[layerId] = newNode;
                   }


### PR DESCRIPTION
This addresses https://github.com/geoadmin/mf-geoadmin3/issues/1118

Using the Pareto rule, I chose to have all layers open on initial window loading. This covers the most common use case of having one layer active.

If we want more fine grained control (as discuess in the issue above), we can add it later.
