### PR TITLE
Use cached API for print info

### DIFF
--- a/src/js/PrintController.js
+++ b/src/js/PrintController.js
@@ -5,10 +5,11 @@
 
   module.controller('GaPrintController',
     function($scope, gaGlobalOptions) {
-      var printPath = gaGlobalOptions.apiUrl + '/print'
+      var printPath = gaGlobalOptions.apiUrl + '/print';
+      var printCachedPath = gaGlobalOptions.cachedApiUrl + '/print';
       
       $scope.options = {
-        printConfigUrl: printPath + '/info.json?url=' +
+        printConfigUrl: printCachedPath + '/info.json?url=' +
             encodeURIComponent(printPath),
         legendUrl: gaGlobalOptions.apiUrl + '/static/images/legends/',
         qrcodeUrl: gaGlobalOptions.apiUrl + '/qrcodegenerator?url=',


### PR DESCRIPTION
On page load, the print info is always loaded. So every time we load the main page, we request something from the print server. I've noticed in the past that page loading is delayed because of that.

This PR assures that the info is cached and we as the cached version on page load. The downside: every update to the info will require a deploy of geoadmin3.
