### PR TITLE
Use undefined year value

### DIFF
--- a/src/components/timeselector/TimeSelectorDirective.js
+++ b/src/components/timeselector/TimeSelectorDirective.js
@@ -190,7 +190,7 @@
 
           //Apply the year selected
           var applyNewYear = function(year) {
-            var newYear = '' + year;
+            var newYear = (year) ? '' + year : year;
 
             // Only valid values are allowed: undefined, null or
             // minYear <= newYear <= maxYear


### PR DESCRIPTION
Activate/deactivate the time selector and see the time is removed correctly  now 

[test](http://mf-geoadmin3.dev.bgdi.ch/fix_time/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=206014.89&Y=654676.59&zoom=1&layers_timestamp=20121231&time=2012&layers=ch.swisstopo.zeitreihen)
