### PR TITLE
Remove the export kml button in IE9

### DIFF
--- a/src/components/ExportKmlService.js
+++ b/src/components/ExportKmlService.js
@@ -113,7 +113,9 @@
             isFileSaveSupported = !!new Blob;
           } catch (e) {
           }
-          return isFileSaveSupported && !gaBrowserSniffer.mobile;
+          return isFileSaveSupported &&
+                 !gaBrowserSniffer.mobile &&
+                 (isNaN(gaBrowserSniffer.msie) || gaBrowserSniffer.msie > 9);
         };
       };
 


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/1866

(IE9 does not support file save functionality and thus can't export kml. Note however, that a drawing can be send by email in the feedback tool)
