### PR TITLE
Fixing browserstack for IE11

### DIFF
--- a/test/selenium/browsers.js
+++ b/test/selenium/browsers.js
@@ -20,7 +20,8 @@ var create = function(os, osver, res, browser, brover) {
     'browser' : browser,
     'browser_version' : brover,
     'browserstack.user' : process.env.BROWSERSTACK_USER,
-    'browserstack.key' : process.env.BROWSERSTACK_KEY
+    'browserstack.key' : process.env.BROWSERSTACK_KEY,
+    'browserstack.bfcache' : '0'
   };
 }
 


### PR DESCRIPTION
According to browserstack support, this is needed to circumvent some IE WebDriver bug for IE11.

I've tested it locally and it worked fine.
