### PR TITLE
Don't export measurement azimuth help circle

### DIFF
--- a/src/components/ExportKmlService.js
+++ b/src/components/ExportKmlService.js
@@ -65,7 +65,11 @@
             var myStyle = new ol.style.Style(newStyle);
             clone.setStyle(myStyle);
 
-            exportFeatures.push(clone);
+            //We silently ignore Circle elements as they are not supported
+            //in kml
+            if (f.getGeometry().getType() !== 'Circle') {
+              exportFeatures.push(clone);
+            }
           });
 
           if (exportFeatures.length > 0) {


### PR DESCRIPTION
This is a workaround for https://github.com/geoadmin/mf-geoadmin3/issues/1742

The trouble seems to be that features of type ol.geom.Circle can't be exported using ol3. At least, an exception is thrown when trying to export the cloned circle.

@oterral As this is hacky, could you shortly look for another solution? If not, please review/merge this.
