### PR TITLE
Add invokeApply parameter to gaDebounce service

### DIFF
--- a/src/components/DebounceService.js
+++ b/src/components/DebounceService.js
@@ -6,7 +6,7 @@
   module.provider('gaDebounce', function() {
     this.$get = function($timeout, $q) {
       var Debounce = function() {
-        this.debounce = function(func, wait, immediate) {
+        this.debounce = function(func, wait, immediate, invokeApply) {
           var timeout;
           var deferred = $q.defer();
           return function() {
@@ -22,7 +22,7 @@
             if (timeout) {
               $timeout.cancel(timeout);
             }
-            timeout = $timeout(later, wait);
+            timeout = $timeout(later, wait, invokeApply);
             if (callNow) {
               deferred.resolve(func.apply(context, args));
               deferred = $q.defer();

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -85,7 +85,7 @@
               map.getTarget().style.cursor = (feature) ? 'pointer' : '';
             };
             var updateCursorStyleDebounced = gaDebounce.debounce(
-                updateCursorStyle, 10, false);
+                updateCursorStyle, 10, false, false);
 
             if (!gaBrowserSniffer.mobile) {
               $(map.getViewport()).on('mousemove', function(evt) {


### PR DESCRIPTION
When we use gaDebounce or $timeout service,  if the function called modifies only html and not scope values no need to invoke $digest cycle.
