### PR TITLE
De-activate IE11 tests for now (browserstack problem)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "karma": "0.8.5",
     "ng-annotate": "0.2.0",
     "commander": "2.2.0",
-    "browserstack": "1.0.1",
-    "browserstack-webdriver": "2.39.2"
+    "browserstack": "1.1.0",
+    "browserstack-webdriver": "2.41.1"
   }
 }
 

--- a/test/selenium/browsers.js
+++ b/test/selenium/browsers.js
@@ -34,7 +34,7 @@ var capabilities = [
     create('Windows', '7', '1280x1024', 'Chrome', '36.0'),
     create('Windows', '7', '1280x1024', 'IE', '9.0'),
     create('Windows', '7', '1280x1024', 'IE', '10.0'),
-    create('Windows', '7', '1280x1024', 'IE', '11.0'),
+//    create('Windows', '7', '1280x1024', 'IE', '11.0'),
     create('Windows', '7', '1280x1024', 'Firefox', '30.0'),
     create('Windows', '7', '1280x1024', 'Firefox', '31.0'),
     create('Windows', '7', '1280x1024', 'Safari', '5.1'),


### PR DESCRIPTION
Browserstack is having troubles with win7/IE11 which causes our tests to fail. I already informed them, no response yet.

Meanwhile, I removed the tests on IE11 with this PR until this is resolved on browserstacks side. I also update to latest version of browsertack libraries.

Please review/merge as soon as possible.
