### PR TITLE
Add a gaPreviewLayers service

### DIFF
--- a/src/components/catalogtree/partials/catalogitem.html
+++ b/src/components/catalogtree/partials/catalogitem.html
@@ -1,7 +1,7 @@
 <div class="ga-catalogitem-template" ng-switch="item.children">
 
   <div ng-switch-when="undefined" class="ga-catalogitem-leaf ga-catalogitem-entry"
-    ng-class="{'ga-catalogitem-preview': inPreviewMode(), 'ga-catalogitem-selected': item.selectedOpen}"
+    ng-class="{'ga-catalogitem-preview': inPreviewMode, 'ga-catalogitem-selected': item.selectedOpen}"
     ng-mouseover="addPreviewLayer($event)"
     ng-mouseleave="removePreviewLayer($event)">
     <label title="{{item.label}}" class="ga-truncate-text ga-checkbox">

--- a/src/components/catalogtree/style/catalogtree.less
+++ b/src/components/catalogtree/style/catalogtree.less
@@ -29,13 +29,13 @@
   .ga-catalogitem-template {
     background-color: #fff;
 
-    .ga-catalogitem-selected {
-      color: #f00;
-    }
-
     .ga-catalogitem-preview {
       color: #666;
       cursor: pointer;
+    }
+
+    .ga-catalogitem-selected {
+      color: #f00;
     }
   }
 

--- a/src/components/importwms/partials/importwms.html
+++ b/src/components/importwms/partials/importwms.html
@@ -30,8 +30,8 @@
             <td>
               <div class="icon-zoom-in" ng-click="zoomOnLayerExtent(layer)"></div>
             </td>
-            <td ng-mouseover="addLayerHovered(layer)"
-                ng-mouseleave="removeLayerHovered()"
+            <td ng-mouseover="addPreviewLayer(layer)"
+                ng-mouseleave="removePreviewLayer()"
                 ng-click="toggleLayerSelected(layer)" >
               {{layer.Title}}
             </td>

--- a/src/components/importwms/style/importwms.less
+++ b/src/components/importwms/style/importwms.less
@@ -105,6 +105,10 @@
     th {
       border-bottom: none;
     }
+
+    th, td {
+      vertical-align: middle;
+    }
   }
 
   .ga-import-wms-content {

--- a/test/specs/importwms/ImportWmsDirective.spec.js
+++ b/test/specs/importwms/ImportWmsDirective.spec.js
@@ -128,14 +128,12 @@ describe('ga_importwms__directive', function() {
     }));
     
     it('adds/removes a preview layer to the map', inject(function($rootScope) {
-      $rootScope.addLayerHovered($rootScope.layers[0]);
+      $rootScope.addPreviewLayer($rootScope.layers[0]);
       expect($rootScope.map.getLayers().getLength()).to.be(1);      
-      expect($rootScope.olLayerHovered.preview).to.be(true);
       expect($rootScope.map.getLayers().getAt(0).preview).to.be(true);
-      $rootScope.removeLayerHovered();   
+      $rootScope.removePreviewLayer();   
       expect($rootScope.map.getLayers().getLength()).to.be(0);
       expect($rootScope.layerHovered).to.be(null);
-      expect($rootScope.olLayerHovered).to.be(null);
     }));
     
     it('selects/unselects a layer', inject(function($rootScope) {
@@ -149,7 +147,7 @@ describe('ga_importwms__directive', function() {
       $rootScope.toggleLayerSelected($rootScope.layers[0]);
       $rootScope.addLayerSelected();
       expect($rootScope.map.getLayers().getLength()).to.be(1);      
-      expect($rootScope.map.getLayers().getAt(0).preview).to.be(false);
+      expect($rootScope.map.getLayers().getAt(0).preview).to.be(undefined);
     }));
 
     it('zooms on layer extent', inject(function($rootScope) {


### PR DESCRIPTION
This PR add a service to manage preview layers (catalogTree, Search, ImportWMS). 

As preview layers is a nice-to-have functionnality, it shouldn't break the application or the css  if we remove it, moreover a modification like managing time in preview layer should be easier than it was so I try to factorize and harmonbize the code in the three components with this service.
