### PR TITLE
Add ability to flush varnish. Flush varnish on deploy (inside our deploy...

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,12 @@ Per default, the API used in the **main** instance of mf-chsdi3. If you want
 to target a specific branch of mf-chsdi3, please adapt the `API_URL` variable
 in the `rc_branch.mako` file on **your branch**
 
+# Flushing varnish
+
+You can flush varnish instances manually.
+
+    ./scripts/flushvarnish.sh varnihs_host_ip api_host
+
+Where `varnish_host_ip` is the ip of the varnish server and api_host is the hostname of the url you want to flush. e.g. mf-chsdi3.dev.bgdi.ch for dev and api3.geo.admin.ch for prod.
+
+

--- a/rc_dev
+++ b/rc_dev
@@ -3,3 +3,4 @@ export DEPLOY_TARGET=dev
 export API_URL=//mf-chsdi3.dev.bgdi.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch
+export VARNISH_HOSTS=(ip-10-220-4-40.eu-west-1.compute.internal)

--- a/rc_int
+++ b/rc_int
@@ -3,3 +3,4 @@ export DEPLOY_TARGET=int
 export API_URL=//mf-chsdi3.int.bgdi.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.int.bgdi.ch
+export VARNISH_HOSTS=(ip-10-220-6-55.eu-west-1.compute.internal)

--- a/rc_prod
+++ b/rc_prod
@@ -3,3 +3,4 @@ export DEPLOY_TARGET=prod
 export API_URL=//api3.geo.admin.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=http://map.geo.admin.ch
+export VARNISH_HOSTS=(ip-10-220-5-136.eu-west-1.compute.internal ip-10-220-6-61.eu-west-1.compute.internal)

--- a/scripts/deploydev.sh
+++ b/scripts/deploydev.sh
@@ -35,6 +35,13 @@ sudo apache2ctl graceful
 
 echo "Deployed branch $GITBRANCH to dev main."
 
+echo "Flushing varnishes"
+for VARNISHHOST in ${VARNISH_HOSTS[@]}
+do
+  ./scripts/flushvarnish.sh $VARNISHHOST "${API_URL////}"
+  echo "Flushed varnish at: ${VARNISHHOST}"
+done
+
 # create a snapshot
 if [ $CREATE_SNAPSHOT == 'true' ]; then
   sudo -u deploy deploy -c deploy/deploy.cfg $SNAPSHOTDIR

--- a/scripts/deploysnapshot.sh
+++ b/scripts/deploysnapshot.sh
@@ -23,6 +23,21 @@ cd $cwd
 
 sudo -u deploy deploy -r deploy/deploy.cfg $2 $SNAPSHOTDIR
 
+VARNISH_FLUSH_FILE=rc_int
+
+if [ "$2" == "prod" ]
+then
+  VARNISH_FLUSH_FILE=rc_prod
+fi
+
+echo "Flushing varnishes"
+source $VARNISH_FLUSH_FILE
+for VARNISHHOST in ${VARNISH_HOSTS[@]}
+do
+  ./scripts/flushvarnish.sh $VARNISHHOST "${API_URL////}"
+  echo "Flushed varnish at: ${VARNISHHOST}"
+done
+
 T="$(($(date +%s)-T))"
 
 printf "Deploy time: %02d:%02d:%02d\n" "$((T/3600%24))" "$((T/60%60))" "$((T%60))"

--- a/scripts/flushvarnish.sh
+++ b/scripts/flushvarnish.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# First parameter is varnish host
+# Second parameter is base url to flush
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+[ "$#" -eq 2 ] || die "2 argument required, $# provided"
+
+ssh -l ${USER} $1 "sudo varnish-ban.sh 'req.http.host == $2 && req.url ~ \"^/[0-9]+/\"'"
+


### PR DESCRIPTION
This is to address https://github.com/geoadmin/mf-geoadmin3/issues/1920

Note that flushing varnish is done inside our deploy scripts. So this does not work if you deploy by hand.

See the README about the deployment.

(We can't put it in the hook as the deploy user can't access the varnish instances)
