### PR TITLE
LUBIS: Remove layer opacity by setting opacity in feature's style

### DIFF
--- a/src/components/StylesService.js
+++ b/src/components/StylesService.js
@@ -5,12 +5,12 @@
 
   module.provider('gaStyleFactory', function() {
     var selectStroke = new ol.style.Stroke({
-      color: '#ff8000',
+      color: [255, 128, 0, 1],
       width: 3
     });
 
     var selectFill = new ol.style.Fill({
-      color: '#ffff00'
+      color: [255, 255, 0, 0.75]
     });
 
     var selectStyle = new ol.style.Style({
@@ -24,12 +24,12 @@
     });
 
     var hlStroke = new ol.style.Stroke({
-      color: '#f00000',
+      color: [240, 0, 0, 1],
       width: 6
     });
 
     var hlFill = new ol.style.Fill({
-      color: '#ff0000'
+      color: [255, 0, 0, 1]
     });
 
     var hlStyle = new ol.style.Style({
@@ -44,7 +44,7 @@
 
     var srStyle = new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color: 'blue',
+        color: [0, 0, 255, 1],
         width: 3
       })
     });

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1025,7 +1025,6 @@
       // Define layer default properties
       gaDefinePropertiesForLayer(vector);
       vector.preview = true;
-      vector.invertedOpacity = 0.25;
 
       // TO DO: May be this method should be elsewher?
       var getFeatures = function(featureIdsByBodId) {


### PR DESCRIPTION
Fix #1282

Test [here](http://mf-geoadmin3.dev.bgdi.ch/fix_highlight/prod/?ch.swisstopo.lubis-luftbilder_schwarzweiss=20100660125020&lang=fr&topic=lubis&X=159855.16&Y=672170.60&zoom=7&bgLayer=ch.swisstopo.pixelkarte-grau&catalogNodes=1179,1180,1186&layers=ch.swisstopo.lubis-luftbilder_schwarzweiss)
