### PR TITLE
Centralize waiting cursor usage

### DIFF
--- a/src/components/help/HelpDirective.js
+++ b/src/components/help/HelpDirective.js
@@ -2,9 +2,12 @@
   goog.provide('ga_help_directive');
 
   goog.require('ga_help_service');
+  goog.require('ga_waitcursor_service');
 
-  var module = angular.module('ga_help_directive',
-      ['ga_help_service']);
+  var module = angular.module('ga_help_directive', [
+    'ga_help_service',
+    'ga_waitcursor_service'
+  ]);
 
   /* Help Directive
    *
@@ -23,7 +26,7 @@
    * <span ga-help="12,13,14"></div>
   */
   module.directive('gaHelp',
-      function($document, gaHelpService, gaPopup) {
+      function(gaWaitCursor, gaHelpService, gaPopup) {
         var popupContent = '<div class="ga-help-content" ' +
                                 'ng-repeat="res in options.results">' +
                              '<h2 ng-bind="res[1]"></h2>' +
@@ -77,9 +80,6 @@
               } else {
                 var ids = scope.helpIds.split(',');
 
-                var waitClass = 'ga-metadata-popup-wait';
-                var bodyEl = angular.element($document[0].body);
-
                 //Create the popup
                 popup = gaPopup.create({
                   className: 'ga-help-popup',
@@ -107,10 +107,10 @@
 
                     resCount++;
                     if (resCount == len) {
-                        bodyEl.removeClass(waitClass);
+                      gaWaitCursor.remove();
                     }
                   };
-                  bodyEl.addClass(waitClass);
+                  gaWaitCursor.add();
                   for (i = 0; i < len; i++) {
                     gaHelpService.get(ids[i]).then(function(res) {
                       results.push(res.rows[0]);

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -8,12 +8,10 @@
      'pascalprecht.translate']);
 
   module.controller('GaPrintDirectiveController', function($scope, $http,
-      $window, $translate, $document,
+      $window, $translate, gaWaitCursor,
       gaLayers, gaPermalink, gaBrowserSniffer) {
 
-    var waitclass = 'ga-print-wait';
-    var bodyEl = angular.element($document[0].body);
-    bodyEl.removeClass(waitclass);
+    gaWaitCursor.remove();
     var pdfLegendsToDownload = [];
     var pdfLegendString = '_big.pdf';
     var printRectangle;
@@ -528,7 +526,7 @@
         return;
       }
       // http://mapfish.org/doc/print/protocol.html#print-pdf
-      bodyEl.addClass(waitclass);
+      gaWaitCursor.add();
       var view = $scope.map.getView();
       var proj = view.getProjection();
       var lang = $translate.uses();
@@ -657,7 +655,7 @@
         var http = $http.post(that.capabilities.createURL + '?url=' +
             encodeURIComponent(that.capabilities.createURL), spec);
         http.success(function(data) {
-          bodyEl.removeClass(waitclass);
+          gaWaitCursor.remove();
           $scope.downloadUrl(data.getURL);
           //After standard print, download the pdf Legends
           //if there are any
@@ -666,10 +664,10 @@
           }
         });
         http.error(function() {
-          bodyEl.removeClass(waitclass);
+          gaWaitCursor.remove();
         });
       }).error(function() {
-        bodyEl.removeClass(waitclass);
+        gaWaitCursor.remove();
       });
     };
 

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -8,6 +8,7 @@
   goog.require('ga_permalink');
   goog.require('ga_search_service');
   goog.require('ga_urlutils_service');
+  goog.require('ga_waitcursor_service');
 
   var module = angular.module('ga_search_directive', [
     'ga_debounce_service',
@@ -17,12 +18,13 @@
     'ga_permalink',
     'pascalprecht.translate',
     'ga_urlutils_service',
-    'ga_search_service'
+    'ga_search_service',
+    'ga_waitcursor_service'
   ]);
 
   module.directive('gaSearch',
-      function($compile, $translate, $timeout, $rootScope, $http, $document,
-        gaMapUtils, gaLayerMetadataPopup, gaPermalink, gaUrlUtils,
+      function($compile, $translate, $timeout, $rootScope, $http,
+        gaWaitCursor, gaMapUtils, gaLayerMetadataPopup, gaPermalink, gaUrlUtils,
         gaGetCoordinate, gaBrowserSniffer, gaLayerFilters, gaKml,
         gaPreviewLayers, gaLayers, gaPreviewFeatures, gaMarkerOverlay,
         gaSwisssearch, gaDebounce) {
@@ -52,8 +54,7 @@
             'body={{encodedPermalinkHref}}">',
             '<i class="icon-envelope-alt"></i>',
             '</a>',
-            '</div>'].join(''),
-            waitClass = 'ga-search-wait';
+            '</div>'].join('');
 
           var geojsonParser = new ol.format.GeoJSON();
 
@@ -104,7 +105,6 @@
                 parcel: 10,
                 sn25: 8
               };
-              var bodyEl = angular.element($document[0].body);
 
               var footerTemplate = angular.element(footer);
               $compile(footerTemplate)(scope);
@@ -147,15 +147,6 @@
               };
 
               scope.query = '';
-              scope.pendingRequests = 0;
-              scope.$watch('pendingRequests', function(newval) {
-                if (newval <= 0 ||
-                    scope.query === '') {
-                  bodyEl.removeClass(waitClass);
-                } else {
-                  bodyEl.addClass(waitClass);
-                }
-              });
 
               scope.layers = map.getLayers().getArray();
 
@@ -349,9 +340,11 @@
                         var extent = [center, center];
                         gaMarkerOverlay.add(map, center, extent, true);
                       } else {
-                        scope.$apply(function() {
-                          scope.pendingRequests++;
-                        });
+                        // Requests are not sent but before sent is invoked
+                        // anyway
+                        if (scope.query !== '') {
+                          gaWaitCursor.add();
+                        }
                       }
                       return !position;
                     },
