### PR TITLE
Fix browserstack tests

### DIFF
--- a/test/selenium/basic_test.js
+++ b/test/selenium/basic_test.js
@@ -1,7 +1,7 @@
 var webdriver = require('browserstack-webdriver');
 var assert = require('assert');
 
-var QUERYSTRING_OF_BERN = "X=200393.27&Y=596671.16";
+var QUERYSTRING_OF_BERN = "X=200393.28&Y=596671.16";
 
 var runTest = function(cap, driver, target){
   var TIMEOUT = 20000;


### PR DESCRIPTION
It seems like the coordinates of the Bern entry in the swissserach have changed slightly. So tests needs adaption.

Self-merge as it's failing tests only.
