### PR TITLE
Reduce tooltip feature cursor timeout

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -72,7 +72,7 @@
               map.getTarget().style.cursor = (feature) ? 'pointer' : '';
             };
             var updateCursorStyleDebounced = gaDebounce.debounce(
-                updateCursorStyle, 100, false);
+                updateCursorStyle, 10, false);
 
             if (!gaBrowserSniffer.mobile) {
               $(map.getViewport()).on('mousemove', function(evt) {


### PR DESCRIPTION
Based on the disccusion in #1317, I propose the reduction of the debounce timeout to 10ms. The application reacts much better but still benefits from reduced polling of the features whith constant mouse moving.

@oterral could you test with the big kml and merge if acceptable for you?
