### PR TITLE
Keep crosshair parameter as long as map is not moved/zoomed

### DIFF
--- a/src/components/map/MapDirective.js
+++ b/src/components/map/MapDirective.js
@@ -41,12 +41,16 @@
             if (queryParams.crosshair !== undefined) {
               var crosshair = $('<div></div>')
                 .addClass('ga-crosshair')
-                .addClass(queryParams.crosshair);
+                .addClass(queryParams.crosshair),
+                unregister;
               map.addOverlay(new ol.Overlay({
                 element: crosshair.get(0),
                 position: view.getCenter()
               }));
-              gaPermalink.deleteParam('crosshair');
+              unregister = view.on('propertychange', function() {
+                gaPermalink.deleteParam('crosshair');
+                map.unByKey(unregister);
+              });
             }
 
             // Update permalink based on view states.


### PR DESCRIPTION
The crosshair parameter is removed from the URL after the page is loaded. This led to confusion as with page refresh (F5). the crosshair disappeard. See https://github.com/geoadmin/mf-geoadmin3/issues/1200 /  https://github.com/geoadmin/mf-chsdi3/issues/469 and others.

This PR keeps the crosshair parameter in the url as long as the map is not panned or zoomed.
