### PR TITLE
Disable offline check for desktop

### DIFF
--- a/src/components/NetworkStatusService.js
+++ b/src/components/NetworkStatusService.js
@@ -36,11 +36,17 @@
     var count = 0;
     var promise;
     this.$get = function($document, $rootScope, $timeout, $window,
-        gaGlobalOptions) {
+        gaGlobalOptions, gaBrowserSniffer) {
       var NetworkStatusService = function() {
         var that = this;
         this.offline = !navigator.onLine;
+        if (!gaBrowserSniffer.mobile) {
+          this.offline = false;
+        }
         this.check = function(timeout) {
+          if (!gaBrowserSniffer.mobile) {
+            return;
+          }
           if (promise) {
             $timeout.cancel([promise]);
           }

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -61,8 +61,8 @@
         }
 
         var onMobile = ((('ontouchstart' in w) ||
-            (('maxTouchPoints' in n) && n.maxTouchPoints > 0) ||
-            (('msMaxTouchPoints' in n) && n.msMaxTouchPoints > 0)) &&
+            (('maxTouchPoints' in n) && n.maxTouchPoints > 1) ||
+            (('msMaxTouchPoints' in n) && n.msMaxTouchPoints > 1)) &&
             (screen.width<=768 || screen.height<=768));
         if (m=='false' || (!onMobile && p=='mobile') ) {
           redirectToDesktop();

--- a/test/specs/contextpopup/ContextPopupDirective.spec.js
+++ b/test/specs/contextpopup/ContextPopupDirective.spec.js
@@ -12,6 +12,9 @@ describe('ga_contextpopup_directive', function() {
           menu: 'contextmenu'
         }
       });
+      $provide.value('gaNetworkStatus', {
+        offline: true
+      });
     });
     originalEvt = {originalEvent:{}}; 
     element = angular.element(


### PR DESCRIPTION
This is a PR for https://github.com/geoadmin/mf-geoadmin3/issues/1697

Basically, when on index.html, we don't do any offline checks and we assume to always be online. This potentially reduces traffic on the checker as well. This makes sense since we don't offer offline for desktop anyway.
