### PR TITLE
Fix closure lib to ol3 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,9 +292,11 @@ $(addprefix .build-artefacts/annotated/, $(SRC_JS_FILES) src/TemplateCacheModule
 	mkdir -p .build-artefacts
 	virtualenv --no-site-packages $@
 
+## Check compatibility with ol3 https://github.com/openlayers/ol3/blob/master/closure-util.json
 .build-artefacts/closure-library:
 	mkdir -p .build-artefacts
 	git clone http://github.com/google/closure-library/ $@
+	cd $@ && git reset --hard fb35d5232edef340dd9a7c6e479556829d0fa452 && cd ../../
 
 .build-artefacts/closure-compiler/compiler.jar: .build-artefacts/closure-compiler/compiler-latest.zip
 	unzip $< -d .build-artefacts/closure-compiler


### PR DESCRIPTION
At the moment we are relying on the master version of closure library. A recent update broke the app in test. Maybe this commit https://github.com/google/closure-library/commit/bd304248f8bf0254d9b99d8e5b071c8d7dd0212c#diff-97793ad6fce25c1435ef52bf41ea519b

This PR fixes this issue and relies on the same version than ol3.
https://github.com/openlayers/ol3/blob/master/closure-util.json

Please review and merge ASAP.

To test:
`make cleanall all`
