### PR TITLE
Improves popup css

### DIFF
--- a/src/components/popup/style/popup.less
+++ b/src/components/popup/style/popup.less
@@ -9,12 +9,15 @@
   max-height: @ga-popup-max-height;
   z-index: 2000;
 
+
+  /* !important is used to override (and so deactivate) draggable styles
+  applied */
   @media (max-width: @screen-tablet) {
     z-index: 1500;
-    left: 2%;
+    top: 2% !important;
+    left: 2% !important;
     right: 2%;
     bottom: 2%;
-    top: 2%;
     max-height: none;
     max-width: none;
     -webkit-overflow-scrolling: touch;

--- a/src/components/tooltip/style/tooltip.less
+++ b/src/components/tooltip/style/tooltip.less
@@ -20,15 +20,18 @@
     border-bottom-color: #c7c7c7;
   }
   
+
+  /* !important is used to override (and so deactivate) draggable styles
+  applied */
   @media (max-width: @screen-tablet) {
-    top: 89px;
+    top: @small-header-height !important;
     max-height: 300px;
   }
   
   @media (max-width: @screen-phone) {
-    top: 50%;
+    top: 50% !important;
+    left: 2% !important;
     right: 2%;
-    left: 2%;
     bottom: 2%;
     max-height: none;
     width: auto;

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -613,10 +613,26 @@ a .ga-icon-separator {
 }
 
 // ****** POPUP
+#import-wms-popup, #import-kml-popup, #measure-popup, #draw-popup,
+#featuretree-popup {
+  @media (max-width: @screen-tablet) {
+    top: auto!important;
+    height: 190px;
+
+    .ga-popup-content {
+      overflow: auto;
+    }
+  }
+}
+
 #import-wms-popup {
   max-width: none;
   max-height: none;
   display: none;
+  
+  @media (max-width: @screen-tablet) {
+    height: 435px;
+  }
 
   .ga-popup-content {
     max-height: inherit;
@@ -628,14 +644,28 @@ a .ga-icon-separator {
   max-height: none;
 
   .ga-popup-content {
-    overflow: visible;
     max-height: inherit;
+  }
+
+  @media (max-width: @screen-tablet) {
+    .ga-profile-inner {
+      overflow: visible;
+    }
+  }
+}
+
+#draw-popup {
+  @media (max-width: @screen-tablet) {
+    .ga-icons, .ga-choose-icon {
+      width: 100%;
+      height: auto;
+    }
   }
 }
 
 #featuretree-popup {
   width: 320px;
-  
+ 
   .ga-popup-content {
     padding: 5px 9px 5px 5px;
 
@@ -649,6 +679,7 @@ a .ga-icon-separator {
     }
   }
 }
+
 
 .ga-popup-content,
 [ga-context-popup] .popover-content {


### PR DESCRIPTION
This PR:
- deactivates the resize of popup (when we drag the header)
- makes the popup of tools (draw, measure, featuretree, importXXX) usable on small screen

Test [here](http://mf-geoadmin3.dev.bgdi.ch/dev_popupcss/prod/?X=88500.00&Y=611000.00&zoom=1&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&catalogNodes=457&layers_opacity=0.75)
