### PR TITLE
SEO: Refactoring - use promises instead of counter

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -16,8 +16,8 @@
    * See examples on how it can be used
    */
   module.directive('gaCatalogtree',
-      function($http, $translate, gaPermalink, gaCatalogtreeMapUtils,
-          gaLayers, gaLayerFilters) {
+      function($http, $translate, $rootScope, gaPermalink,
+          gaCatalogtreeMapUtils, gaLayers, gaLayerFilters) {
 
         return {
           restrict: 'A',
@@ -179,6 +179,7 @@
                 } else {
                   handleTree(newTree, oldTree);
                 }
+                $rootScope.$broadcast('gaCatalogChange');
               });
             });
 

--- a/src/components/seo/SeoDirective.js
+++ b/src/components/seo/SeoDirective.js
@@ -10,7 +10,7 @@
   ]);
 
   module.directive('gaSeo',
-      function($sce, $timeout, $interval, gaSeoService, gaLayers) {
+      function($sce, $timeout, $interval, $q, gaSeoService, gaLayers) {
         return {
           restrict: 'A',
           replace: true,
@@ -18,64 +18,103 @@
           scope: {
           },
           link: function(scope, element, attrs) {
+            var MIN_WAIT = 300;
 
             scope.triggerPageEnd = false;
             scope.showPopup = false;
             scope.htmls = [];
 
-
             var addHtmlSnippet = function(htmlSnippet) {
               scope.htmls.push($sce.trustAsHtml(htmlSnippet));
             };
 
-            var initSnapshot = function() {
-              var i, intervalpromise,
-                  layers = gaSeoService.getLayers(),
-                  firstTime = true,
-                  MIN_WAIT = 1000;
+            var getWaitPromise = function(time) {
+              var def = $q.defer();
+              $timeout(function() {
+                def.resolve();
+              }, time);
+              return def.promise;
+            };
 
-              //Minimal wait is 1 second and is the minimal wait time
-              //after the layersconfig is loaded. Usually, catalog
-              //is loaded later...so if we want to assure that
-              //the catalog is loaded, we have to adapt a little
+            var insertLayerMetadata = function(layers) {
+              var promises = [], i;
 
+              var getMetadata = function(layerId) {
+                var def = $q.defer();
+                gaLayers.getMetaDataOfLayer(layerId)
+                    .success(function(data) {
+                      addHtmlSnippet(data);
+                      def.resolve();
+                    }).error(function() {
+                      def.resolve();
+                    });
+                return def.promise;
+              };
+
+              for (i = 0; i < layers.length; i++) {
+                promises.push(getMetadata(layers[i]));
+              }
+              return $q.all(promises);
+            };
+
+            var onLayersChange = function() {
+              var layers = gaSeoService.getLayers(),
+                  def = $q.defer(),
+                  unregister;
+
+              unregister = scope.$on('gaLayersChange', function() {
+                var promises = [];
+
+                //We wait at least MIN_WAIT after layers-config is loaded
+                promises.push(getWaitPromise(MIN_WAIT));
+
+                //Display layer metadata
+                if (layers.length > 0) {
+                  promises.push(insertLayerMetadata(layers));
+                }
+
+                $q.all(promises).then(function() {
+                  def.resolve();
+                });
+                unregister();
+              });
+
+              return def.promise;
+            };
+
+            var onCatalogChange = function() {
+              var def = $q.defer(),
+                  unregister;
+
+              unregister = scope.$on('gaCatalogChange', function() {
+                getWaitPromise(MIN_WAIT).then(function() {
+                  def.resolve();
+                });
+                unregister();
+              });
+
+              return def.promise;
+            };
+
+            var injectSnapshotData = function() {
+              var promises = [];
+
+              promises.push(onLayersChange());
+              promises.push(onCatalogChange());
+
+              return $q.all(promises);
+            };
+
+            // Just do something if we are in snapshot mode
+            if (gaSeoService.isSnapshot()) {
+              //Show popup
               $timeout(function() {
                 scope.showPopup = true;
               }, 0);
 
-              //We could adapt the description
-              //$('meta[name=description]').attr('content', 'holidu');
-
-              scope.$on('gaLayersChange', function() {
-                if (firstTime) {
-                  //Load metadata of selected layers
-                  for (i = 0; i < layers.length; i++) {
-                    gaSeoService.addRequestCount();
-                    gaLayers.getMetaDataOfLayer(layers[i])
-                        .success(function(data) {
-                          addHtmlSnippet(data);
-                          gaSeoService.removeRequestCount();
-                        }).error(function() {
-                          gaSeoService.removeRequestCount();
-                        });
-                  }
-
-
-                  //keep this in the end here
-                  intervalpromise = $interval(function() {
-                    if (!gaSeoService.waitOnRequests()) {
-                      $interval.cancel(intervalpromise);
-                      scope.triggerPageEnd = true;
-                    }
-                  }, MIN_WAIT);
-                }
-                firstTime = false;
+              injectSnapshotData().then(function() {
+                scope.triggerPageEnd = true;
               });
-
-            };
-
-            if (gaSeoService.isSnapshot()) {
-              initSnapshot();
            }
          }
        };

--- a/src/components/seo/SeoService.js
+++ b/src/components/seo/SeoService.js
@@ -19,8 +19,6 @@
    */
   module.provider('gaSeoService', function() {
     this.$get = function(gaPermalink) {
-      var openRequests = 0;
-
       var layersAtStart = gaPermalink.getParams().layers ?
                           gaPermalink.getParams().layers.split(',') : [];
 
@@ -32,18 +30,6 @@
       gaPermalink.deleteParam('snapshot');
 
       var SeoService = function() {
-        this.addRequestCount = function() {
-          openRequests += 1;
-        };
-
-        this.removeRequestCount = function() {
-          openRequests -= 1;
-        };
-
-        this.waitOnRequests = function() {
-          return openRequests > 0;
-        };
-
         this.isSnapshot = function() {
           return isSnapshot;
         };


### PR DESCRIPTION
This is a little refactoring to use promises instead of the awkward counter. This should be much more robust when we add functionality to this component.
