### PR TITLE
Update labels on data update

### DIFF
--- a/src/components/profile/ProfileDirective.js
+++ b/src/components/profile/ProfileDirective.js
@@ -56,7 +56,7 @@
 
             $rootScope.$on('gaProfileDataUpdated', function(ev, data) {
               profile.update(data);
-              scope.unitX = profile.unitX;
+              profile.updateLabels();
             });
 
             function attachPathListeners(areaChartPath) {


### PR DESCRIPTION
This PR fixes https://github.com/geoadmin/mf-geoadmin3/issues/1598

where the labels are not updated if the scale changes ([m] -> [km] and [km] -> [m])
