### PR TITLE
Use all topic for layerConfig to avoid proxy definition

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -46,13 +46,6 @@ RewriteRule ^${apache_base_path}/sitemap_(.*)\.xml http:${api_url}/${version}/si
     Header merge Cache-Control "no-cache"
 </LocationMatch>
 
-# Proxy definitions
-ProxyPassMatch ^${apache_base_path}/([0-9/]*rest/services/[a-z]+/MapServer/layersConfig)(.*) http:${api_url}/$1$2
-<LocationMatch ^${apache_base_path}/([0-9/]*rest/services/[a-z]+/MapServer/layersConfig)>
-    Order allow,deny
-    Allow from all
-</LocationMatch>
-
 # Checker definitions (never cache)
 <Location ~ "${apache_base_path}/checker$">
     ExpiresDefault "access"

--- a/src/components/catalogtree/example/index.html
+++ b/src/components/catalogtree/example/index.html
@@ -108,7 +108,7 @@
                '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
            gaLayersProvider.layersConfigUrlTemplate =
-               'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/layersConfig' +
+               'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
                '?lang={Lang}';
            gaLayersProvider.legendUrlTemplate =
                'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/{Layer}/legend' +

--- a/src/components/featuretree/example/index.html
+++ b/src/components/featuretree/example/index.html
@@ -131,7 +131,7 @@
                '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
            gaLayersProvider.layersConfigUrlTemplate =
-               'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/layersConfig' +
+               'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
                '?lang={Lang}';
            gaLayersProvider.legendUrlTemplate =
                'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/{Layer}/legend' +

--- a/src/components/importkml/example/index.html
+++ b/src/components/importkml/example/index.html
@@ -90,7 +90,7 @@
               '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
-              'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/layersConfig' +
+              'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
               '?lang={Lang}';
         }]);
 

--- a/src/components/importwms/example/index.html
+++ b/src/components/importwms/example/index.html
@@ -93,7 +93,7 @@
               '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
-              'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/layersConfig' +
+              'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
               '?lang={Lang}';
         }]);
 

--- a/src/components/map/example/index.html
+++ b/src/components/map/example/index.html
@@ -81,7 +81,7 @@
               '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
-            'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/layersConfig' +
+            'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
             '?lang={Lang}';
         }]);
 

--- a/src/components/search/example/index.html
+++ b/src/components/search/example/index.html
@@ -92,7 +92,7 @@
               '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
-              'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/layersConfig' +
+              'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
               '?lang={Lang}';
         }]);
 

--- a/src/geoadmin.mako.appcache
+++ b/src/geoadmin.mako.appcache
@@ -11,6 +11,9 @@ ${version}/style/app.css
 ${version}/style/font-awesome-3.2.1/font/fontawesome-webfont.woff?v=3.2.1
 ${version}/img/logo.ch.small.png
 ${api_url}/${version}/rest/services
+% for lang in languages:
+${api_url}/${version}/rest/services/all/MapServer/layersConfig?lang=${lang}
+% endfor
 
 # Use case: opens in offline then online.
 # In that case we need to have all languages, because we can't reload manually
@@ -34,11 +37,6 @@ ${version}/img/logo.ch.${lang}.png ${version}/img/logo.ch.${defaultLanguage}.png
 # Topic images
 % for topic in topics:
 ${version}/img/${topic}.jpg ${version}/img/dev.jpg
-% endfor
-
-# Layers config
-% for topic in topics:
-${apache_base_path}/rest/services/${topic}/MapServer/layersConfig ${apache_base_path}/rest/services/ech/MapServer/layersConfig?lang=${defaultLanguage}
 % endfor
 
 # With Permalink

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -656,7 +656,7 @@
               '//wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
-              gaGlobalOptions.mapUrl + '/rest/services/{Topic}/MapServer/layersConfig?lang={Lang}';
+              gaGlobalOptions.cachedApiUrl + '/rest/services/all/MapServer/layersConfig?lang={Lang}';
 
           gaLayersProvider.legendUrlTemplate =
               gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/MapServer/{Layer}/legend?lang={Lang}';


### PR DESCRIPTION
As discussed with @oterral yesterday.

This PR tries to remove the proxy definition in the apache configuration by using the 'all' topic only for our layersConfig in our application.

@oterral Can you review and verify/test this for offline? Does it make sense?
