### PR TITLE
Fix topic selector on mobile

### DIFF
--- a/src/components/topic/partials/topic.select.html
+++ b/src/components/topic/partials/topic.select.html
@@ -1,2 +1,2 @@
-<select ng-model="activeTopic" ng-options="l.id as l.label for l in topics">
+<select ng-model="activeTopic" ng-options="l.id as (l.id | translate) for l in topics">
 </select>


### PR DESCRIPTION
This should fix the topic selection on mobile in a similar manner as on desktop.

@loicgasser We could then remove the diretive changes introduced in https://github.com/geoadmin/mf-geoadmin3/pull/1937
