### PR TITLE
BUILD: react to env variable change, remove cleanrc

### DIFF
--- a/deploy/hooks/post-restore-code
+++ b/deploy/hooks/post-restore-code
@@ -18,7 +18,7 @@ if [ -f rc_$TARGET ]; then
             source rc_branch
         fi
     fi
-    make cleanrc all
+    make all
 fi
 
 exit $?


### PR DESCRIPTION
This PR adapts the build process in the following way:
- A change in the 4 environment variables [1] is now automatically detected and the dependent files re-build with a simple `make all`
- `make help` now shows the values of the 4 environment variables as they were set in the last `make all` command. As beforer, the currently set values is also shown
- Removes the `make cleanrc` command because the changes above now takes care of this.

This also speeds up deployment of mf-geoadmin3, because only index.html, mobile.html and app.conf need a re-build on the targets (before, the whole js was re-build).

[1] DEPLOY_TARGET, API_URL, APACHE_BASE_PATH and APACHE_BASE_DIRECTORY
