### PR TITLE
Remove user_env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ SRC_COMPONENTS_PARTIALS_FILES = $(shell find src/components -type f -path '*/par
 APACHE_BASE_DIRECTORY ?= $(CURDIR)
 LAST_APACHE_BASE_DIRECTORY := $(shell if [ -f .build-artefacts/last-apache-base-directory ]; then cat .build-artefacts/last-apache-base-directory 2> /dev/null; else echo '-none-'; fi)
 ifeq "$(CURDIR)" "/var/www/vhosts/mf-geoadmin3/private/geoadmin"
-	APACHE_BASE_PATH ?= "main"
+	APACHE_BASE_PATH ?= ""
 else
-	APACHE_BASE_PATH ?= $(shell id -un)
+	APACHE_BASE_PATH ?= /$(shell id -un)
 endif
 LAST_APACHE_BASE_PATH := $(shell if [ -f .build-artefacts/last-apache-base-path ]; then cat .build-artefacts/last-apache-base-path 2> /dev/null; else echo '-none-'; fi)
 API_URL ?= //mf-chsdi3.dev.bgdi.ch
@@ -166,12 +166,12 @@ prd/style/app.css: src/style/app.less src/style/print.less src/style/ga_bootstra
 
 prd/index.html: src/index.mako.html prd/lib/build.js prd/style/app.css .build-artefacts/python-venv/bin/mako-render .build-artefacts/python-venv/bin/htmlmin .build-artefacts/last-api-url .build-artefacts/last-apache-base-path
 	mkdir -p $(dir $@)
-	.build-artefacts/python-venv/bin/mako-render --var "device=desktop" --var "mode=prod" --var "version=$(VERSION)" --var "versionslashed=$(VERSION)/" --var "user_env=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
+	.build-artefacts/python-venv/bin/mako-render --var "device=desktop" --var "mode=prod" --var "version=$(VERSION)" --var "versionslashed=$(VERSION)/" --var "apache_base_path=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
 	.build-artefacts/python-venv/bin/htmlmin --remove-comments --keep-optional-attribute-quotes $@ $@
 
 prd/mobile.html: src/index.mako.html .build-artefacts/python-venv/bin/mako-render .build-artefacts/python-venv/bin/htmlmin .build-artefacts/last-api-url .build-artefacts/last-apache-base-path
 	mkdir -p $(dir $@)
-	.build-artefacts/python-venv/bin/mako-render --var "device=mobile" --var "mode=prod" --var "version=$(VERSION)" --var "versionslashed=$(VERSION)/" --var "user_env=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
+	.build-artefacts/python-venv/bin/mako-render --var "device=mobile" --var "mode=prod" --var "version=$(VERSION)" --var "versionslashed=$(VERSION)/" --var "apache_base_path=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
 	.build-artefacts/python-venv/bin/htmlmin --remove-comments --keep-optional-attribute-quotes $@ $@
 
 prd/img/: src/img/*
@@ -197,10 +197,10 @@ src/style/app.css: src/style/app.less src/style/print.less src/style/ga_bootstra
 	node_modules/.bin/lessc $(LESS_PARAMETERS) $< $@
 
 src/index.html: src/index.mako.html .build-artefacts/python-venv/bin/mako-render .build-artefacts/last-api-url .build-artefacts/last-apache-base-path
-	.build-artefacts/python-venv/bin/mako-render --var "device=desktop" --var "version=" --var "versionslashed=" --var "user_env=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
+	.build-artefacts/python-venv/bin/mako-render --var "device=desktop" --var "version=" --var "versionslashed=" --var "apache_base_path=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
 
 src/mobile.html: src/index.mako.html .build-artefacts/python-venv/bin/mako-render .build-artefacts/last-api-url .build-artefacts/last-apache-base-path
-	.build-artefacts/python-venv/bin/mako-render --var "device=mobile" --var "version=" --var "versionslashed=" --var "user_env=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
+	.build-artefacts/python-venv/bin/mako-render --var "device=mobile" --var "version=" --var "versionslashed=" --var "apache_base_path=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
 
 src/TemplateCacheModule.js: src/TemplateCacheModule.mako.js $(SRC_COMPONENTS_PARTIALS_FILES) .build-artefacts/python-venv/bin/mako-render
 	.build-artefacts/python-venv/bin/mako-render --var "partials=$(subst src/,,$(SRC_COMPONENTS_PARTIALS_FILES))" --var "basedir=src" $< > $@

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Use `make translate` to import directly translations from the googlespreadshhet.
 
 Variables have sensible default values for development. Anyhow, they can be set as make macros or envvars. For example:
 
-    $ make APACHE_BASE_PATH=elemoine apache 
-    $ APACHE_BASE_PATH=elemoine make 
+    $ make APACHE_BASE_PATH=/elemoine apache 
+    $ APACHE_BASE_PATH=/elemoine make 
 
 You can customize the build by creating an `rc` file that you source once. Ex:  
 
     $ cat rc_elemoine 
-    export APACHE_BASE_PATH=mypath
+    export APACHE_BASE_PATH=/mypath
     export APACHE_BASE_DIRECTORY=/home/elemoine/mf-geoadmin3
     export API_URL=//mf-chsdi.3dev.bgdi.ch
     export DEPLOY_TARGET=dev

--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -1,14 +1,3 @@
-<%
-
-entry_path = '/' + apache_base_path
-base_directory = apache_base_directory
-
-if 'main' in apache_base_path:
-    entry_path = ''
-    base_directory = '/var/www/vhosts/mf-geoadmin3/private/geoadmin'
-
-%>
-
 RewriteEngine On
 ExpiresActive On
 
@@ -29,25 +18,25 @@ AddOutputFilterByType DEFLATE application/json
 </IfModule>
 
 # Redirect no-slash target to slashed version
-RedirectMatch ^${entry_path}$ ${entry_path}/
+RedirectMatch ^${apache_base_path}$ ${apache_base_path}/
 
-Alias ${entry_path}/src ${base_directory}/src
-Alias ${entry_path}/ ${base_directory}/prd/
+Alias ${apache_base_path}/src ${apache_base_directory}/src
+Alias ${apache_base_path}/ ${apache_base_directory}/prd/
 
 # Cached resources
-RewriteRule ^${entry_path}/[0-9]+/(img|lib|style|locales)(.*) ${base_directory}/prd/$1$2
-<LocationMatch ^${entry_path}/[0-9]+/>
+RewriteRule ^${apache_base_path}/[0-9]+/(img|lib|style|locales)(.*) ${apache_base_directory}/prd/$1$2
+<LocationMatch ^${apache_base_path}/[0-9]+/>
    ExpiresDefault "now plus 1 year"
    Header merge Cache-Control "public"
 </LocationMatch>
 
 # Sitemaps (we are using version here to get a cached version from backend)
-RewriteRule ^${entry_path}/sitemap_(.*)\.xml http:${api_url}/${version}/sitemap?content=$1 [P]
+RewriteRule ^${apache_base_path}/sitemap_(.*)\.xml http:${api_url}/${version}/sitemap?content=$1 [P]
 
 # We tell the public to not cache the response, even with
 # this, the versioned sitemap of the back-end _is_ cached
 # This assures that latest sitemaps is used after deploy
-<LocationMatch ^${entry_path}/sitemap_.*\.xml>
+<LocationMatch ^${apache_base_path}/sitemap_.*\.xml>
     Order allow,deny
     Allow from all
     Header unset Cache-Control
@@ -56,17 +45,17 @@ RewriteRule ^${entry_path}/sitemap_(.*)\.xml http:${api_url}/${version}/sitemap?
 
 # Snapshot definitions for search engines
 RewriteCond %{QUERY_STRING} _escaped_fragment_=(.*)$
-RewriteRule ^${entry_path}/(index.html|mobile.html)(.*) http:${api_url}/snapshot [NE,L,P]
+RewriteRule ^${apache_base_path}/(index.html|mobile.html)(.*) http:${api_url}/snapshot [NE,L,P]
 
 # Proxy definitions
-ProxyPassMatch ^${entry_path}/print/(.*) http:${api_url}/print/$1
-<LocationMatch ^${entry_path}/print>
+ProxyPassMatch ^${apache_base_path}/print/(.*) http:${api_url}/print/$1
+<LocationMatch ^${apache_base_path}/print>
     Order allow,deny
     Allow from all
 </LocationMatch>
 
 # Checker definitions (never cache)
-<Location ~ "${entry_path}/checker$">
+<Location ~ "${apache_base_path}/checker$">
     ExpiresDefault "access"
     Header merge Cache-Control "no-cache"
     Header unset ETag

--- a/rc_branch.mako
+++ b/rc_branch.mako
@@ -1,3 +1,3 @@
-export APACHE_BASE_PATH=${apache_base_path}
+export APACHE_BASE_PATH=/${apache_base_path}
 export API_URL=//mf-chsdi3.${deploy_target}.bgdi.ch
 

--- a/rc_dev
+++ b/rc_dev
@@ -1,5 +1,3 @@
 export DEPLOY_TARGET=dev
 export API_URL=//mf-chsdi3.dev.bgdi.ch
-export APACHE_BASE_PATH=main
-
 

--- a/rc_int
+++ b/rc_int
@@ -1,4 +1,2 @@
 export DEPLOY_TARGET=int
 export API_URL=//mf-chsdi3.int.bgdi.ch
-export APACHE_BASE_PATH=main
-

--- a/rc_ltclm
+++ b/rc_ltclm
@@ -1,2 +1,2 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltclm
-export APACHE_BASE_PATH=ltclm
+export APACHE_BASE_PATH=/ltclm

--- a/rc_ltgal
+++ b/rc_ltgal
@@ -1,2 +1,2 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltgal
-export APACHE_BASE_PATH=ltgal
+export APACHE_BASE_PATH=/ltgal

--- a/rc_ltgud
+++ b/rc_ltgud
@@ -1,2 +1,2 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltgud
-export APACHE_BASE_PATH=ltgud
+export APACHE_BASE_PATH=/ltgud

--- a/rc_ltjeg
+++ b/rc_ltjeg
@@ -1,2 +1,2 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltjeg
-export APACHE_BASE_PATH=ltjeg
+export APACHE_BASE_PATH=/ltjeg

--- a/rc_ltmoc
+++ b/rc_ltmoc
@@ -1,2 +1,2 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltmoc
-export APACHE_BASE_PATH=ltmoc
+export APACHE_BASE_PATH=/ltmoc

--- a/rc_ltmom
+++ b/rc_ltmom
@@ -1,3 +1,2 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltmom
-export APACHE_BASE_PATH=ltmom
-
+export APACHE_BASE_PATH=/ltmom

--- a/rc_ltteo
+++ b/rc_ltteo
@@ -1,2 +1,2 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltteo
-export APACHE_BASE_PATH=ltteo
+export APACHE_BASE_PATH=/ltteo

--- a/rc_prod
+++ b/rc_prod
@@ -1,4 +1,2 @@
 export DEPLOY_TARGET=prod
 export API_URL=//api3.geo.admin.ch
-export APACHE_BASE_PATH=main
-

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -1,11 +1,4 @@
 # -*- coding: utf-8 -*-
-<%
-
-print_entry = '/' + user_env
-if 'main' in user_env:
-    print_entry = ''
-
-%>
 <!DOCTYPE html>
 <html ng-app="ga" ng-controller="GaMainController">
   <head>
@@ -623,7 +616,7 @@ if 'main' in user_env:
         var pathname = location.pathname.replace(/(index.html)|(mobile.html)/g, '');
 
         module.constant('gaGlobalOptions', {
-          mapUrl : location.origin + '${print_entry}',
+          mapUrl : location.origin + '${apache_base_path}',
           apiUrl : location.protocol + '${api_url}',
           cachedApiUrl: location.protocol + '${api_url}' + cacheAdd,
           resourceUrl: location.origin + pathname + '${versionslashed}',


### PR DESCRIPTION
For appcache, I needed to clarify what was the `user_env` variable and it seems it's useless now. 
Morever with the previous modification of apache conf, `main` it's not used anymore so it's a little bit weird to see we use it in some files (makefile, app.mako-dot-conf, index.mako.html).

So this PR remove the use of `main` and use the `apache_base_path` variable instead of `entry_path` and `print_entry` 

Possible `apache_base_path` values: ` `,`/[user_name]`or`/[branch_name]`

Test links:

[http://mf-geoadmin3.dev.bgdi.ch](http://mf-geoadmin3.dev.bgdi.ch)
[http://mf-geoadmin3.dev.bgdi.ch/ltteo](http://mf-geoadmin3.dev.bgdi.ch/ltteo)
[http://mf-geoadmin3.dev.bgdi.ch/fix_user_env](http://mf-geoadmin3.dev.bgdi.ch/fix_user_env)
