### PR TITLE
Refactoring of the timestamp use

### DIFF
--- a/src/components/catalogtree/CatalogitemDirective.js
+++ b/src/components/catalogtree/CatalogitemDirective.js
@@ -52,14 +52,11 @@
                 }
                 item.errorLoading = error;
               }
-              if (layer && layer.timeEnabled) {
-                // options.currentYear is setted in CatalogTreeDirective
-                var val = $scope.options.currentYear;
 
-                if (!val && bodLayer &&
-                    layer.getSource() instanceof ol.source.WMTS) {
-                  val = bodLayer.timestamps[0];
-                }
+              if (layer.bodId && layer.timeEnabled) {
+                // options.currentYear is setted in CatalogTreeDirective
+                var val = gaLayers.getLayerTimestampFromYear(layer.bodId,
+                    $scope.options.currentYear);
                 layer.time = val;
               }
             };

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -492,8 +492,7 @@
         this.getOlLayerById = function(bodId) {
           var layer = layers[bodId];
           var olLayer;
-          var time = (layer.timeEnabled) ?
-              currentTime : false;
+          var timestamp = this.getLayerTimestampFromYear(bodId, currentTime);
           var attributions = [
             gaMapUtils.getAttribution('<a href="' +
               layer.attributionUrl +
@@ -506,7 +505,7 @@
               olSource = layer.olSource = new ol.source.WMTS({
                 attributions: attributions,
                 dimensions: {
-                  'Time': time || layer.timestamps[0]
+                  'Time': timestamp
                 },
                 projection: 'EPSG:21781',
                 requestEncoding: 'REST',
@@ -531,8 +530,8 @@
               FORMAT: 'image/' + layer.format
             };
 
-            if (layer.timeEnabled && angular.isDefined(time)) {
-              wmsParams['TIME'] = time || layer.timestamps[0];
+            if (timestamp) {
+              wmsParams['TIME'] = timestamp;
             }
             if (layer.singleTile === true) {
               if (!olSource) {
@@ -618,6 +617,47 @@
         this.getMetaDataOfLayer = function(bodId) {
           var url = getMetaDataUrl(currentTopic.id, bodId, $translate.uses());
           return $http.get(url);
+        };
+
+        /**
+         * Find the correct timestamp of layer from a specific year string.
+         *
+         * Returns undefined if the layer has no timestamp.
+         * Returns undefined if the layer has not a timestamp for this year.
+         * If there is more than one timestamp for a year we choose the first
+         * found.
+         */
+        this.getLayerTimestampFromYear = function(bodId, yearStr) {
+          var layer = this.getLayer(bodId);
+          var timestamps = layer.timestamps || [];
+
+          if (!layer.timeEnabled) {
+            // a WMTS layer has at least one timestamp
+            return (layer.type == 'wmts') ? timestamps[0] : undefined;
+          } else if (layer.type == 'wms') {
+            // A time enabled WMS layer has no timestamps so we return the
+            // yearsStr unchanged
+            return yearStr;
+          }
+
+          if (!angular.isDefined(yearStr)) {
+            var timeBehaviour = this.getLayerProperty(bodId,
+                'timeBehaviour');
+            yearStr = (timeBehaviour === 'all' || timestamps.length == 0) ?
+                undefined : timestamps[0];
+          }
+
+          for (var i = 0, ii = timestamps.length; i < ii; i++) {
+            var ts = timestamps[i];
+            //Strange if statement here because yearStr can either be
+            //full timestamp string or year-only string...
+            if (yearStr === ts ||
+                parseInt(yearStr) === parseInt(ts.substr(0, 4))) {
+              return ts;
+            }
+          }
+
+          return undefined;
         };
 
         $rootScope.$on('gaTopicChange', function(event, topic) {

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -136,6 +136,12 @@
                   !isPreview) {
                   layerInMap.preview = isPreview;
                 }
+                if (olLayer.bodId && olLayer.timeEnabled) {
+                  // options.currentYear is setted in CatalogTreeDirective
+                  var val = gaLayers.getLayerTimestampFromYear(olLayer.bodId,
+                      year);
+                  olLayer.time = val;
+                }
               };
 
               scope.removePreviewLayer = function(bodId) {
@@ -426,9 +432,9 @@
                 }
               });
 
-              scope.$on('gaTimeSelectorChange', function(event, currentyear) {
-                if (currentyear !== year) {
-                  year = currentyear;
+              scope.$on('gaTimeSelectorChange', function(event, newYear) {
+                if (newYear !== year) {
+                  year = newYear;
                   if (scope.query !== '') {
                     //Update locations search (containing feature search)
                     var datasetLocations = $(taElt).data('ttView').datasets[0];

--- a/src/components/timeselector/style/timeselector.less
+++ b/src/components/timeselector/style/timeselector.less
@@ -88,7 +88,7 @@
         height: 30px;
         border: none;
         border-radius: 0px; 
-        cursor: move;
+        cursor: w-resize;
         z-index: 0;
         background: data-uri('pointer.png') no-repeat 2px 1px;
 


### PR DESCRIPTION
Fix #1223 #1224 #1219 

It simplifies the management of timestamp and makes it reusable.

I have no WMS layer to test the functionnality but with WMTS it seems working well.

Needs emergency review and testing.

http://mf-geoadmin3.dev.bgdi.ch/ltteo/prod/?topic=lubis&X=243507.71&Y=709667.29&zoom=2&lang=fr&bgLayer=voidLayer&catalogNodes=1179,1180,1186&time=1984&layers=ch.swisstopo.lubis-luftbilder-dritte-kantone
