### PR TITLE
Allow branched API_URL for deployed branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ deploy/deploy-branch.cfg: deploy/deploy-branch.mako.cfg .build-artefacts/last-gi
 	.build-artefacts/python-venv/bin/mako-render --var "git_branch=$(GIT_BRANCH)" $< > $@
 
 rc_branch: rc_branch.mako .build-artefacts/last-git-branch .build-artefacts/last-deploy-target .build-artefacts/python-venv/bin/mako-render
-	.build-artefacts/python-venv/bin/mako-render --var "apache_base_path=$(GIT_BRANCH)" $< > $@
+	.build-artefacts/python-venv/bin/mako-render --var "deploy_target=$(DEPLOY_TARGET)" --var "apache_base_path=$(GIT_BRANCH)" $< > $@
 
 scripts/00-$(GIT_BRANCH).conf: scripts/00-branch.mako-dot-conf .build-artefacts/last-git-branch .build-artefacts/python-venv/bin/mako-render
 	.build-artefacts/python-venv/bin/mako-render --var "git_branch=$(GIT_BRANCH)" $< > $@

--- a/README.md
+++ b/README.md
@@ -98,3 +98,8 @@ Please only use integration url for external communication (including here on
 github), even though the exact same structure is also available on our test 
 instances.
 
+### Get correct link the API
+Per default, the API used in the **main** instance of mf-chsdi3. If you want
+to target a specific branch of mf-chsdi3, please adapt the `API_URL` variable
+in the `rc_branch.mako` file on **your branch**
+

--- a/rc_branch.mako
+++ b/rc_branch.mako
@@ -1,2 +1,3 @@
 export APACHE_BASE_PATH=${apache_base_path}
+export API_URL=//mf-chsdi3.${deploy_target}.bgdi.ch
 


### PR DESCRIPTION
As we can now deploy branches of chsdi3 (https://github.com/geoadmin/mf-chsdi3/pull/725), this PR allows the ability to choose the API used in deployed branches of geoadmin3.

Read the doc.
