### PR TITLE
Allow to not change cache version on prod and int

### DIFF
--- a/rc_int
+++ b/rc_int
@@ -1,3 +1,4 @@
+export KEEP_VERSION=true
 export DEPLOY_TARGET=int
 export API_URL=//mf-chsdi3.int.bgdi.ch
 export APACHE_BASE_PATH=

--- a/rc_prod
+++ b/rc_prod
@@ -1,3 +1,4 @@
+export KEEP_VERSION=true
 export DEPLOY_TARGET=prod
 export API_URL=//api3.geo.admin.ch
 export APACHE_BASE_PATH=

--- a/src/geoadmin.mako.appcache
+++ b/src/geoadmin.mako.appcache
@@ -2,11 +2,8 @@
   defaultLanguage = 'en'
   languages = ('de', 'en', 'fr', 'it', 'rm')
   topics = ('are', 'bafu', 'blw', 'dev', 'ech', 'funksender', 'geol', 'inspire', 'ivs', 'kgs', 'luftbilder', 'nga', 'sachplan', 'swisstopo', 'vu', 'wildruhezonen')
-  appcache_version = commit_hash
-  if deploy_target == 'dev':
-      appcache_version = version
 %>CACHE MANIFEST
-# Version ${appcache_version}
+# Version ${version}
 
 CACHE:
 ${version}/lib/build.js	


### PR DESCRIPTION
Followin discussion of @oterral .

On prod and int, each instance will get it's proper cache version. This is unnecessary and leads to bugs in appcache handling. With this PR, when we deploy to production or integration, the cache version is not changed anymore on the instances. All instances have the same version. This addes the benefirt that caching on varnish level should be more efficient.

Mid-Term, we should try to switch to Zadara backed deploymenent.
