### PR TITLE
Fix digest error on language change

### DIFF
--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -550,9 +550,9 @@
                 } else if (dataset.name === 'layers') {
                   // hasLayerResults is used to control
                   // the display of the footer
-                  scope.$apply(function() {
+                  $timeout(function() {
                     scope.hasLayerResults = (suggestions.length !== 0);
-                  });
+                  }, 0);
                 }
                 renderSuggestions.apply(this, [dataset, suggestions]);
                 if (invokeApply !== false) {
@@ -590,7 +590,9 @@
               viewDropDown.on('gaSuggestionsRendered', function(evt) {
                 var el;
                 if (viewDropDown.isVisible()) {
-                  setListCount();
+                  $timeout(function() {
+                    setListCount();
+                  }, 0);
                   el = element.find('.tt-dataset-' + evt.data.name);
                   el.attr('ng-class', 'nbOfSuggestionsLists');
                   $compile(el)(scope);


### PR DESCRIPTION
 [#1464]

In this PR, we make sure that the hasLayerResults variable is set asyncronously.

$timout with 0s ensures that the changes to the scope will occur as soon as possible in the call stack.

This can be tested here:
http://mf-geoadmin3.int.bgdi.ch/gal_search_digest_errors/src/
