### PR TITLE
Change search minimum length from 3 to 2

### DIFF
--- a/src/js/SearchController.js
+++ b/src/js/SearchController.js
@@ -18,7 +18,7 @@
           applyTopicToUrl: function (url, topic) {
             return url.replace(topicPlaceHolder, topic);
           },
-          minLength: 3,
+          minLength: 2,
           rateLimitWait: (gaBrowserSniffer.mobile) ? 500 : 300,
           renderWait: (gaBrowserSniffer.mobile) ? 500 : 0
         };


### PR DESCRIPTION
Based on user feedback, some layers contain 2 letter id's that need to be found. Not it's possible again.

@alcapat This is the user feedback that we just discussed.
