### PR TITLE
SEO: Add location information from PL Y,X,zoom

### DIFF
--- a/src/components/seo/SeoDirective.js
+++ b/src/components/seo/SeoDirective.js
@@ -18,7 +18,8 @@
           replace: true,
           templateUrl: 'components/seo/partials/seo.html',
           scope: {
-            options: '=gaSeoOptions'
+            options: '=gaSeoOptions',
+            map: '=gaSeoMap'
           },
           link: function(scope, element, attrs) {
             var MIN_WAIT = 300,
@@ -28,6 +29,7 @@
             scope.showPopup = false;
             scope.layerMetadatas = [];
             scope.featureMetadatas = [];
+            scope.coordinateLocations = [];
 
             var getWaitPromise = function(time) {
               var def = $q.defer();
@@ -37,33 +39,35 @@
               return def.promise;
             };
 
-            var insertLayerMetadata = function(layers) {
-              var promises = [], i;
-
-              var getMetadata = function(layerId) {
-                var def = $q.defer();
-                gaLayers.getMetaDataOfLayer(layerId)
-                    .success(function(data) {
-                      scope.layerMetadatas.push($sce.trustAsHtml(data));
-                      def.resolve();
-                    }).error(function() {
-                      def.resolve();
-                    });
-                return def.promise;
-              };
-
-              for (i = 0; i < layers.length; i++) {
-                promises.push(getMetadata(layers[i]));
-              }
-              return $q.all(promises);
-            };
-
-            var onLayersChange = function() {
+            var permalinkLayers = function() {
               var layers = gaSeoService.getLayers(),
                   def = $q.defer(),
                   unregister;
 
               unregister = scope.$on('gaLayersChange', function() {
+
+                var insertLayerMetadata = function(layers) {
+                  var promises = [], i;
+
+                  var getMetadata = function(layerId) {
+                    var locdef = $q.defer();
+                    gaLayers.getMetaDataOfLayer(layerId)
+                        .success(function(data) {
+                          scope.layerMetadatas.push($sce.trustAsHtml(data));
+                          locdef.resolve();
+                        }).error(function() {
+                          locdef.resolve();
+                        });
+                    return locdef.promise;
+                  };
+
+                  for (i = 0; i < layers.length; i++) {
+                    promises.push(getMetadata(layers[i]));
+                  }
+                  return $q.all(promises);
+                };
+
+
                 var promises = [];
 
                 //We wait at least MIN_WAIT after layers-config is loaded
@@ -183,13 +187,154 @@
               return def.promise;
             };
 
+            var permalinkYXZoom = function() {
+              var def = $q.defer(),
+                  xyzoom = gaSeoService.getYXZoom(),
+                  bailed = false,
+                  BBOX_SIZE = 1000, //1km on each side...likely to be changed
+                  MIN_ZOOM = 5, //Minimal zoom to include xy based location info
+                  PIXEL_TOLERANCE = 10, //Used for identify service
+                  //polygon like layers (better suited for identify)
+                  identifyLayers = [
+                    'ch.swisstopo-vd.ortschaftenverzeichnis_plz',
+                    'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill',
+                    'ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill',
+                    'ch.swisstopo.swissboundaries3d-kanton-flaeche.fill'
+                  ],
+                  //Match layer with property to be inserted
+                  layersProperties = {
+                    'ch.swisstopo-vd.ortschaftenverzeichnis_plz': 'plz',
+                    'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill':
+                        'gemname',
+                    'ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill':
+                        'name',
+                    'ch.swisstopo.swissboundaries3d-kanton-flaeche.fill': 'name'
+                  },
+                  //point like searchable layers (better suited for search)
+                  searchLayers = [
+                    'ch.swisstopo.vec200-names-namedlocation',
+                    'ch.bfs.gebaeude_wohnungs_register'
+                  ],
+                  //for searchlayers, we specify how many results we want
+                  layersMaxResults = {
+                    'ch.swisstopo.vec200-names-namedlocation' : 3,
+                    'ch.bfs.gebaeude_wohnungs_register': 1
+                  },
+                  lTpl = '<a href="' + gaSeoService.getLinkAtStart() +
+                                 '">{result}</a>',
+                  east, north, zoom, bbox;
+
+              if (xyzoom.Y !== undefined &&
+                  xyzoom.X !== undefined &&
+                  xyzoom.zoom !== undefined) {
+                east = parseFloat(xyzoom.Y.replace(/,/g, '.'));
+                north = parseFloat(xyzoom.X.replace(/,/g, '.'));
+                zoom = parseInt(xyzoom.zoom, 10);
+                if (isFinite(east) &&
+                    isFinite(north) &&
+                    isFinite(zoom) &&
+                    zoom >= MIN_ZOOM) {
+                  var searchDef = $q.defer();
+                  var identifyDef = $q.defer();
+                 //for now, we simply get the extent and include everything
+                  //in future, we determine with extent and zoom which layers to
+                  //actually query...
+                  bbox = (east - BBOX_SIZE).toString() + ',' +
+                         (north - BBOX_SIZE).toString() + ',' +
+                         (east + BBOX_SIZE).toString() + ',' +
+                         (north + BBOX_SIZE).toString();
+
+                  $http.get(scope.options.searchUrl, {
+                    params: {
+                      bbox: bbox,
+                      type: 'features',
+                      features: searchLayers.join(','),
+                      timeEnabled: $.map(searchLayers, function(layer) {
+                            return 'false';
+                          }).join(',')
+
+                    }
+                  }).success(function(json) {
+                    var i, li, result, added = {};
+                    if (json.results &&
+                        json.results.length > 0) {
+                      //todo: apply bbox filter? (as in feature tree...)
+                      for (i = 0, li = json.results.length; i < li; i++) {
+                        result = json.results[i];
+                        if (!added[result.attrs.layer]) {
+                          added[result.attrs.layer] = 0;
+                        }
+                        if (added[result.attrs.layer] <
+                            layersMaxResults[result.attrs.layer]) {
+                          added[result.attrs.layer] += 1;
+
+                          scope.coordinateLocations.push($sce.trustAsHtml(
+                              lTpl.replace('{result}', result.attrs.label)));
+                        }
+                      }
+                    }
+                    searchDef.resolve();
+                  }).error(function() {
+                    searchDef.resolve();
+                  });
+
+                  var map = scope.map;
+                  var size = map.getSize();
+
+                  $http.get(scope.options.identifyUrl, {
+                    params: {
+                      lang: $translate.uses(),
+                      geometryType: 'esriGeometryPoint',
+                      geometryFormat: 'geojson',
+                      geometry: east + ',' + north,
+                      imageDisplay: size[0] + ',' + size[1] + ',96',
+                      mapExtent: map.getView().calculateExtent(size).join(','),
+                      tolerance: PIXEL_TOLERANCE,
+                      layers: 'all:' + identifyLayers.join(',')
+                    }
+                  }).success(function(json) {
+                    var i, li, result, prop;
+                    if (json.results &&
+                        json.results.length > 0) {
+                      for (i = 0, li = json.results.length; i < li; i++) {
+                        result = json.results[i];
+                        prop = layersProperties[result.layerBodId];
+                        scope.coordinateLocations.push($sce.trustAsHtml(
+                            lTpl.replace('{result}', result.properties[prop])));
+                      }
+                    }
+                    identifyDef.resolve();
+                  }).error(function() {
+                    identifyDef.resolve();
+                  });
+                  $q.all([searchDef.promise, identifyDef.promise])
+                  .then(function() {
+                    def.resolve();
+                  });
+                } else {
+                  bailed = true;
+                }
+              } else {
+                bailed = true;
+              }
+
+              if (bailed) {
+                $timeout(function() {
+                  def.resolve();
+                }, 0);
+              }
+
+              return def.promise;
+            };
+
             var injectSnapshotData = function() {
               var promises = [];
 
-              promises.push(onLayersChange());
               promises.push(onCatalogChange());
               promises.push(swissSearchParameter());
+              promises.push(permalinkLayers());
               promises.push(permalinkFeatures());
+              promises.push(permalinkYXZoom());
 
               return $q.all(promises);
             };

--- a/src/components/seo/SeoService.js
+++ b/src/components/seo/SeoService.js
@@ -19,10 +19,18 @@
    */
   module.provider('gaSeoService', function() {
     this.$get = function(gaPermalink) {
+      var isSnapshot = gaPermalink.getParams().snapshot == 'true';
       var layersAtStart = gaPermalink.getParams().layers ?
                           gaPermalink.getParams().layers.split(',') : [];
 
-      var isSnapshot = gaPermalink.getParams().snapshot == 'true';
+      var yxzoom = {
+        Y: gaPermalink.getParams().Y,
+        X: gaPermalink.getParams().X,
+        zoom: gaPermalink.getParams().zoom
+      };
+
+      //has to come after snapshot parameter is removed
+      var linkAtStart = gaPermalink.getHref();
 
       // We remove the snapshot parameter in order to not have it
       // anywhere in the page as part of the permalink inside the page.
@@ -30,12 +38,20 @@
       gaPermalink.deleteParam('snapshot');
 
       var SeoService = function() {
+        this.getLinkAtStart = function() {
+          return linkAtStart;
+        };
+
         this.isSnapshot = function() {
           return isSnapshot;
         };
 
         this.getLayers = function() {
           return layersAtStart;
+        };
+
+        this.getYXZoom = function() {
+          return yxzoom;
         };
       };
 

--- a/src/components/seo/partials/seo.html
+++ b/src/components/seo/partials/seo.html
@@ -5,6 +5,11 @@
        ga-draggable=".ga-popup-title"
        id="seo-popup" >
 
+    <!-- Show all locations derived from PL Y,X and zoom -->
+    <div ng-repeat="htmlsnippet in coordinateLocations">
+      <div ng-bind-html="htmlsnippet"></div>
+    </div>
+
     <!-- Show all feature metadata -->
     <div ng-repeat="htmlsnippet in featureMetadatas">
       <div ng-bind-html="htmlsnippet"></div>

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -101,7 +101,7 @@
       </script>
     <![endif]-->
     <div ng-controller="GaSeoController">
-      <div ga-seo ga-seo-options="options"></div>
+      <div ga-seo ga-seo-options="options" ga-seo-map="map"></div>
     </div>
     <div id="header" class="navbar navbar-fixed-top">
       <div id="logo" class="pull-left">

--- a/src/js/SeoController.js
+++ b/src/js/SeoController.js
@@ -7,7 +7,9 @@
       function($scope, gaGlobalOptions) {
 
         $scope.options = {
-          htmlUrlTemplate: gaGlobalOptions.cachedMapUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup'
+          htmlUrlTemplate: gaGlobalOptions.cachedMapUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup',
+          searchUrl: gaGlobalOptions.mapUrl + '/rest/services/ech/SearchServer',
+          identifyUrl: gaGlobalOptions.mapUrl + '/rest/services/all/MapServer/identify'
         };
 
       });


### PR DESCRIPTION
This injects location data based on Y, X and zoom values of the permlink. The below only happens when zoom is >= 5.

add all results of an identify request @ Y, X with following layers (pixel tolerance 10 pixels):
- 'ch.swisstopo-vd.ortschaftenverzeichnis_plz'
- 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill'
- 'ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill'
- 'ch.swisstopo.swissboundaries3d-kanton-flaeche.fill'

add x number of closest results from search request with bounding box of 4km`2 around Y,X with following layers)
- 'ch.swisstopo.vec200-names-namedlocation' -> x = 3
- 'ch.bfs.gebaeude_wohnungs_register' -> x = 1

Don't merge for tomorrow :)
