### PR TITLE
Add address sitemap to robots

### DIFF
--- a/scripts/robots.mako-dot-txt
+++ b/scripts/robots.mako-dot-txt
@@ -4,6 +4,7 @@ User-agent: *
 
 Disallow: /checker
 
+Sitemap: http://map.geo.admin.ch/sitemap_addresses.xml
 Sitemap: http://map.geo.admin.ch/sitemap_index.xml
 
 % else:


### PR DESCRIPTION
Nested sitemaps are, surprisingly, not allowed.

https://productforums.google.com/forum/#!topic/webmasters/6UyJ3pfRXZk

This PR therefore lists addresses explicitely.
