### PR TITLE
Adapt proxy definition for print

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -64,17 +64,16 @@ RewriteRule ^/${apache_base_path}/prod/[0-9]+/(.*)$ ${apache_base_directory}/prd
    Header merge Cache-Control "public"
 </LocationMatch>
 
-# FIXME: temporary because of cookies in CORS requests
-# proxy
+# FIXME: temporary because of cookies in CORS requests that don't work
 % if (re.match('^http(s)?:*', api_url)):
 ProxyPassMatch /${apache_base_path}/print/(.*) ${api_url}/print/$1
-ProxyPassReverse /${apache_base_path} ${api_url}
+ProxyPassReverse /${apache_base_path}/print/ ${api_url}/print/
 % else:
 ProxyPassMatch /${apache_base_path}/print/(.*) http:${api_url}/print/$1
-ProxyPassReverse /${apache_base_path} http:${api_url}
+ProxyPassReverse /${apache_base_path}/print/ http:${api_url}/print/
 % endif
 
-<LocationMatch /${apache_base_path}/print>
+<LocationMatch ^/${apache_base_path}/print>
     Order allow,deny
     Allow from all
 </LocationMatch>


### PR DESCRIPTION
Adapt to print specific proxy path. This is more clear and seems to be needed for IE9 and the cookie settings (see corresponding PR in chsdi3 https://github.com/geoadmin/mf-chsdi3/issues/871)
