### PR TITLE
Make sure version is created before deployment

### DIFF
--- a/rc_dev
+++ b/rc_dev
@@ -1,3 +1,4 @@
+export KEEP_VERSION=false
 export DEPLOY_TARGET=dev
 export API_URL=//mf-chsdi3.dev.bgdi.ch
 export APACHE_BASE_PATH=


### PR DESCRIPTION
Short version:
This is needed to assure that our deployment works correctly when it comes to keeping the version the same on our targets.

A little longer version:
Without this and if the executer's enviroment has the KEEP_VERSION set to 'true', the last-version file is deleted in deploydev proccess and never re-created, hence resulting in an unkown version in the snapshot, which results a re-creation of the version on each target.

Note: today's deploy was done 'manually' to avoid this problem.
