### PR TITLE
Popup: Keep position on close

### DIFF
--- a/src/components/popup/PopupDirective.js
+++ b/src/components/popup/PopupDirective.js
@@ -71,6 +71,20 @@
             scope.options.showReduce = true;
           }
 
+          // Set default x and y values on non mobile device if not defined
+          if (!gaBrowserSniffer.mobile && !scope.options.x &&
+              !scope.options.y) {
+            scope.options.x =
+                $(document.body).width() / 2 - element.width() / 2;
+            scope.options.y = 89; //89 is the default size of the header
+          }
+
+          if (!gaBrowserSniffer.mobile) {
+            element.css({
+              left: scope.options.x,
+              top: scope.options.y
+            });
+          }
 
           // Add close popup function
           scope.close = function(evt) {
@@ -108,9 +122,6 @@
               // so we make  a test if the popup is displayed or not
               if (newVal != oldVal ||
                 (newVal != (element.css('display') == 'block'))) {
-                if (!gaBrowserSniffer.mobile && newVal) {
-                  moveToOriginalPosition();
-                }
 
                 if (scope.isReduced) {
                   scope.isReduced = false;
@@ -154,16 +165,6 @@
               deregister[i]();
             }
           });
-
-          /* Utils  */
-          // Move the popup to its original position, only used on desktop
-          var moveToOriginalPosition = function() {
-            element.css({
-              left: scope.options.x ||
-                $(document.body).width() / 2 - element.width() / 2,
-              top: scope.options.y || 89 //89 is the default size of the header
-            });
-          };
 
           // Execute the custom close callback
           var onClose = function() {

--- a/src/components/popup/PopupService.js
+++ b/src/components/popup/PopupService.js
@@ -49,6 +49,9 @@
       };
 
       Popup.prototype.close = function() {
+        var position = this.element.position();
+        this.scope.options.x = position.left;
+        this.scope.options.y = position.top;
         this.scope.toggle = false;
       };
 


### PR DESCRIPTION
Step to reproduce:
1) open map.geo.admin.ch
2) open a legend (or help etc..)
3) move the popup
4) close the popup
5) reopen the popup

Result:
popup position is reset

Expected result:
popup position is persistent

This PR solves this issue.
