### PR TITLE
Fix bypass for window.printOnLoad if onLoad undefined

### DIFF
--- a/src/components/PrintService.js
+++ b/src/components/PrintService.js
@@ -13,7 +13,7 @@
         };
 
         var buildHtml = function(body, head, onLoad) {
-          window.printOnLoad = onLoad;
+          window.printOnLoad = onLoad || function() {};
           var html = '';
           html += '<html><head>';
           html += head || getStylesheetString();


### PR DESCRIPTION
Avoid error if onLoad is not defined for other print as print profile
