### PR TITLE
Specify an extent for WMTS layer

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -692,6 +692,7 @@
               });
             }
             olLayer = new ol.layer.Tile({
+              extent: olSource.getProjection().getExtent(),
               minResolution: gaNetworkStatus.offline ? null :
                   layer.minResolution,
               maxResolution: layer.maxResolution,


### PR DESCRIPTION
Keep the old way (before ol3 update) to defined the source of the layer.
