### PR TITLE
Improve rotation on mobile avoiding digest cycle

### DIFF
--- a/src/components/rotate/RotateDirective.js
+++ b/src/components/rotate/RotateDirective.js
@@ -10,23 +10,17 @@
       scope: {
         map: '=gaRotateMap'
       },
-      template: '<button ng-class="stateClass"></button>',
+      template: '<button></button>',
       link: function(scope, element, attrs) {
         var map = scope.map;
         var view = map.getView();
-
         var setButtonRotation = function(rotation) {
-          if (rotation != scope.rotation) {
-            scope.$apply(function() {
-              scope.stateClass = (rotation == 0) ? '' : 'ga-rotate-enabled';
-            });
-          }
           var rotateString = 'rotate(' + rotation + 'deg)';
           element.css({
             'transform': rotateString,
             '-ms-transform': rotateString,
             '-webkit-transform': rotateString
-          });
+          }).toggleClass('ga-rotate-enabled', !(rotation == 0));
         };
 
         // Button is rotated according to map rotation

--- a/src/components/rotate/style/rotate.less
+++ b/src/components/rotate/style/rotate.less
@@ -6,3 +6,4 @@
     display: block;
   }
 }
+


### PR DESCRIPTION
Rotation is very slow on mobile and with more than one layer is nearly impossible.

This PR removes the calls of digest cycle.

Test [here](http://mf-geoadmin3.dev.bgdi.ch/dev_rotate3/) 
