### PR TITLE
Handle updates of metadata per popup

### DIFF
--- a/src/components/LayerMetadataPopupService.js
+++ b/src/components/LayerMetadataPopupService.js
@@ -13,43 +13,60 @@
   module.provider('gaLayerMetadataPopup', function() {
     this.$get = function($document, $translate, $rootScope, $sce,
         gaPopup, gaLayers) {
-      var popupContent = '<div ng-bind-html=' +
-          '"options.results[options.bodid]"></div>';
+      var popupContent = '<div ng-bind-html="options.result.html"></div>';
 
       var LayerMetadataPopup = function() {
         var popups = {};
-        var results = {};
         var waitClass = 'ga-metadata-popup-wait';
         var bodyEl = angular.element($document[0].body);
 
-        this.get = function(bodid) {
-          bodyEl.addClass(waitClass);
-          gaLayers.getMetaDataOfLayer(bodid)
-            .success(function(data) {
-              var popup = popups[bodid];
+        var create = function(bodid) {
+          var result = {html: ''},
+              popup;
+
+          // Called to update the content
+          var updateContent = function(init) {
+
+            var handleResult = function() {
               bodyEl.removeClass(waitClass);
-              results[bodid] = $sce.trustAsHtml(data);
-              if (!popup) {
-                popups[bodid] = gaPopup.create({
-                  title: $translate('metadata_window_title'),
-                  destroyOnClose: false,
-                  content: popupContent,
-                  bodid: bodid,
-                  results: results,
-                  className: 'ga-tooltip-metadata',
-                  x: 400,
-                  y: 200,
-                  showPrint: true
-                });
-                popups[bodid].open();
+              if (init) {
+                popup.open();
               }
-            })
-            .error(function() {
-              bodyEl.removeClass(waitClass);
-              //FIXME: better error handling
-              var msg = 'Could not retrieve information for ' + bodid;
-              alert(msg);
-            });
+            };
+
+            bodyEl.addClass(waitClass);
+            gaLayers.getMetaDataOfLayer(bodid)
+              .success(function(data) {
+                result.html = $sce.trustAsHtml(data);
+                handleResult();
+              })
+              .error(function() {
+                handleResult();
+                //FIXME: better error handling
+                var msg = 'Could not retrieve information for ' + bodid;
+                alert(msg);
+              });
+          };
+
+          //We assume popup does not exist yet
+          popup = gaPopup.create({
+            title: $translate('metadata_window_title'),
+            destroyOnClose: false,
+            content: popupContent,
+            result: result,
+            className: 'ga-tooltip-metadata',
+            x: 400,
+            y: 200,
+            showPrint: true
+          });
+          popups[bodid] = popup;
+
+          updateContent(true);
+
+          $rootScope.$on('$translateChangeEnd', function() {
+            updateContent(false);
+          });
+
         };
 
         this.toggle = function(bodid) {
@@ -61,34 +78,12 @@
               popup.open();
             }
           } else {
-            this.get(bodid);
+            create(bodid);
           }
-        };
-
-        this.refresh = function() {
-          var that = this;
-          var keys = [];
-          var n = 0;
-          for (var k in popups) keys.push(k);
-          var recursiveFetch = function(n) {
-            if (n < keys.length) {
-              var bodid = keys[n];
-              var popup = popups[bodid];
-              that.get(bodid);
-              recursiveFetch(n + 1);
-            }
-          };
-          recursiveFetch(0);
         };
       };
 
-      var metadataPopup = new LayerMetadataPopup();
-
-      $rootScope.$on('$translateChangeEnd', function() {
-        metadataPopup.refresh();
-      });
-
-      return metadataPopup;
+      return new LayerMetadataPopup();
     };
   });
 })();


### PR DESCRIPTION
This is a proposal to refactor https://github.com/geoadmin/mf-geoadmin3/pull/1500
- No exposed function that is not needed
- Removes results object (avoids having to keep this in sync with popups), result is kept in closure per popup
- No need to pass/store bodid to popup options, where it's not used (kept in closure per popup)
- Remove bulk refresh function (recursion), but updates content on language change per popup

IMO, this reduces complexity and renders to component a little more self-contained.

What do you think @loicgasser?

Note: PR is done for your branch.
