### PR TITLE
Replace touchXXX events bx pointerXXX events in the ContextMenu

### DIFF
--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -145,18 +145,18 @@
                 // On touch devices and browsers others than ie10, display the
                 // context popup after a long press (300ms)
                 var startPixel, holdPromise;
-                map.on('touchstart', function(event) {
+                map.on('pointerdown', function(event) {
                   $timeout.cancel(holdPromise);
                   startPixel = event.pixel;
                   holdPromise = $timeout(function() {
                     handler(event);
                   }, 300, false);
                 });
-                map.on('touchend', function(event) {
+                map.on('pointerup', function(event) {
                   $timeout.cancel(holdPromise);
                   startPixel = undefined;
                 });
-                map.on('touchmove', function(event) {
+                map.on('pointermove', function(event) {
                   if (startPixel) {
                     var pixel = event.pixel;
                     var deltaX = Math.abs(startPixel[0] - pixel[0]);

--- a/test/specs/contextpopup/ContextPopupDirective.spec.js
+++ b/test/specs/contextpopup/ContextPopupDirective.spec.js
@@ -112,7 +112,7 @@ describe('ga_contextpopup_directive', function() {
       it('correctly emulates contextmenu', function() {
         $httpBackend.expectJSONP(expectedHeightUrl);
         $httpBackend.expectJSONP(expectedReframeUrl);
-        handlers.touchstart(mapEvt);
+        handlers.pointerdown(mapEvt);
 
         $timeout.flush();
         $httpBackend.flush();
@@ -133,8 +133,8 @@ describe('ga_contextpopup_directive', function() {
         // Make sure there aren't any timouts left (this might
         // compenstate for a bug in angular.mock or angular in general)
         $timeout.flush();
-        handlers.touchstart(mapEvt);
-        handlers.touchend(mapEvt);
+        handlers.pointerdown(mapEvt);
+        handlers.pointerup(mapEvt);
         $timeout.verifyNoPendingTasks();
 
         var popover = element.find('.popover');
@@ -146,8 +146,8 @@ describe('ga_contextpopup_directive', function() {
         // Make sure there aren't any timouts left (this might
         // compenstate for a bug in angular.mock or angular in general)
         $timeout.flush();
-        handlers.touchstart(mapEvt);
-        handlers.touchmove({
+        handlers.pointerdown(mapEvt);
+        handlers.pointermove({
           pixel: [30, 60]
         });
         $timeout.verifyNoPendingTasks();


### PR DESCRIPTION
Fix the contextmenu on mobile
