### PR TITLE
Use the default fallback behavior of localforage

### DIFF
--- a/src/components/StorageService.js
+++ b/src/components/StorageService.js
@@ -72,10 +72,12 @@
               version: (gaBrowserSniffer.msie) ? 1 : '1.0',
               description: 'Storage for map.geo.admin.ch'
             });
-            // Firefox and IE don't manage webSQL.
-            if (gaBrowserSniffer.mobile && gaBrowserSniffer.webkit) {
-              $window.localforage.setDriver('webSQLStorage');
-            }
+            // IE > 10, Safari, Chrome, Opera, FF -> indexeddb
+            //
+            // Exceptions:
+            // Android default browser -> websql
+            // iOS Chrome, Opera -> websql
+            // iOS 7 Safari -> websql
             isInitialized = true;
           }
         };


### PR DESCRIPTION
Since we store a compressed base64 string we can use indexeddb on mobile when available.

This PR removes the the use of websql by default.

Tested with a 15km2 extent with 3 layers (pixelkarte, wander, cadastralwebmap), here the result:

Amdroid Chrome: 99mo,
Amdroid  Firefox: 71mo
Amdroid Opera: 138mo

ios 8 Safari: 58 mo
