### PR TITLE
Fix Html interpretation in help

### DIFF
--- a/src/components/help/HelpDirective.js
+++ b/src/components/help/HelpDirective.js
@@ -24,12 +24,12 @@
    * <span ga-help="12,13,14"></div>
   */
   module.directive('gaHelp',
-      function($rootScope, gaHelpService, gaPopup) {
+      function($rootScope, $sce, gaHelpService, gaPopup) {
         var popupContent = '<div class="ga-help-content" ' +
                                 'ng-repeat="res in options.results">' +
-                             '<h2 ng-bind="res[1]"></h2>' +
-                             '<div ng-bind="res[2]"></div>' +
-                             '<img ng-src="{{res[4]}}" ' +
+                             '<h2 ng-bind-html="res[0]"></h2>' +
+                             '<div ng-bind-html="res[1]"></div>' +
+                             '<img ng-src="{{res[2]}}" ' +
                                   'draggable="false"/>' +
                            '</div>';
 
@@ -101,7 +101,11 @@
                   };
                   for (i = 0; i < len; i++) {
                     gaHelpService.get(ids[i]).then(function(res) {
-                      results.push(res.rows[0]);
+                      results.push([
+                        $sce.trustAsHtml(res.rows[0][1]),
+                        $sce.trustAsHtml(res.rows[0][2]),
+                        res.rows[0][4]
+                      ]);
                       resultReceived();
                     }, function() {
                       resultReceived();

--- a/src/components/help/HelpService.js
+++ b/src/components/help/HelpService.js
@@ -58,10 +58,7 @@
         //we only support certain languages
         function fixLang(langa) {
           var l = langa;
-          if (langa == 'it') {
-            l = 'fr';
-          } else if (langa == 'en' ||
-                     langa == 'rm') {
+          if (langa == 'rm') {
             l = 'de';
           }
           return l;

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -472,7 +472,7 @@ itemscope itemtype="http://schema.org/WebApplication"
 % if device == 'desktop':
     <!-- Popup: Import WMS -->
     <div ga-popup="globals.importWmsPopupShown"
-         ga-popup-options="{title:'import_wms', help:'63'}"
+         ga-popup-options="{title:'import_wms', help:'62'}"
          ga-draggable=".popover-title"
          id="import-wms-popup" >
       <div ng-controller="GaImportWmsController">
@@ -485,7 +485,7 @@ itemscope itemtype="http://schema.org/WebApplication"
 
     <!-- Popup: Import KML -->
     <div ga-popup="globals.importKmlPopupShown"
-         ga-popup-options="{title:'import_kml', help:'64'}"
+         ga-popup-options="{title:'import_kml', help:'63'}"
          ga-draggable=".popover-title"
          id="import-kml-popup" >
       <div ng-controller="GaImportKmlController">


### PR DESCRIPTION
Fix #1950, #1838 and #1896

Solve html binding for help
(inclusive sce validation)
Allow it/en translations
Fix wms and kml help popups

Test [here](http://mf-geoadmin3.dev.bgdi.ch/ltpoa/) 
