### PR TITLE
Fix space betweens map buttons

### DIFF
--- a/src/components/map/style/map.less
+++ b/src/components/map/style/map.less
@@ -22,6 +22,7 @@
     padding: 0;
     background-color: transparent;
     border: none;
+    display: block; /*without this, chrome add 3 pixels between zoomin/out buttons*/
   }
 
   .ol-dragbox {
@@ -35,6 +36,7 @@
   }
   
   .ol-zoom-out {
+    margin-top: unit(@control-btn-space, px);
     background-image: data-uri('zoomOut.png');
   }
 
@@ -44,7 +46,6 @@
 
   .ol-zoom {
     width: unit(@control-btn-size, px);
-    height: unit(@control-btn-size * 2 + @control-btn-space, px);
   }
 
   .ol-zoom, .ol-zoom-extent {


### PR DESCRIPTION
Fix #1460 

Test [here](http://mf-geoadmin3.dev.bgdi.ch/fix_css/prod/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&catalogNodes=457,477&layers_opacity=0.75&layers=ch.bafu.biogeographische_regionen)
