### PR TITLE
CSS: adapt profile box width when built

### DIFF
--- a/src/js/MeasureController.js
+++ b/src/js/MeasureController.js
@@ -146,9 +146,9 @@
               panel = $('.ga-measure-panel');
               panelBt =  $('.ga-measure-buttons-panel');
             }
-            // 69 padding and margins 
+            // 62 padding and margins 
             $scope.options.profileOptions.width = win.width() - panel.width() -
-                panelBt.width() - 69;
+                panelBt.width() - 62;
             $rootScope.$emit('gaProfileDataUpdated', null, [
               $scope.options.profileOptions.width,
               $scope.options.profileOptions.height


### PR DESCRIPTION
Fix #1984 

[Testlink](http://mf-geoadmin3.dev.bgdi.ch/kan_css_profile_box)