### PR TITLE
Remove fixed width of tooltip

### DIFF
--- a/src/components/tooltip/style/tooltip.less
+++ b/src/components/tooltip/style/tooltip.less
@@ -2,7 +2,6 @@
 @tooltip-height: 600;
 
 .ga-tooltip {
-  width: unit(@tooltip-width, px);
   max-width: unit(@tooltip-width, px);
   max-height: unit(@tooltip-height, px);
 


### PR DESCRIPTION
Fix: #1263 

Url de test:

http://mf-geoadmin3.dev.bgdi.ch/dev_width/prod/?X=188870.30&Y=640914.35&zoom=3&lang=de&topic=bafu&bgLayer=ch.swisstopo.pixelkarte-grau&layers_opacity=0.4,0.4,1&layers=ch.bafu.waldschadenflaechen-lothar,ch.bafu.waldschadenflaechen-vivian,KML%7C%7Chttps:%2F%2Fdocs.google.com%2Fuc%3Fexport%3Ddownload%26id%3D0B1q30s3mf7gPTFdtQTZNNVJ4M2c&catalogNodes=813
