### PR TITLE
SEO: Integrate feature specified in PL in page

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1252,6 +1252,11 @@
             featureIdsCount = 0;
           };
 
+          $rootScope.$broadcast('gaPermalinkFeaturesAdd', {
+            featureIdsByBodId: featureIdsByBodId,
+            count: featureIdsCount
+          });
+
           if (featureIdsCount > 0) {
             gaPreviewFeatures.addBodFeatures(map, featureIdsByBodId,
                 removeParamsFromPL);

--- a/src/components/seo/partials/seo.html
+++ b/src/components/seo/partials/seo.html
@@ -4,7 +4,14 @@
        ga-popup-options="{title:'seo title'}"
        ga-draggable=".ga-popup-title"
        id="seo-popup" >
-    <div ng-repeat="htmlsnippet in htmls">
+
+    <!-- Show all feature metadata -->
+    <div ng-repeat="htmlsnippet in featureMetadatas">
+      <div ng-bind-html="htmlsnippet"></div>
+    </div>
+
+    <!-- Show all layer metadata -->
+    <div ng-repeat="htmlsnippet in layerMetadatas">
       <div ng-bind-html="htmlsnippet"></div>
     </div>
   </div> <!-- end popup -->

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -100,7 +100,9 @@
        })();
       </script>
     <![endif]-->
-    <div ga-seo></div>
+    <div ng-controller="GaSeoController">
+      <div ga-seo ga-seo-options="options"></div>
+    </div>
     <div id="header" class="navbar navbar-fixed-top">
       <div id="logo" class="pull-left">
         <a ng-href="?topic={{topicId}}&lang={{langId}}">

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -47,6 +47,7 @@
   goog.require('ga_feedback_controller');
   goog.require('ga_contextpopup_controller');
   goog.require('ga_search_controller');
+  goog.require('ga_seo_controller');
   goog.require('ga_timeselector_controller');
   goog.require('ga_tooltip_controller');
   goog.require('ga_featuretree_controller');
@@ -100,6 +101,7 @@
     'ga_feedback_controller',
     'ga_contextpopup_controller',
     'ga_search_controller',
+    'ga_seo_controller',
     'ga_timeselector_controller',
     'ga_tooltip_controller',
     'ngAnimate',

--- a/src/js/SeoController.js
+++ b/src/js/SeoController.js
@@ -1,0 +1,15 @@
+(function() {
+  goog.provide('ga_seo_controller');
+
+  var module = angular.module('ga_seo_controller', []);
+
+  module.controller('GaSeoController',
+      function($scope, gaGlobalOptions) {
+
+        $scope.options = {
+          htmlUrlTemplate: gaGlobalOptions.cachedMapUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup'
+        };
+
+      });
+
+})();


### PR DESCRIPTION
This adds features passed with the PL to the indexed page. It will integrate the html popups of the passed feature(s) as part of the snapshot paste.

Example PL: map.geo.admin.ch/?ch.bafu.schutzgebiete-paerke_nationaler_bedeutung=7,12&ch.swisstopo.fixpunkte-agnes=HUTT

This likely conflicts with #1369. Whichever is later needs a rebase.
