### PR TITLE
ech layers can be used in all other topics

### DIFF
--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -124,7 +124,28 @@
               });
             });
 
+            var removeNonExistantBodLayers = function() {
+              var removeLayers = [];
+              // We assemble the layers to remove because
+              // we shouldn't remove from the array that
+              // we are iterating over
+              scope.map.getLayers().forEach(function(olLayer) {
+                if (olLayer.bodId &&
+                    !olLayer.background &&
+                    !scope.isBodLayer(olLayer)) {
+                  removeLayers.push(olLayer);
+                }
+              });
+              removeLayers.forEach(function(olLayer) {
+                scope.removeLayerFromMap(olLayer);
+              });
+            };
+
             scope.$on('gaLayersChange', function(event, data) {
+              // We remove all bod layers from the map that
+              // don't have a layers definition
+              removeNonExistantBodLayers();
+
               scope.map.getLayers().forEach(function(olLayer) {
                 if (scope.isBodLayer(olLayer)) {
                   olLayer.label = gaLayers.getLayerProperty(olLayer.bodId,

--- a/src/components/topic/TopicDirective.js
+++ b/src/components/topic/TopicDirective.js
@@ -56,18 +56,6 @@
               return res;
             }
 
-            function removeOverlays() {
-              var i, layer;
-              var map = scope.map;
-              var layers = map.getLayers().getArray();
-              for (i = layers.length - 1; i >= 0; --i) {
-                layer = layers[i];
-                if (!layer.background) {
-                  map.removeLayer(layer);
-                }
-              }
-            }
-
             $http.get(options.url).then(function(result) {
               scope.topics = result.data.topics;
               angular.forEach(scope.topics, function(value) {
@@ -93,11 +81,6 @@
                 for (i = 0; i < len; i++) {
                   var topic = scope.topics[i];
                   if (topic.id == newVal) {
-                    // We remove the overlays only as the new topic's default
-                    // background layer may be the same as the current
-                    // background layer.
-                    removeOverlays();
-
                     gaPermalink.updateParams({topic: newVal});
                     $rootScope.$broadcast('gaTopicChange', topic);
                     break;


### PR DESCRIPTION
This PR adresses all use cases in https://github.com/geoadmin/mf-geoadmin3/issues/886

We can now search and add all 'ech' layers in all other topics. Also, on topic change, the layers are only removed if they are not part of the new topic and the ech topic.

**ATTENTION**: This needs https://github.com/geoadmin/mf-chsdi3/pull/651 to work. Keep that in mind when testing (adapt your API_URL in the rc_file to my account if you want to test it)
