### PR TITLE
Metadatainfo: Make the popup service toggleable

### DIFF
--- a/src/components/LayerMetadataPopupService.js
+++ b/src/components/LayerMetadataPopupService.js
@@ -12,28 +12,45 @@
 
   module.provider('gaLayerMetadataPopup', function() {
     this.$get = function($document, $translate, gaPopup, gaLayers) {
+          // Keep track of existing popups
+          var popups = {};
+          var getCloseCallback = function(bodid) {
+            return function() {
+              popups[bodid] = undefined;
+            }
+          };
+
+          // This service acts as a toggle. Repeated calls with
+          // the same bodid will 'toggle' the popup with the
+          // meta information.
           return function(bodid) {
             var waitClass = 'ga-metadata-popup-wait';
             var bodyEl = angular.element($document[0].body);
-            bodyEl.addClass(waitClass);
-            gaLayers.getMetaDataOfLayer(bodid)
-            .success(function(data) {
-              bodyEl.removeClass(waitClass);
-              gaPopup.create({
-                title: $translate('metadata_window_title'),
-                content: data,
-                className: 'ga-tooltip-metadata',
-                x: 400,
-                y: 200,
-                showPrint: true
-              }).open();
-            })
-            .error(function() {
-              bodyEl.removeClass(waitClass);
-              //FIXME: better error handling
-              var msg = 'Could not retrieve information for ' + bodid;
-              alert(msg);
-            });
+            if (angular.isDefined(popups[bodid])) {
+              popups[bodid].close();
+            } else {
+              bodyEl.addClass(waitClass);
+              gaLayers.getMetaDataOfLayer(bodid)
+                .success(function(data) {
+                  bodyEl.removeClass(waitClass);
+                  popups[bodid] = gaPopup.create({
+                    title: $translate('metadata_window_title'),
+                    content: data,
+                    className: 'ga-tooltip-metadata',
+                    x: 400,
+                    y: 200,
+                    showPrint: true,
+                    onCloseCallback: getCloseCallback(bodid)
+                  });
+                  popups[bodid].open();
+              })
+              .error(function() {
+                bodyEl.removeClass(waitClass);
+                //FIXME: better error handling
+                var msg = 'Could not retrieve information for ' + bodid;
+                alert(msg);
+              });
+            }
           };
     };
   });


### PR DESCRIPTION
This transform the existing gaLayerMetadatPopup service into a toggleable service. The service is used in 3 components: catalog, layermanager and search. Wherever the service is called, it toggles the metadata information popup for the given layer.

This addresses #1246