@@ -392,9 +385,9 @@
                       if (!triggerFeatureSearch()) {
                         return false;
                       }
-                      scope.$apply(function() {
-                        scope.pendingRequests++;
-                      });
+                      if (scope.query !== '') {
+                        gaWaitCursor.add();
+                      }
                       return true;
                     },
                     replace: function(url, searchText) {
@@ -452,9 +445,9 @@
                             scope.query)) {
                         return false;
                       }
-                      scope.$apply(function() {
-                        scope.pendingRequests++;
-                      });
+                      if (scope.query !== '') {
+                        gaWaitCursor.add();
+                      }
                       return true;
                     },
                     replace: function(url, searchText) {
@@ -617,6 +610,7 @@
 
               viewDropDown.on('gaSuggestionsRendered', function(evt) {
                 var el;
+                gaWaitCursor.remove();
                 if (viewDropDown.isVisible()) {
                   $timeout(function() {
                     setListCount();
@@ -631,9 +625,6 @@
                     }
                     el.scrollTop(0);
                   }
-                }
-                if (scope.pendingRequests > 0) {
-                  scope.pendingRequests--;
                 }
                 gaSwisssearch.check();
               });
@@ -653,16 +644,28 @@
               });
 
               var triggerSearch = function(dataSetIndex) {
-                var dataset = $(taElt).data('ttView').datasets[dataSetIndex];
-                dataset.getSuggestions(scope.query,
-                    function(suggestions) {
-                      viewDropDown.renderSuggestions(dataset, suggestions,
-                          false);
-                });
+                if (scope.query !== '') {
+                  var dataset = $(taElt).data('ttView').datasets[dataSetIndex];
+                  dataset.getSuggestions(scope.query,
+                      function(suggestions) {
+                        viewDropDown.renderSuggestions(dataset, suggestions,
+                            false);
+                  });
+                }
               };
 
