### PR TITLE
WIP Use clientX/Y verification only for IE

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -233,7 +233,8 @@
             // pointerup with the exact same coordinates of the pointerdown
             // event. to avoid a 'false' touchmove event to be dispatched,
             // we test if the pointer effectively moved.
-            if (down && (evt.clientX != down.clientX ||
+            if (down && (!gaBrowserSniffer.msie ||
+                evt.clientX != down.clientX ||
                 evt.clientY != down.clientY)) {
               moving = true;
             }


### PR DESCRIPTION
clientX/Y properties  doesn't exist on new browser.

Fix a bug mentioned by @loicgasser: when we quickly drag the map the tooltip was requested.

[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_tooltip_mobile/mobile.html?X=190000.00&Y=660000.00&zoom=1&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&mobile=true&layers=ch.bafu.biogeographische_regionen&layers_opacity=0.75)
