### PR TITLE
Use waf-less wmts adresses for map.geo.admin.ch

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -589,7 +589,7 @@
 
         module.config(function(gaLayersProvider, gaGlobalOptions) {
           gaLayersProvider.wmtsGetTileUrlTemplate =
-              '//wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
+              '//wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
               gaGlobalOptions.cachedMapUrl + '/rest/services/{Topic}/MapServer/layersConfig?lang={Lang}';


### PR DESCRIPTION
This will use the WAF-lest wmts addresses for performance reasons.

Only apply if Hanspi gives the go. (see latest mails)
