### PR TITLE
Don't use snapshot service anymore

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -43,10 +43,6 @@ RewriteRule ^${apache_base_path}/sitemap_(.*)\.xml http:${api_url}/${version}/si
     Header merge Cache-Control "no-cache"
 </LocationMatch>
 
-# Snapshot definitions for search engines
-RewriteCond %{QUERY_STRING} _escaped_fragment_=(.*)$
-RewriteRule ^${apache_base_path}/(index.html|mobile.html)(.*) http:${api_url}/snapshot [NE,L,P]
-
 # Proxy definitions
 ProxyPassMatch ^${apache_base_path}/print/(.*) http:${api_url}/print/$1
 <LocationMatch ^${apache_base_path}/print>

--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -107,25 +107,6 @@
   module.provider('gaSwisssearch', function() {
     this.$get = function($timeout, $rootScope) {
 
-      /*
-       * PhantomJS does not support the click event
-       * on an element. So we have to create
-       * the event ourselves and apply it to the
-       * element. This needs to be done for
-       * the snapshot service.
-       */
-      var clickElement = function(el) {
-        if (el.click) {
-          el.click();
-        } else if (document.createEvent) {
-          var evt = document.createEvent('MouseEvents');
-          evt.initMouseEvent('click', true, true, window,
-                             0, 0, 0, 0, 0, false, false,
-                            false, false, 0, null);
-          el.dispatchEvent(evt);
-        }
-      };
-
       var PermalinkSearch = function() {
         var active = false,
             hitCount = 0,
@@ -162,7 +143,7 @@
               if (totalResults == 1 &&
                   clickEl) {
                 singleResult = true;
-                clickElement(clickEl);
+                clickEl.click();
               }
               $rootScope.$broadcast('gaSwisssearchDone');
             }

--- a/src/components/seo/SeoDirective.js
+++ b/src/components/seo/SeoDirective.js
@@ -339,8 +339,8 @@
               return $q.all(promises);
             };
 
-            // Just do something if we are in snapshot mode
-            if (gaSeoService.isSnapshot()) {
+            // Just do something if we are active
+            if (gaSeoService.isActive()) {
               //Show popup
               $timeout(function() {
                 scope.showPopup = true;

--- a/src/components/seo/SeoService.js
+++ b/src/components/seo/SeoService.js
@@ -19,7 +19,7 @@
    */
   module.provider('gaSeoService', function() {
     this.$get = function(gaPermalink) {
-      var isSnapshot = gaPermalink.getParams().snapshot == 'true';
+      var isActive = gaPermalink.getParams()._escaped_fragment_ !== undefined;
       var layersAtStart = gaPermalink.getParams().layers ?
                           gaPermalink.getParams().layers.split(',') : [];
 
@@ -29,21 +29,21 @@
         zoom: gaPermalink.getParams().zoom
       };
 
-      //has to come after snapshot parameter is removed
-      var linkAtStart = gaPermalink.getHref();
-
-      // We remove the snapshot parameter in order to not have it
+     // We remove the _escaped_fragment_ parameter in order to not have it
       // anywhere in the page as part of the permalink inside the page.
-      // Snapshot state is available through the isSnapshot function.
-      gaPermalink.deleteParam('snapshot');
+      // State is available through the isActive function.
+      gaPermalink.deleteParam('_escaped_fragment_');
+
+      //has to come after _escaped_fragment_ parameter is removed
+      var linkAtStart = gaPermalink.getHref();
 
       var SeoService = function() {
         this.getLinkAtStart = function() {
           return linkAtStart;
         };
 
-        this.isSnapshot = function() {
-          return isSnapshot;
+        this.isActive = function() {
+          return isActive;
         };
 
         this.getLayers = function() {

--- a/src/components/seo/partials/seo.html
+++ b/src/components/seo/partials/seo.html
@@ -1,7 +1,7 @@
 <div>
  <!-- this is the popup we will show our information -->
   <div ga-popup="showPopup"
-       ga-popup-options="{title:'seo title'}"
+       ga-popup-options="{title:'Information'}"
        ga-draggable=".ga-popup-title"
        id="seo-popup" >
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -36,14 +36,7 @@
     <script>
       (function(){
         var w = window, l = w.location, n = w.navigator, pathname, p = '${device}',
-          m = l.search.match(/(?:mobile=(true|false))/),
-          fromSnapshot = l.search.match(/(?:snapshot=true)/);
-
-        //We need this guard as it prevents constant re-loading when
-        //testing the snapshot service in the browser
-        if (fromSnapshot) {
-          return;
-        }
+          m = l.search.match(/(?:mobile=(true|false))/);
 
         if (!l.origin) { l.origin = l.protocol + "//" + l.hostname } // IE fix
 


### PR DESCRIPTION
As google recently changed who their crawlers index pages [1], it isn't necessary anymore to use our snapshot service to deliver pages to its crawler.

This PR removes the redirection to the snapshot service and assures that the content is delivered directly to the crawler. We will then be able to remove the snapshot service itself.

Note that only google officially supports full rendering of SPA pages, so other crawlers don't get as much information as google...unless they change their ways. I think this is acceptable as google accounts for 95.5% of all search-engine based incoming requests (bing is second with 2.8%).

[1] http://googlewebmastercentral.blogspot.ch/2014/05/understanding-web-pages-better.html
