### PR TITLE
Disable varnish flush for dev instance

### DIFF
--- a/rc_dev
+++ b/rc_dev
@@ -3,4 +3,4 @@ export DEPLOY_TARGET=dev
 export API_URL=//mf-chsdi3.dev.bgdi.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch
-export VARNISH_HOSTS=(ip-10-220-4-40.eu-west-1.compute.internal)
+export VARNISH_HOSTS=()


### PR DESCRIPTION
We disabel the flush on dev instance. This will hopefully fix jenkins build too.

Self-merge.
