### PR TITLE
Reduce marker size on print

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -588,17 +588,17 @@
         var center = overlay.getPosition();
         var offset = 5 * resolution;
         if (center) {
-          var cross = {
+          var marker = {
             'type': 'Vector',
             'styles': {
               '1': {
                 'externalGraphic': $scope.options.markerUrl,
-                'graphicWidth': 30,
-                'graphicHeight': 40,
+                'graphicWidth': 20,
+                'graphicHeight': 30,
                 // the icon is not perfectly centered in the image
                 // these values must be the same in map.less
-                'graphicXOffset': -17,
-                'graphicYOffset': -40
+                'graphicXOffset': -12,
+                'graphicYOffset': -30
               }
             },
             'styleProperty': '_gx_style',
@@ -618,7 +618,7 @@
             'name': 'drawing',
             'opacity': 1
           };
-          encLayers.push(cross);
+          encLayers.push(marker);
         }
       });
 


### PR DESCRIPTION
Hi,
I found that when printing the marker, one always gets it to big.

Old:
![actual](https://cloud.githubusercontent.com/assets/3306154/3386425/60ad233c-fc74-11e3-8ff8-5c557f25f92f.png)

New:
![new](https://cloud.githubusercontent.com/assets/3306154/3386442/87f8d45e-fc74-11e3-8dc5-cdea29203051.png)

Please test and let me know.
