### PR TITLE
Fix #1284 : Remove preview layer when a new layer is added to the map

### DIFF
--- a/src/components/catalogtree/CatalogitemDirective.js
+++ b/src/components/catalogtree/CatalogitemDirective.js
@@ -53,7 +53,9 @@
               $scope.inPreviewMode = false;
             };
 
-            $scope.toggleLayer = function() {
+            $scope.toggleLayer = function(evt) {
+              // Avoid to have the same layer twice on the map
+              $scope.removePreviewLayer(evt);
               var item = $scope.item;
               var map = $scope.map;
               var layer = gaMapUtils.getMapOverlayForBodId(

--- a/src/components/catalogtree/partials/catalogitem.html
+++ b/src/components/catalogtree/partials/catalogitem.html
@@ -5,7 +5,7 @@
     ng-mouseover="addPreviewLayer($event)"
     ng-mouseleave="removePreviewLayer($event)">
     <label title="{{item.label}}" class="ga-truncate-text ga-checkbox">
-      <input type="checkbox" ng-model="item.selectedOpen" ng-change="toggleLayer()" />
+      <input type="checkbox" ng-model="item.selectedOpen" ng-change="toggleLayer($event)" />
       <span></span>
       {{item.label}}
     </label>

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -122,6 +122,10 @@
               };
 
               scope.addLayer = function(bodId) {
+                // removePreviewLayer is not called automaticallay
+                // after a click
+                scope.removePreviewLayer();
+
                 var layerInMap = gaMapUtils.getMapOverlayForBodId(
                     map, bodId);
                 if (!angular.isDefined(layerInMap)) {


### PR DESCRIPTION
Removes correctly the preview layer.
