### PR TITLE
Add search box in FullScreen mode

### DIFF
--- a/src/components/BrowserSnifferService.js
+++ b/src/components/BrowserSnifferService.js
@@ -22,6 +22,8 @@
       var iosChrome = /CriOS/.test(ua);
       var webkit = /WebKit/.test(ua);
       var mac = /Mac/.test(platform);
+      var chrome = /Chrome/.test(ua);
+      var safari = !chrome && /Safari/.test(ua);
       var testSize = function(size) {
         var m = $window.matchMedia;
         return m && (m('(max-width: ' + size + 'px)').matches ||
@@ -92,6 +94,7 @@
         msie: msie,
         webkit: webkit,
         mac: mac,
+        safari: safari,
         ios: ios,
         iosChrome: iosChrome,
         touchDevice: touchDevice,

--- a/src/components/fullscreen/FullscreenDirective.js
+++ b/src/components/fullscreen/FullscreenDirective.js
@@ -20,32 +20,35 @@
         "ng-click='click()' translate>full_screen</a>",
       link: function(scope, element, attrs) {
         var fullScreenCssClass = 'ga-full-screen';
+        var inputsForbidCssClass = 'ga-full-screen-no-inputs';
         // Use the documentElement element in order to check if the
         // Fullscreen API is usable
         // Documentation about Fullscreen API flavours:
         // https://docs.google.com/spreadsheet/
         //  ccc?key=0AvgmqEgDEiu5dGtqVEUySnBvNkxiYlAtbks1eDFibkE#gid=0
-        var docElm = document.documentElement;
+        var target = document.documentElement;
         scope.fullscreenSupported = (
             // IE 11 bug when the page is inside an iframe:
             // http://connect.microsoft.com/IE/feedback/details/814527/
             // ie11-iframes-body-offsetwidth-incorrect-when-iframe-is-in
             // -full-screen-mode
             !(gaBrowserSniffer.msie == 11 && gaBrowserSniffer.isInFrame) &&
-            (docElm.requestFullScreen ||
-            docElm.mozRequestFullScreen ||
-            docElm.webkitRequestFullScreen ||
-            docElm.msRequestFullscreen)
+            (target.requestFullScreen ||
+            target.mozRequestFullScreen ||
+            target.webkitRequestFullScreen ||
+            target.msRequestFullscreen)
         );
 
         scope.click = function() {
-          var target = scope.map.getTarget();
           if (target.requestFullScreen) {
             target.requestFullScreen();
           } else if (target.mozRequestFullScreen) {
             target.mozRequestFullScreen();
           } else if (target.webkitRequestFullScreen) {
-            target.webkitRequestFullScreen();
+            // Element.ALLOW_KEYBOARD_INPUT allow keyboard input in fullscreen
+            // mode, but that doesn't work for Safari
+            target.webkitRequestFullScreen((gaBrowserSniffer.safari ?
+                0 : Element.ALLOW_KEYBOARD_INPUT));
           } else if (target.msRequestFullscreen) {
             target.msRequestFullscreen();
           }
@@ -54,15 +57,21 @@
         if (scope.fullscreenSupported) {
           var onFullscreenChange = function() {
             $(document.body).addClass(fullScreenCssClass);
-            // Bug in Safari
+
+            // Safari forbids inputs in full screen mode
+            // for security reasons
+            if (gaBrowserSniffer.safari) {
+              $(document.body).addClass(inputsForbidCssClass);
+            }
+
             scope.map.updateSize();
-            var target = scope.map.getTarget();
             if (!(document.fullscreenElement ||
                 document.mozFullScreenElement ||
                 document.webkitFullscreenElement ||
                 document.msFullscreenElement)) {
               gaPermalink.refresh();
               $(document.body).removeClass(fullScreenCssClass);
+              $(document.body).removeClass(inputsForbidCssClass);
             }
           };
 
@@ -70,7 +79,16 @@
           document.addEventListener('mozfullscreenchange', onFullscreenChange);
           document.addEventListener('webkitfullscreenchange',
               onFullscreenChange);
-          document.addEventListener('msfullscreenchange', onFullscreenChange);
+          document.addEventListener('MSFullscreenChange', onFullscreenChange);
+
+          // Catch F11 event to provide an HTML5 fullscreen instead of
+          // default one
+          $(document).on('keydown', function(event) {
+            if (event.which == 122) {
+              event.preventDefault();
+              scope.click(); // From fullscreen API
+            }
+          });
         }
       }
     };

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -79,8 +79,20 @@ form {
 }
 
 .ga-full-screen {
-  .ga-swipe, [ga-popup], [ga-time-selector] {
-    z-index: 3000000000;
+  
+  #header {
+    background-color: transparent;
+    box-shadow: none;
+    
+    .pull-right > div {
+      display: none;
+    }
+  }
+  
+  &.ga-full-screen-no-inputs #search-container, 
+  #logo, #background-selection, 
+  #toptools, #pulldown, #footer {
+    display: none;
   }
 }
 


### PR DESCRIPTION
This PR refactor a little bit the FullScreen directive to make easier the add of visible elements in full screen mode.
Now simple CSS is needed to display or hide element in fullscreen mode.

As suggest @gjn  I've also added the searchbox (unfortunately that doesn't work for Safari for security reasons).

Last point when it's possible I use the fullscreen api using F11

Test [here](http://mf-geoadmin3.dev.bgdi.ch/dev_searchbar/prod/)
