### PR TITLE
Destroy metadata popups on language change

### DIFF
--- a/src/components/LayerMetadataPopupService.js
+++ b/src/components/LayerMetadataPopupService.js
@@ -11,9 +11,20 @@
   ]);
 
   module.provider('gaLayerMetadataPopup', function() {
-    this.$get = function($document, $translate, gaPopup, gaLayers) {
+    this.$get = function($document, $rootScope, $translate, gaPopup,
+        gaLayers) {
       // Keep track of existing popups
       var popups = {};
+
+      // On language change we destroy all the popups
+      $rootScope.$on('$translateChangeEnd', function(event) {
+        for (var i in popups) {
+          if (popups[i].scope) {
+            popups[i].destroy();
+            delete popups[i];
+          }
+        }
+      });
 
       // This service acts as a toggle. Repeated calls with
       // the same bodid will 'toggle' the popup with the


### PR DESCRIPTION
Fix #1469 

It's a quick fix when we change the language we destroy all the popup. To make the popup reopened on language change needs a bit more refactoring of the service.

Test [here](http://mf-geoadmin3.dev.bgdi.ch/fix_metadata/prod/?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&catalogNodes=457,491&layers_opacity=0.75&layers=ch.bafu.biogeographische_regionen)
