### PR TITLE
Adding jenkins build status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ mf-geoadmin3
 
 next generation map.geo.admin.ch
 
-[![Build Status](https://travis-ci.org/geoadmin/mf-geoadmin3.png?branch=master)](https://travis-ci.org/geoadmin/mf-geoadmin3)
+Jenkins build status: [![Jenkins Build Status](https://jenkins.dev.bgdi.ch/buildStatus/icon?job=geoadmin3)](https://jenkins.dev.bgdi.ch/job/geoadmin3/)
+
+Travis build status: [![Jenkins Build Status](https://travis-ci.org/geoadmin/mf-geoadmin3.png?branch=master)](https://travis-ci.org/geoadmin/mf-geoadmin3)
 
 # Getting started
 


### PR DESCRIPTION
This adds a jenkins build status icon (representing state of last master branch build) to the README file.
