### PR TITLE
Print A3 faking resolution

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -27,7 +27,7 @@
 
         // default values:
         $scope.layout = data.layouts[0];
-        $scope.dpi = data.dpis[0];
+        $scope.dpi = data.dpis;
         $scope.scales = data.scales;
         $scope.scale = data.scales[5];
         $scope.options.legend = false;
@@ -652,7 +652,8 @@
           rotation: -((view.getRotation() * 180.0) / Math.PI),
           app: 'config',
           lang: lang,
-          dpi: that.dpi.value,
+          //use a function to get correct dpi according to layout (A4/A3)
+          dpi: getDpi(that.layout.name, that.dpi),
           layers: encLayers,
           legends: encLegends,
           enableLegends: (encLegends && encLegends.length > 0),
@@ -680,6 +681,14 @@
         });
       });
     };
+
+    function getDpi(layoutName, dpiConfig) {
+      if (/a4/i.test(layoutName) && dpiConfig.length > 1) {
+        return dpiConfig[1].value;
+      } else {
+        return dpiConfig[0].value;
+      }
+    }
 
     var getPrintRectangleCenterCoord = function() {
       // Framebuffer size!!


### PR DESCRIPTION
Here we use now 2 dpi settings values instead of 1 (one for A4 and one for A3), comming from the config.yaml in mf-chsdi3. See PR [#1125](https://github.com/geoadmin/mf-chsdi3/pull/1125)

Seems tricky to set dpi setting as a property of the layout, therefore I created the function getDpi to retrieve the good one according to A4 or A3 layout name. 

Nevertheless if we set only one dpi value in the config.yaml, it keeps going with it.
