### PR TITLE
Profile tooltip: correct unit update

### DIFF
--- a/src/components/profile/ProfileDirective.js
+++ b/src/components/profile/ProfileDirective.js
@@ -54,6 +54,7 @@
               } else {
                 profile.update(data);
                 profile.updateLabels();
+                scope.unitX = profile.unitX;
               }
             });
 


### PR DESCRIPTION
Fix #1821

Allow to get a correct unit in profile tooltip when a profile is modified. This was the lightest way as this tooltip does not call the updateLabel function in [ProfileService.js](mf-geoadmin3/src/components/profile/ProfileService.js).

[Testlink](http://mf-geoadmin3.dev.bgdi.ch/kan_profile_correct_unit_update/src/)
