### PR TITLE
Simplify robots.txt file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ prd/: $(SITEMAP_FILES)
 
 prd/robots.txt: scripts/robots.mako-dot-txt .build-artefacts/last-deploy-target
 	mkdir -p $(dir $@)
-	.build-artefacts/python-venv/bin/mako-render --var "version=$(VERSION)" --var "deploy_target=$(DEPLOY_TARGET)" $< > $@
+	.build-artefacts/python-venv/bin/mako-render --var "deploy_target=$(DEPLOY_TARGET)" $< > $@
 
 prd/lib/: src/lib/d3-3.3.1.min.js
 	mkdir -p $@

--- a/scripts/robots.mako-dot-txt
+++ b/scripts/robots.mako-dot-txt
@@ -2,8 +2,7 @@ User-agent: *
 
 % if deploy_target == 'prod':
 
-Disallow: /main/
-Disallow: /${version}
+Disallow: /*/
 Disallow: /info.json
 Disallow: /checker
 


### PR DESCRIPTION
This simplifies the robots file. Before, each instance disallowed the cached urls. This didn't work perfectly behind the ELB's.

Using this approach, the ELB has no influence anymore.
