### PR TITLE
Use new select by rectangle attribute

### DIFF
--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -69,7 +69,7 @@
               return gaLayerFilters.selected(l) &&
                      l.visible &&
                      gaLayers.getLayer(l.bodId) &&
-                     gaLayers.getLayerProperty(l.bodId, 'queryable');
+                     gaLayers.getLayerProperty(l.bodId, 'selectbyrectangle');
 
             };
 


### PR DESCRIPTION
Needs https://github.com/geoadmin/mf-chsdi3/pull/722 to be merged first.

There's a new attribute to determine if a layer can be used in the feature tree component.
