### PR TITLE
Fix tablet switch mode from coming too early

### DIFF
--- a/src/style/app.less
+++ b/src/style/app.less
@@ -30,7 +30,7 @@
 @header-height: 89;
 @footer-height: 26;
 @small-header-height: 50;
-@screen-sm-max-height: 630px;
+@screen-sm-max-height: 600px;
 @tooltip-bg: #999;
 @pulldown-width: 320;
 @control-btn-size: 44;


### PR DESCRIPTION
[Test Here](mf-geoadmin3.dev.bgdi.ch/ltpoa/)

Switch your screen res to 1366x768
open mozilla with 3 toolbars
geoadmin should still be in desktop mode

Fix #1842
