### PR TITLE
Print bug fixes

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -124,7 +124,11 @@
     // Encode ol.Layer to a basic js object
     var encodeLayer = function(layer, proj) {
       var encLayer, encLegend;
-      var ext = proj.getExtent();
+      var minXY = $scope.map.getCoordinateFromPixel([printRectangle[0],
+          printRectangle[3]]);
+      var maxXY = $scope.map.getCoordinateFromPixel([printRectangle[2],
+          printRectangle[1]]);
+      var ext = minXY.concat(maxXY);
       var resolution = $scope.map.getView().getResolution();
 
       if (!(layer instanceof ol.layer.Group)) {


### PR DESCRIPTION
Set a minimal value to the image's size sent to the print server and use print rectangle extent to filter out features to print.

Test [here](http://mf-geoadmin3.dev.bgdi.ch/fix_width/)

Fix #1546 
Fix #1520

Testé avec fichier petite_robella.kml
