### PR TITLE
Stop propagation of click event

### DIFF
--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -175,7 +175,10 @@
                 }
               });
 
-              scope.hidePopover = function() {
+              scope.hidePopover = function(evt) {
+                if (evt) {
+                  evt.stopPropagation();
+                }
                 hidePopover();
               };
 


### PR DESCRIPTION
Stop propagation of click event  on close button of context popup.

Test [here](http://mf-geoadmin3.dev.bgdi.ch/dev_stop/prod/)

Fix part of #1477 
