### PR TITLE
Fix installation on plain ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ this to work, you need to make sure to install the following dependencies:
     sudo apt-get install make gcc+ git unzip openjdk-6-jre openjdk-6-jdk g++ npm python-virtualenv
     npm install phantomjs
 
+### Caveats
+
+You might get an error similar to:
+    /usr/bin/env: node: No such file or directory
+This can be fixed by running:
+    sudo ln -s /usr/bin/nodejs /usr/bin/node 
+    #see https://github.com/joyent/node/issues/3911
+
 # Automated tests
 
 ## Unit tests


### PR DESCRIPTION
When trying to run `make all` on a semi plain 14.04 I had to fix some dependencies problem. 
`apt-get install nodejs` doesn't bring `npm` and the install command in the read me was line wrapped at the wrong place.

also, on 14.04 the nodejs executable is called nodejs but some of the dependencies try to execute `node` this is simply solved with a symlink
