### PR TITLE
Get rid of explicit sleep times in browserstack tests

### DIFF
--- a/test/selenium/basic_test.js
+++ b/test/selenium/basic_test.js
@@ -4,38 +4,33 @@ var assert = require('assert');
 var QUERYSTRING_OF_BERN = "X=200393.27&Y=596671.16";
 
 var runTest = function(cap, driver, target){
-  //on every action we wait a maximum of 10 seconds before thrwosing and error (ajax etc.)
-  driver.manage().timeouts().implicitlyWait(30000);
+  var TIMEOUT = 20000;
+  driver.manage().timeouts().implicitlyWait(TIMEOUT);
   //We maximizse our window to be sure to be in full resolution
   driver.manage().window().maximize();
   //Goto the travis deployed site.
-  driver.get(target).then(function() {
-    driver.sleep(3000);
-  });
+  driver.get(target + '/?lang=de');
+  //wait until topics related stuff is loaded. We know this when catalog is there
+  driver.findElement(webdriver.By.xpath("//a[contains(text(), 'Grundlagen und Planung')]"));
   //type in "Bern" into the search field.
-  driver.findElement(webdriver.By.xpath("//*[@type='search']")).sendKeys('Bern').then(function() {
-    driver.sleep(3000);
-  });
+  driver.findElement(webdriver.By.xpath("//*[@type='search']")).sendKeys('Bern');
   //Click on the field "Bern (BE)"
-  driver.findElement(webdriver.By.xpath("//*[contains(text(), 'Bern (BE)')]")).click().then(function(){
-    driver.sleep(3000);
-    //The first test does not have to work on IE 9
-    if(!(cap.browser == "IE" && cap.browser_version == "9.0")){
-
-      //If we have a look at the URL
-      driver.getCurrentUrl().then(function(url){
-        //We should be located in Bern
-        assert.ok(url.indexOf(QUERYSTRING_OF_BERN) > -1);
-      });
-    }
-  });
-
+  driver.findElement(webdriver.By.xpath("//*[contains(text(), 'Bern (BE)')]")).click();
   //We click on the "share" button
   driver.findElement(webdriver.By.xpath("//a[@id='shareHeading']")).click();
+  //Any link with the adapted URL? (there should be many)
+  driver.findElement(webdriver.By.xpath("//a[contains(@href, '" + QUERYSTRING_OF_BERN + "')]"));
+  //Was the URL in the address bar adatped?
+  if(!(cap.browser == "IE" && cap.browser_version == "9.0")) {
+    //check if url is adapted to reflect Bern location
+    driver.getCurrentUrl().then(function(url) {
+        assert.ok(url.indexOf(QUERYSTRING_OF_BERN) > -1);
+    });
+  }
   //And have a look at the permanent Link
   driver.findElement(webdriver.By.xpath("//*[@ng-model='permalinkValue']")).getAttribute("value").then(function(val){
-    //The perma Link should point to Bern
-    assert.ok(val.indexOf(QUERYSTRING_OF_BERN) > -1);
+      //The perma Link should point to Bern
+      assert.ok(val.indexOf(QUERYSTRING_OF_BERN) > -1);
   }); 
 }
 


### PR DESCRIPTION
Making tests more robust...once again. We avoid to use timeouts and wait until elements are present before checking for value.
