### PR TITLE
Reduce size of button's icon to fit correctly its width

### DIFF
--- a/src/components/draw/style/draw.less
+++ b/src/components/draw/style/draw.less
@@ -17,7 +17,7 @@
       }
 
       i {
-        font-size: 60px;
+        font-size: 54px;
       }
 
       div {


### PR DESCRIPTION
Minor css fix for safari
