### PR TITLE
Support translated labels in featuretree

### DIFF
--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -23,6 +23,15 @@
           gaMapClick, gaPreviewFeatures, gaLayerFilters,
           gaBrowserSniffer) {
 
+        var getTranslatedLabel = function(obj) {
+          var possibleKey = 'label_' + $translate.uses();
+          if (angular.isDefined(obj[possibleKey])) {
+            return obj[possibleKey];
+          } else {
+            return obj.label;
+          }
+        };
+
         return {
           restrict: 'A',
           replace: true,
@@ -174,7 +183,7 @@
                       geometry: null,
                       id: result.attrs.featureId || result.attrs.id,
                       layer: layerId,
-                      label: result.attrs.label
+                      label: getTranslatedLabel(result.attrs)
                     };
                   }
                   newNode.features.push(feature);


### PR DESCRIPTION
This PR allows the possibility to have translated labels for search results in the feature tree. It looks for `label_xx` entries on the results, and takes the one corresponding to the current language. If it's not found in the results, it takes the `label` attribute, which should always be present.

See also https://github.com/geoadmin/service-sphinxsearch/pull/146

Please review/merge quickly as we want this in next weeks deploy.

(Note: this could be extended to other locations, mainly the search)
