### PR TITLE
Add widgets permalink parameter to open widgets on startup

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -140,8 +140,10 @@
         touch: gaBrowserSniffer.touchDevice,
         webkit: gaBrowserSniffer.webkit,
         ios: gaBrowserSniffer.ios,
-        offline: gaNetworkStatus.offline
+        offline: gaNetworkStatus.offline,
+        feedbackPopupShown: /feedback/g.test(gaPermalink.getParams().widgets)
       };
+      gaPermalink.deleteParam('widgets');
 
       $rootScope.$on('gaNetworkStatusChange', function(evt, offline) {
         $scope.globals.offline = offline;


### PR DESCRIPTION
First widget we support to open on startup: feedback.

`widgets=feedback`
