### PR TITLE
Fix topic selection translations

### DIFF
--- a/src/components/topic/partials/topic.html
+++ b/src/components/topic/partials/topic.html
@@ -1,7 +1,7 @@
 <div>
   <div class="ga-topic-item" ng-class="{'ga-topic-active': topic.id == activeTopic}" ng-repeat="topic in
   topics" ng-click="setActiveTopic(topic.id)" data-original-title="{{topic.tooltip | translate}}">
-    <div>{{topic.label}}</div>
+    <div translate>{{topic.id}}</div>
     <img ng-src="{{topic.thumbnail}}" alt="" height="60" width="110" draggable="false" >
   </div>
 </div>


### PR DESCRIPTION
This fixes the topic selector translations for desktop.

Note: mobile still does not work properly on initial page load. @loicgasser could you have a look for mobile?
