### PR TITLE
Remove unused info.json file and refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ help:
 all: prod dev lint apache testdev testprod deploy/deploy-branch.cfg fixrights
 
 .PHONY: prod
-prod: prd/ prd/lib/ prd/lib/build.js prd/style/app.css prd/index.html prd/mobile.html prd/info.json prd/img/ prd/style/font-awesome-3.2.1/font/ prd/locales/ prd/checker prd/robots.txt
+prod: prd/ prd/lib/ prd/lib/build.js prd/style/app.css prd/index.html prd/mobile.html prd/img/ prd/style/font-awesome-3.2.1/font/ prd/locales/ prd/checker prd/robots.txt
 
 .PHONY: dev
 dev: src/deps.js src/style/app.css src/index.html src/mobile.html
@@ -171,11 +171,6 @@ prd/locales/: src/locales/*.json
 	cp $^ $@
 
 prd/checker: src/checker
-	mkdir -p $(dir $@)
-	cp $< $@
-
-# Temporary: the entire rule should go away eventually
-prd/info.json: src/info.json
 	mkdir -p $(dir $@)
 	cp $< $@
 

--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -30,7 +30,7 @@ Alias /${apache_base_path}/prod ${apache_base_directory}/prd
 RewriteCond %{QUERY_STRING} _escaped_fragment_=(.*)$
 RewriteRule ^/(index.html|mobile.html)(.*) http:${api_url}/snapshot [NE,L,P]
 
-RewriteRule ^/(index.html|mobile.html|info.json|checker|robots.txt|sitemap_\w*\.xml)(.*) /var/www/vhosts/mf-geoadmin3/private/geoadmin/prd/$1
+RewriteRule ^/(index.html|mobile.html|checker|robots.txt|sitemap_\w*\.xml)(.*) /var/www/vhosts/mf-geoadmin3/private/geoadmin/prd/$1
 RewriteRule ^/[0-9]+/(img|lib|style|rest|locales)(.*) /var/www/vhosts/mf-geoadmin3/private/geoadmin/prd/$1$2
 
 <IfModule mod_headers.c>


### PR DESCRIPTION
This was introduced at the beginning of the dev process because print back-end was not ready yet. Now, this file is served by the API and its print service.