+              // When the query string changes, renderSuggestions is not
+              // necessarily called if the response time is long and the
+              // query string changes very fast. Here we make sure the waiting
+              // cursor is removed between different searches.
+              scope.$watch('query', function() {
+                for (var i in typeAheadDatasets) {
+                  gaWaitCursor.remove();
+                }
+              });
+
               scope.$on('$translateChangeEnd', function() {
-                if (angular.isDefined(currentTopic) && scope.query !== '') {
+                if (angular.isDefined(currentTopic)) {
                   triggerSearch(LAYERS);
                 }
               });
@@ -670,9 +673,7 @@
               scope.$on('gaTimeSelectorChange', function(event, newYear) {
                 if (newYear !== year) {
                   year = newYear;
-                  if (scope.query !== '') {
-                    triggerSearch(FEATURES);
-                  }
+                  triggerSearch(FEATURES);
                 }
               });
 

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -5,25 +5,25 @@
   goog.require('ga_debounce_service');
   goog.require('ga_map_service');
   goog.require('ga_popup_service');
+  goog.require('ga_waitcursor_service');
 
   var module = angular.module('ga_tooltip_directive', [
     'ga_debounce_service',
     'ga_popup_service',
     'ga_map_service',
+    'ga_waitcursor_service',
     'pascalprecht.translate'
   ]);
 
   module.directive('gaTooltip',
-      function($timeout, $document, $http, $q, $translate, $sce, gaPopup,
+      function($timeout, $http, $q, $translate, $sce, gaPopup, gaWaitCursor,
           gaLayers, gaBrowserSniffer, gaDefinePropertiesForLayer, gaMapClick,
           gaPreviewFeatures, gaDebounce) {
-        var waitclass = 'ga-tooltip-wait',
-            bodyEl = angular.element($document[0].body),
-            popupContent = '<div ng-repeat="htmlsnippet in options.htmls">' +
-                              '<div ng-bind-html="htmlsnippet"></div>' +
-                              '<div class="ga-tooltip-separator" ' +
-                                'ng-show="!$last"></div>' +
-                            '</div>';
+        var popupContent = '<div ng-repeat="htmlsnippet in options.htmls">' +
+                            '<div ng-bind-html="htmlsnippet"></div>' +
+                            '<div class="ga-tooltip-separator" ' +
+                              'ng-show="!$last"></div>' +
+                           '</div>';
         return {
           restrict: 'A',
           scope: {
@@ -185,7 +185,7 @@
                 function incResponseCount() {
                   responseCount += 1;
                   if (responseCount == identifyCount) {
-                    bodyEl.removeClass(waitclass);
+                    gaWaitCursor.remove();
                   }
                 }
 
@@ -199,7 +199,7 @@
                 // order of execution.
                 $timeout(function() {
                   if (responseCount < identifyCount) {
-                    bodyEl.addClass(waitclass);
+                    gaWaitCursor.add();
                   }
                 }, 0);
 
@@ -309,10 +309,10 @@
                         imageDisplay: size[0] + ',' + size[1] + ',96'
                       }
                     }).success(function(html) {
-                      bodyEl.removeClass(waitclass);
+                      gaWaitCursor.remove();
                       showPopup(html);
                     }).error(function() {
-                      bodyEl.removeClass(waitclass);
+                      gaWaitCursor.remove();
                     });
                   }
                 });

--- a/src/components/waitcursor/WaitCursorService.js
+++ b/src/components/waitcursor/WaitCursorService.js
@@ -1,0 +1,33 @@
+(function() {
+  goog.provide('ga_waitcursor_service');
+
+  var module = angular.module('ga_waitcursor_service', []);
+
+  module.provider('gaWaitCursor', function() {
+    this.$get = function($document) {
+      var waitClass = 'ga-wait-cursor';
+      var bodyEl = angular.element($document[0].body);
+
+      var waitCursor = function() {
+        var processCounter = 0;
+        this.add = function() {
+          processCounter++;
+          if (processCounter === 1) {
+            bodyEl.addClass(waitClass);
+          }
+        };
+        this.remove = function() {
+          if (processCounter > 0) {
+            processCounter--;
+          }
+          if (processCounter === 0) {
+            bodyEl.removeClass(waitClass);
+          }
+        };
+      };
+
+      var waitingCursor = new waitCursor();
+      return waitingCursor;
+    };
+  });
+})();

