### PR TITLE
Remove snapshot parameter from permalink

### DIFF
--- a/src/components/seo/SeoService.js
+++ b/src/components/seo/SeoService.js
@@ -26,6 +26,11 @@
 
       var isSnapshot = gaPermalink.getParams().snapshot == 'true';
 
+      // We remove the snapshot parameter in order to not have it
+      // anywhere in the page as part of the permalink inside the page.
+      // Snapshot state is available through the isSnapshot function.
+      gaPermalink.deleteParam('snapshot');
+
       var SeoService = function() {
         this.addRequestCount = function() {
           openRequests += 1;


### PR DESCRIPTION
This removes the snapshot parameter from the permalink in order to avoid the search engine crawlers to index URL's containing this parameter.

This should be included in the next deploy.
