### PR TITLE
Wait after pageload because topics might not be set yet

### DIFF
--- a/test/selenium/basic_test.js
+++ b/test/selenium/basic_test.js
@@ -9,7 +9,9 @@ var runTest = function(cap, driver, target){
   //We maximizse our window to be sure to be in full resolution
   driver.manage().window().maximize();
   //Goto the travis deployed site.
-  driver.get(target);
+  driver.get(target).then(function() {
+    driver.sleep(3000);
+  });
   //type in "Bern" into the search field.
   driver.findElement(webdriver.By.xpath("//*[@type='search']")).sendKeys('Bern').then(function() {
     driver.sleep(3000);


### PR DESCRIPTION
Another attempt to stabilize the browserstack tests. Sometimes it takes longer for the page to load. The problem was that no topic was set when 'Bern' was entered in the search box, especially when apache was restarted (chsdi3 needs some warmup time).

Hopefully, the tests are not stable/usable again.

Self-merge.
