### PR TITLE
Remove use of ol.extent.getArea and ol.extent.getIntersectionArea

### DIFF
--- a/scripts/ga-ol3.exports
+++ b/scripts/ga-ol3.exports
@@ -1,5 +1,3 @@
 @exportProperty ol.View2D.prototype.getResolutionForExtent
-@exportSymbol ol.extent.getArea
-@exportSymbol ol.extent.getIntersectionArea
 @exportSymbol ol.feature
 @exportProperty ol.feature.defaultStyleFunction

--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -137,15 +137,7 @@
                   // the future
                   if (result.attrs.geom_st_box2d) {
                     bbox = parseBoxString(result.attrs.geom_st_box2d);
-                    ext = ol.extent.boundingExtent([[bbox[0], bbox[1]],
-                                                       [bbox[2], bbox[3]]]);
-                    if (ol.extent.getArea(ext) <= 0) {
-                      if (!ol.extent.containsCoordinate(searchExtent,
-                                                        [ext[0], ext[1]])) {
-                        continue;
-                      }
-                    } else if (ol.extent.getIntersectionArea(searchExtent,
-                                                              ext) <= 0) {
+                    if (!ol.extent.intersects(searchExtent, bbox)) {
                       continue;
                     }
                   }


### PR DESCRIPTION
This PR use `ol.extent.intersects` to replace the use of  `ol.extent.getArea` and `ol.extent.getIntersectionArea`
