### PR TITLE
Use change:rotation event on the view instead of postRender on map to av...

### DIFF
--- a/src/components/rotate/RotateDirective.js
+++ b/src/components/rotate/RotateDirective.js
@@ -34,12 +34,8 @@
         };
 
         // Button is rotated according to map rotation
-        map.on('postrender', function(mapEvent) {
-          var frameState = mapEvent.frameState;
-          if (frameState && frameState.viewState) {
-            var rotation = frameState.viewState.rotation;
-            setButtonRotation(rotation * 180 / Math.PI);
-          }
+        map.getView().on('change:rotation', function(evt) {
+          setButtonRotation(evt.target.getRotation() * 180 / Math.PI);
         });
 
         // Button event - map rotation is animated


### PR DESCRIPTION
That avoid to trigger unnecessary $digest cycle.

Test [here](http://mf-geoadmin3.dev.bgdi.ch/dev_rotate/)

If there was a reason to use postRender events instead fo change:rotation, please close this
