### PR TITLE
Deploying a snapshot will update the cache/version number

### DIFF
--- a/scripts/deploysnapshot.sh
+++ b/scripts/deploysnapshot.sh
@@ -14,6 +14,13 @@ fi
 
 SNAPSHOTDIR=/var/www/vhosts/mf-geoadmin3/private/snapshots/$1
 
+# we assure that snapshot is re-build with new version
+cwd=$(pwd)
+cd $SNAPSHOTDIR/geoadmin/code/geoadmin
+KEEP_VERSION=false
+make all
+cd $cwd
+
 sudo -u deploy deploy -r deploy/deploy.cfg $2 $SNAPSHOTDIR
 
 T="$(($(date +%s)-T))"


### PR DESCRIPTION
This PR creates a new version whenever we deploy a snapshot using the `make deployint SNAPSHOT=***`, `make deployprod SNAPSHOT=****` or `./scripts/deploysnapshot.sh int/prod ****` commands because that's usually what we want.

Note that we need to have the same version number on each instance of a given staging because otherwise, our offline/appcache mechanism will fail.

@procrastinatio Does this make sense?
