### PR TITLE
Add page end load trigger to seo again

### DIFF
--- a/src/components/seo/partials/seo.html
+++ b/src/components/seo/partials/seo.html
@@ -10,7 +10,7 @@
   </div> <!-- end popup -->
 
   <!-- this is the trigger. activate to indicate the end of page loading -->
-  <div ng-if="triggerPageEnd"></div>
+  <div id="seo-load-end" ng-if="triggerPageEnd"></div>
 </div>
 
 


### PR DESCRIPTION
This re-adds the seo load end page trigger that was removed by 3acf283 (which shouldn't have happened). It's also renamed to a more appropriate name
