### PR TITLE
Permalink: add swisssearch parameter handling

### DIFF
--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -103,5 +103,56 @@
         };
       };
     });
+
+  module.provider('gaPermalinkSearch', function() {
+    this.$get = function($timeout) {
+
+      var PermalinkSearch = function() {
+        var active = false,
+            resultCounter = 0,
+            clickEl = undefined,
+            maxRounds = 0;
+
+       this.activate = function(numberOfResults) {
+          active = true;
+          resultCounter = 0;
+          clickEl = undefined;
+          maxRounds = numberOfResults;
+        };
+
+        this.feed = function(el) {
+          if (!active) {
+            return;
+          }
+          el = el.find('.tt-suggestion');
+          if (el.length > 1) {
+            active = false;
+          } else if (el.length == 1) {
+            if (clickEl) {
+              active = false;
+            } else {
+              clickEl = el[0];
+            }
+          }
+        };
+
+        this.check = function() {
+          if (active) {
+            resultCounter += 1;
+            if (resultCounter >= maxRounds) {
+              active = false;
+              if (clickEl) {
+                clickEl.click();
+              }
+            }
+          }
+        };
+
+      };
+
+      return new PermalinkSearch();
+    };
+  });
+
 })();
 


### PR DESCRIPTION
https://github.com/geoadmin/mf-geoadmin3/issues/586 and #926

This PR adds feature parity with RE2. A search is triggered on page load when the `swisssearch` parameter is present. If the search returns exactly 1 result, the result is activated (as if clicked by the user). This is the same behaviour as in RE2.

Note: this PR likely conflicts with https://github.com/geoadmin/mf-geoadmin3/pull/1345. Whichever is merged later will probably need a rebasing.

Note: To have only 1 result (and therefore re-location of map), you have to be very specific. Simply putting `Payerne` is not enough. Therefore, this is not really usable for SEO out of the box.
