### PR TITLE
SEARCH: add wait cursor when search is performed

### DIFF
--- a/src/style/app.less
+++ b/src/style/app.less
@@ -800,7 +800,7 @@ ul.panel-body-wide {
 }
 
 // ***** METADATA POPUP
-.ga-measure-wait, .ga-tooltip-wait, .ga-metadata-popup-wait, .ga-print-wait {
+.ga-measure-wait, .ga-tooltip-wait, .ga-metadata-popup-wait, .ga-print-wait, .ga-search-wait {
   cursor: wait;
 }
 


### PR DESCRIPTION
This adds a wait cursor to the page as long as search requests are still done. This improves the feedback given to the user about the search; especially when the query has 0 results.

It might also help to detect the evergreen https://github.com/geoadmin/mf-geoadmin3/issues/1190. If there is no wait cursor, we know that the requests are not send.

The solution with the counter is sub-optimal. But considering that we want to replace the search component in the near future, it should be short-lived anyway.
