### PR TITLE
Use ng-class when possible

### DIFF
--- a/src/components/draw/partials/draw.html
+++ b/src/components/draw/partials/draw.html
@@ -1,9 +1,9 @@
 <div>
   <div class="ga-draw-buttons">
     <button ng-repeat="tool in options.tools"
-      ng-click="toggleTool(tool)"
-      title="{{tool.description | translate}}"
-      class="{{tool.cssClass}} {{options[tool.activeKey] ? 'active' : ''}}">
+            ng-click="toggleTool(tool)"
+            title="{{tool.description | translate}}"
+            class="{{tool.cssClass}}" ng-class="{'active': options[tool.activeKey]}">
       <i class="{{tool.iconClass}}"></i>
       <div translate>{{tool.title}}</div>
     </button>
@@ -29,7 +29,7 @@
       <div>
         <label translate>modify_icon_label</label>: 
         <div class="ga-choose-icon ga-icon-size-{{options.iconSize.value[0]}}">
-          <img class="{{(options.icon == i) ? 'ga-selected' : ''}}" 
+          <img ng-class="{'ga-selected': (options.icon == i)}" 
                draggable="false" 
                ng-click="options.icon = i" 
                ng-repeat="i in options.icons" 

--- a/src/components/importwms/partials/importwms.html
+++ b/src/components/importwms/partials/importwms.html
@@ -24,9 +24,10 @@
       <table class="table table-striped table-hover table-condensed">
         <tbody>
           <tr ng-repeat="layer in layers | orderBy:'Title':reverse"
-              class="
-              {{(layerSelected.Name == layer.Name) ? 'success ' : ''}}
-              {{(layerHovered.Name == layer.Name) ? 'pending ' : ''}}">
+              ng-class="{
+                'success': (layerSelected.Name == layer.Name),
+                'pending': (layerHovered.Name == layer.Name)
+              }">
             <td>
               <div class="icon-zoom-in" ng-click="zoomOnLayerExtent(layer)"></div>
             </td>

--- a/src/components/layermanager/partials/layermanager.html
+++ b/src/components/layermanager/partials/layermanager.html
@@ -1,6 +1,6 @@
 <ul>
   <li ng-if="!(filteredLayers = (layers | gaReverse | filter:layerFilter)).length" translate>no_layers_info</li>
-  <li ng-repeat="layer in filteredLayers" class="ga-layer-folded {{layer.time ? 'ga-layer-time-enabled' : ''}}">
+  <li ng-repeat="layer in filteredLayers" class="ga-layer-folded" ng-class="{'ga-layer-time-enabled': !!(layer.time)}">
     <button type="button" ng-click="removeLayerFromMap(layer)" class="btn btn-primary btn-xs">&times;</button>
     <label class="ga-checkbox">
       <input type="checkbox" ng-model="layer.visible" />

--- a/src/components/offline/partials/offline-bt.html
+++ b/src/components/offline/partials/offline-bt.html
@@ -1,3 +1,4 @@
-<button ng-if="!isIE9"  class="{{(hasOfflineData && !isDownloading) ? 'ga-active' : ''}}" 
+<button ng-if="!isIE9" 
+        ng-class="{'ga-active': (hasOfflineData && !isDownloading)}" 
         ng-hide="offline && !hasOfflineData"
         ng-click="onClick($event)"></button>

--- a/src/components/slider/partials/slider.html
+++ b/src/components/slider/partials/slider.html
@@ -3,11 +3,13 @@
     <span ng-repeat="data in dataList | orderBy:'value':false" 
         ng-style="assignDivisionStyle($index)"
         id="{{data.value}}"
-        class="ga-slider-bar-division 
-          {{($first) ? 'ga-slider-first ' : ''}}
-          {{($last) ? 'ga-slider-last ' : ''}}
-          {{(data.minor) ? 'ga-slider-minor' : ''}} 
-          {{(data.major) ? 'ga-slider-major' : ''}}"
+        class="ga-slider-bar-division"
+        ng-class="{
+          'ga-slider-first': ($first),
+          'ga-slider-last': ($last),
+          'ga-slider-minor': data.minor, 
+          'ga-slider-major': data.major
+        }"
         title="{{($last) ? translate2({value:'slider_last_title'}) : data.value}}"> 
       <span class="ga-slider-bubble" >{{data.value}}</span>
       <span class="ga-slider-available" ng-show="data.available"></span>

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -76,7 +76,15 @@
     <link rel="shortcut icon" type="image/x-icon" href="${versionslashed}img/favicon.ico"/>
   </head>
 
-  <body ng-class="[topicId, globals.searchFocused ? 'search-focused' : '', globals.touch ? 'touch' : '', globals.webkit ? 'webkit' : 'no-webkit', globals.offline ? 'offline' : 'online']">
+  <body class="{{topicId}}" 
+        ng-class="{
+          'search-focused': globals.searchFocused,
+          'touch': globals.touch, 
+          'webkit': globals.webkit, 
+          'no-webkit': !globals.webkit, 
+          'offline': golbals.offline,
+          'online': !globals.offline
+        }">
     <!-- The below conditional is ignored by >= IE10 and all other browsers -->
     <!--![if IE]>
       <script>
@@ -209,7 +217,7 @@
       </div>
     </div>
 
-    <div id="pulldown" ng-show="!globals.offline" class="{{(globals.catalogShown && globals.selectionShown) ? 'selection-and-catalog-shown' : ''}}">
+    <div id="pulldown" ng-show="!globals.offline" ng-class="{'selection-and-catalog-shown': (globals.catalogShown && globals.selectionShown)}">
       <div id="pulldown-content" class="panel-group content ${"in" if device == "desktop" else "collapse"}">
         <div class="panel">
           <a id="shareHeading" class="panel-heading accordion-toggle collapsed" data-toggle="collapse" data-parent="#pulldown-content" href="#share">
@@ -543,10 +551,13 @@
     </div><!-- end Feature Tree -->
 
 
-    <div class="popover homescreen" ng-if="globals.homescreen" ng-class="[
-        globals.homescreen ? 'visible' : '', 
-        globals.tablet ? 'bottom' : 'top',
-        globals.ios >= 8 ? 'tr' : 'tl']">
+    <div ng-if="globals.homescreen" class="popover homescreen"
+         ng-class="{
+           'visible': globals.homescreen, 
+           'bottom': globals.tablet,
+           'top': !globals.tablet,
+           'tr': (globals.ios >= 8)
+         }">
       <div class="arrow"></div>
       <h3 class="popover-title">
         <span translate>homescreen_title</span>


### PR DESCRIPTION
MInor PR, generalize the use of `ng-class` (improve code clarity)

Exhaustive list of components affected : 
- Draw (current selected icon and current selected tool)
- Slider (divisions)
- Homescreen popover (when displayed)
- Body tag
- Import WMS (layer selected or hovered in the list)
- LayerManager (layer has a timestamp or not)
- Offline button  (red when ther is offline data)
- CatalogTree (catalog and selection opened) 

I've tested all and that works as expected.

I've tested the display of homescreen popover on all devices I have on xcode (tablet,iphone) 
