### PR TITLE
Remove swipe_ratio parameter when only one layer is visible

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1037,6 +1037,11 @@
         selected: function(layer) {
           return layer.displayInLayerManager;
         },
+
+        selectedAndVisible: function(layer) {
+          return layer.displayInLayerManager && layer.visible;
+        },
+
         /**
          * Keep only time enabled layer
          */

--- a/src/components/swipe/SwipeDirective.js
+++ b/src/components/swipe/SwipeDirective.js
@@ -25,7 +25,7 @@
         link: function(scope, elt, attrs, controller) {
           scope.layers = scope.map.getLayers().getArray();
           // Use only layers in layer manager
-          scope.layerFilter = gaLayerFilters.selected;
+          scope.layerFilter = gaLayerFilters.selectedAndVisible;
           var draggableElt = elt.find('[ga-draggable]');
           var arrowsElt = elt.find('.ga-swipe-arrows');
           var layerLabelElt = elt.find('.ga-swipe-layer-label');
@@ -117,6 +117,7 @@
 
             if (!scope.isActive || olLayers.length == 0) {
               elt.hide();
+              updatePermalink();
               return;
             }
 
@@ -140,14 +141,15 @@
               ];
             }
             elt.show();
+            updatePermalink(scope.ratio);
             scope.map.render();
           };
 
           // Active the swipe adding events.
           var activate = function() {
             scope.ratio = scope.ratio || 0.5;
-            draggableElt.css({left: calculateOffsetLeft()});
             updatePermalink(scope.ratio);
+            draggableElt.css({left: calculateOffsetLeft()});
             layersDeregisterFn = scope.$watchCollection(
                 'layers | filter:layerFilter', refreshComp);
             elt.on(eventKey.start, dragStart);
@@ -161,14 +163,13 @@
             if (layersDeregisterFn) {
               layersDeregisterFn();
             }
-            updatePermalink();
           };
 
           // Boolean determining if the swipe is activated from the permalink
           // parameter
           var fromPermalink = false;
 
-          // Initalize component with permalink paraneter
+          // Initalize component with permalink parameter
           if (!angular.isDefined(scope.isActive) &&
              angular.isDefined(gaPermalink.getParams().swipe_ratio)) {
             scope.ratio = parseFloat(gaPermalink.getParams().swipe_ratio);


### PR DESCRIPTION
Fix #1409 

Ths PR remove the swipe_ratio parameter form the permalink when there is no layer to compare. 

So permalink with a swipe_ratio paremeter like in   #1409  shouldn't be possible, I guess if the user add it manually in the permalink he knows what he's doing.

[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_swipe_remove)
