### PR TITLE
Allow all site for bots

### DIFF
--- a/scripts/robots.mako-dot-txt
+++ b/scripts/robots.mako-dot-txt
@@ -2,8 +2,6 @@ User-agent: *
 
 % if deploy_target == 'prod':
 
-Disallow: /*/
-Disallow: /info.json
 Disallow: /checker
 
 Sitemap: http://map.geo.admin.ch/sitemap_index.xml


### PR DESCRIPTION
Recent changes in google webmaster tools and google crawlers allows for javarendering for bots (see [1] and [2]. This in turn means that we need to allow all resources to be crawled by our robots.txt definition.

In general, we need to monitor if we could probably get rid of our snapshot service alltogether...

[1] http://www.googlewebmastercentral.blogspot.ch/2014/05/understanding-web-pages-better.html
[2] http://googlewebmastercentral.blogspot.ch/
