### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -524,6 +524,9 @@
     };
 
     $scope.submit = function() {
+      if (!$scope.options.active) {
+        return;
+      }
       // http://mapfish.org/doc/print/protocol.html#print-pdf
       bodyEl.addClass(waitclass);
       var view = $scope.map.getView();

--- a/src/components/print/partials/print.html
+++ b/src/components/print/partials/print.html
@@ -29,5 +29,5 @@
       </div>
     </div>
   </div>
-  <button type="submit" class="btn btn-default col-xs-12" ng-click="submit()" translate>print_action</button>
+  <button type="submit" class="btn btn-default col-xs-12" accesskey="p" ng-click="submit()" translate>print_action</button>
 </form>

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -239,42 +239,48 @@
                 <li><!-- Import WMS -->
                   <a href="" ng-click="globals.importWmsPopupShown = !globals.importWmsPopupShown"
                      data-original-title="{{'wmsimport_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="bottom">
+                     class="ga-custom-tooltip" data-placement="bottom"
+                     accesskey="w">
                     <span ng-class="{'selected': globals.importWmsPopupShown}" translate>import_wms</span>
                   </a>
                 </li>
                 <li><!-- Import KML -->
                   <a href=""  ng-click="globals.importKmlPopupShown = !globals.importKmlPopupShown"
                      data-original-title="{{'kmlimport_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="bottom">
+                     class="ga-custom-tooltip" data-placement="bottom"
+                     accesskey="k">
                     <span ng-class="{'selected': globals.importKmlPopupShown}" translate>import_kml</span>
                   </a>
                 </li>
                 <li><!-- Compare -->
                   <a href=""  ng-click="globals.isSwipeActive = !globals.isSwipeActive"
                      data-original-title="{{'swipe_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="bottom">
+                     class="ga-custom-tooltip" data-placement="bottom"
+                     accesskey="c">
                     <span ng-class="{'selected': globals.isSwipeActive}" translate>swipe</span>
                   </a>
                 </li>
                 <li><!-- Measure -->
                   <a href=""  ng-click="globals.isMeasureActive = !globals.isMeasureActive;globals.isDrawActive = false;"
                      data-original-title="{{'measure_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="bottom">
+                     class="ga-custom-tooltip" data-placement="bottom"
+                     accesskey="m">
                     <span  ng-class="{'selected': globals.isMeasureActive}" translate>measure</span>
                   </a>
                 </li>
                 <li><!-- Draw -->
                   <a href=""  ng-click="globals.isDrawActive = !globals.isDrawActive;globals.isMeasureActive = false;"
                      data-original-title="{{'draw_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="bottom">
+                     class="ga-custom-tooltip" data-placement="bottom"
+                     accesskey="r">
                     <span  ng-class="{'selected': globals.isDrawActive}" translate>draw</span>
                   </a>
                 </li>
                 <li><!-- Feature Tree -->
                   <a href=""  ng-click="globals.isFeatureTreeActive = !globals.isFeatureTreeActive"
                      data-original-title="{{'featuretree_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="top">
+                     class="ga-custom-tooltip" data-placement="top"
+                     accesskey="s">
                     <span  ng-class="{'selected': globals.isFeatureTreeActive}" translate>object_information</span>
                   </a>
                 </li>


### PR DESCRIPTION
Add keyboard shortcut through the html `accesskey` attribute :

| Browser | Windows | Linux | Mac |
| --- | --- | --- | --- |
| Internet Explorer | [Alt] + accesskey then Enter |  |  |
| Chrome | [Alt] + accesskey | [Alt] + accesskey | [Control] [Alt] + accesskey |
| Firefox | [Alt] [Shift] + accesskey | [Alt] [Shift] + accesskey | [Control] [Alt] + accesskey |
| Safari | [Alt] + accesskey |  | [Control] [Alt] + accesskey |
| Opera 15 or newer: | [Alt] + accesskey | [Alt] + accesskey | [Alt] + accesskey |
| Opera 12.1 or older: | [Shift] [Esc] + accesskey | [Shift] [Esc] + accesskey | [Shift] [Esc] + accesskey |

| Tools | Letter |
| --- | --- |
| WMS Import | w |
| KML Import | k |
| Compare | c |
| Measure | m |
| Draw | r |
| Information object | s |
| Print | p   (with print menu already opened) |

Test [here](http://mf-geoadmin3.dev.bgdi.ch/dev_shortcut/prod/)