--- a/src/components/waitcursor/style/waitcursor.less
+++ b/src/components/waitcursor/style/waitcursor.less
@@ -1,0 +1,3 @@
+.ga-wait-cursor {
+  cursor: wait;
+}

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -33,6 +33,7 @@
   goog.require('ga_placeholder_directive');
   goog.require('ga_collapsible_directive');
   goog.require('ga_fullscreen');
+  goog.require('ga_waitcursor_service');
 
   goog.require('ga_importkml_controller');
   goog.require('ga_importwms_controller');
@@ -80,6 +81,7 @@
     'ga_measure',
     'ga_profile',
     'ga_fullscreen',
+    'ga_waitcursor_service',
     'ga_seo',
     'ga_draw',
     'ga_modal_directive',

--- a/src/js/MeasureController.js
+++ b/src/js/MeasureController.js
@@ -2,16 +2,18 @@
   goog.provide('ga_measure_controller');
 
   goog.require('ga_urlutils_service');
+  goog.require('ga_waitcursor_service');
 
   var module = angular.module('ga_measure_controller', [
     'ga_urlutils_service',
+    'ga_waitcursor_service',
     'pascalprecht.translate'
   ]);
 
   module.controller('GaMeasureController',
-      function($scope, $translate, gaGlobalOptions, $http, $rootScope, gaUrlUtils, $document) {
+      function($scope, $translate, $http, $rootScope,
+          gaGlobalOptions, gaUrlUtils, gaWaitCursor) {
         $scope.options = {
-          waitClass: 'ga-measure-wait',
           isProfileActive: false,
           profileUrl: gaGlobalOptions.mapUrl + '/rest/services/profile.json',
           profileOptions: {
@@ -99,7 +101,6 @@
           }
         })();
         
-        var bodyEl = angular.element($document[0].body);
         var isProfileCreated = false;
         var createProfile = function(feature, callback) {
           var coordinates = feature.getGeometry().getCoordinates();
@@ -119,7 +120,7 @@
           http.error(function(data, status) {
             // Display an empty profile
             callback([{alts:{COMB: 0}, dist: 0}], status);
-            bodyEl.removeClass($scope.options.waitClass);
+            gaWaitCursor.remove();
           });;
         };
 

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -24,6 +24,7 @@
 @import "../components/layermanager/style/layermanager.less";
 @import "../components/draw/style/draw.less";
 @import "../components/help/style/help.less";
+@import "../components/waitcursor/style/waitcursor.less";
 
 @header-height: 89;
 @footer-height: 26;
@@ -799,11 +800,6 @@ ul.panel-body-wide {
   text-align: left;
 }
 
-// ***** METADATA POPUP
-.ga-measure-wait, .ga-tooltip-wait, .ga-metadata-popup-wait, .ga-print-wait, .ga-search-wait {
-  cursor: wait;
-}
-
 // ****** LEGEND
 .ga-tooltip-metadata {
   .popover-content {
@@ -916,7 +912,7 @@ ul.panel-body-wide {
   }
 }
 
-.ga-tooltip-wait, .ga-metadata-popup-wait {
+.ga-wait-cursor {
   #loader {
     z-index: 5000;
 


### PR DESCRIPTION
This PR also fixes a bug introduced by this commit https://github.com/geoadmin/mf-geoadmin3/commit/f5f45bbf429b8771fe85cef1307608ff79ff0608

Step to reproduce were:
1) Open app
2) Type ch (and fast after delete c or ch)

Result: waiting cursor is activated

Expected result: waiting cursor is removed

The counter that was previously implemented in the search directive is now in gaWaitCursor.
