### PR TITLE
Support multiple timestamps in featuresearch/featureidentify

### DIFF
--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -98,13 +98,20 @@
             var getLayersToQuery = function() {
               var ids = [];
               var timeenabled = [];
+              var timestamps = [];
               scope.filteredLayers.forEach(function(l) {
+                var ts = '';
+                if (l.time && l.time.substr(0, 4) != '9999') {
+                  ts = l.time.substr(0, 4);
+                }
                 ids.push(l.bodId);
                 timeenabled.push(l.timeEnabled);
+                timestamps.push(ts);
               });
               return {
                 ids: ids,
-                timeenabled: timeenabled
+                timeenabled: timeenabled,
+                timestamps: timestamps
               };
             };
 
@@ -214,12 +221,9 @@
                         ',' + extent[2] + ',' + extent[3],
                     type: 'featureidentify',
                     features: layersToQuery.ids.join(','),
-                    timeEnabled: layersToQuery.timeenabled.join(',')
+                    timeEnabled: layersToQuery.timeenabled.join(','),
+                    timeStamps: layersToQuery.timestamps.join(',')
                   };
-              if (currentYear) {
-                params.timeInstant = currentYear;
-              }
-
               url = url.replace('{Topic}', currentTopic);
               return {
                 url: url,

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -404,14 +404,12 @@
                         scope.searchableLayers.join(',');
                     var timeEnabled = '&timeEnabled=' +
                         scope.timeEnabled.join(',');
-                    var timeInstant = '';
-                    if (year) {
-                      timeInstant = '&timeInstant=' + year;
-                    }
+                    var timeStamps = '&timeStamps=' +
+                        scope.timeStamps.join(',');
                     url = options.applyTopicToUrl(url,
                         currentTopic);
                     url += queryText + searchableLayers + timeEnabled +
-                        bbox + lang + timeInstant;
+                        bbox + lang + timeStamps;
                     return url;
                   },
                   filter: function(response) {
@@ -561,14 +559,22 @@
 
             scope.$watchCollection('layers | filter:searchableLayersFilter',
                 function(layers) {
+              //TODO: this isn't updated when layers param (like 'time') changes
               var layerBodIds = [];
               var timeEnabled = [];
+              var timeStamps = [];
               angular.forEach(layers, function(layer) {
+                var ts = '';
+                if (layer.time && layer.time.substr(0, 4) != '9999') {
+                  ts = layer.time.substr(0, 4);
+                }
                 layerBodIds.push(layer.bodId);
                 timeEnabled.push(layer.timeEnabled);
+                timeStamps.push(ts);
               });
               scope.searchableLayers = layerBodIds;
               scope.timeEnabled = timeEnabled;
+              scope.timeStamps = timeStamps;
             });
 
             // We have to create a small workaround to get the


### PR DESCRIPTION
As discussed in the https://github.com/geoadmin/mf-geoadmin3/pull/1784, the feature tree and the search do not yet support multiple timestamps. This PR addresses it.

Note that it needs https://github.com/geoadmin/mf-chsdi3/pull/1083 to work. A back-end branch is setup and ready to be used for testing `gjn_multiyear_search`. Note that the chsdi3 branch needs to be merged before the timestamp branch gets into master.
