### PR TITLE
Hide visible labels before translated

### DIFF
--- a/src/components/fullscreen/FullscreenDirective.js
+++ b/src/components/fullscreen/FullscreenDirective.js
@@ -17,7 +17,7 @@
         map: '=gaFullscreenMap'
       },
       template: "<a href='#' ng-if='fullscreenSupported' " +
-        "ng-click='click()' translate translate-cloak>full_screen</a>",
+        "ng-click='click()' translate>full_screen</a>",
       link: function(scope, element, attrs) {
         var fullScreenCssClass = 'ga-full-screen';
         var inputsForbidCssClass = 'ga-full-screen-no-inputs';

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -157,7 +157,7 @@ itemscope itemtype="http://schema.org/WebApplication"
             ga-background-layer-selector-map="map"></div>
         </div>
         <div id="toptools">
-          <div ga-fullscreen ga-fullscreen-map="map"></div>&nbsp;&nbsp;
+          <div ga-fullscreen ga-fullscreen-map="map" translate-cloak></div>&nbsp;&nbsp;
           <a href="" ng-click="globals.feedbackPopupShown = !globals.feedbackPopupShown">
             <span ng-class="{'selected': globals.feedbackPopupShown}" translate translate-cloak>problem_announcement</span>
           </a>&nbsp;&nbsp;


### PR DESCRIPTION
Related to issue #1927

[Test](http://mf-geoadmin3.dev.bgdi.ch/kan_hide_labels_bef_translated/src)

Actual: 
![wo-translate-cloak](https://cloud.githubusercontent.com/assets/8038575/5315101/8585d052-7c79-11e4-9c3e-6b20a72624f2.png)

Result: 
![w-translate-cloak](https://cloud.githubusercontent.com/assets/8038575/5315193/aa2a8212-7c7a-11e4-9d8e-a34f6f6c3970.png)

Seems not supported on IE. Still have to adapt on mobile.
