### PR TITLE
[Query Tool] Only allow searchable layers in query tool

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1066,6 +1066,15 @@
                  gaLayers.getLayerProperty(layer.bodId, 'selectbyrectangle');
         },
         /**
+         * Searchable layers
+         */
+        searchable: function(layer) {
+          return layer.displayInLayerManager &&
+                 layer.visible &&
+                 layer.bodId &&
+                 gaLayers.getLayerProperty(layer.bodId, 'searchable');
+        },
+        /**
          * Keep only background layers
          */
         background: function(layer) {

--- a/src/components/query/QueryDirective.js
+++ b/src/components/query/QueryDirective.js
@@ -18,6 +18,7 @@
     var stored;
     $scope.queryType = 1; // Filter attributes
     $scope.searchableLayers = [];
+    $scope.selectByRectangleLayers = [];
     $scope.queriesPredef = [];
     $scope.filters = [];
 
@@ -181,7 +182,7 @@
         var geom = $scope.geometry.getExtent();
         var features = [];
         gaQuery.getLayersFeaturesByBbox($scope,
-            $scope.searchableLayers,
+            $scope.selectByRectangleLayers,
             geom
         ).then(function(layerFeatures) {
           features = features.concat(layerFeatures);
@@ -209,7 +210,7 @@
         var lang = $translate.use();
         var features = [];
         angular.forEach(
-            $scope.searchableLayers,
+            $scope.selectByRectangleLayers,
             function(layer) {
               gaQuery.getLayerIdentifyFeatures(
                   $scope,
@@ -285,7 +286,7 @@
             $scope.geometry.getExtent().join(',') + ', 21781), 0)';
         var features = [];
         angular.forEach(
-            $scope.searchableLayers,
+            $scope.selectByRectangleLayers,
             function(layer) {
               gaQuery.getLayerFeatures(
                   $scope,
@@ -352,8 +353,16 @@
 
     // Watcher/listener
     $scope.layers = $scope.map.getLayers().getArray();
-    $scope.layerFilter = gaLayerFilters.selectByRectangle;
-    $scope.$watchCollection('layers | filter:layerFilter', function(layers) {
+    $scope.selectByRectangleFilter = gaLayerFilters.selectByRectangle;
+    $scope.$watchCollection('layers | filter:selectByRectangleFilter',
+        function(layers) {
+      $scope.selectByRectangleLayers = layers;
+      $scope.search();
+    });
+
+    $scope.searchableFilter = gaLayerFilters.searchable;
+    $scope.$watchCollection('layers | filter:searchableFilter',
+        function(layers) {
       $scope.searchableLayers = layers;
 
       // Load new list of predefines queries and queryable attributes
@@ -461,7 +470,7 @@
             scope.isActive = true;
             boxFeature.setGeometry(evt.target.getGeometry());
             scope.geometry = boxFeature.getGeometry();
-            if (scope.searchableLayers.length == 0) {
+            if (scope.selectByRectangleLayers.length == 0) {
               scope.$apply();
             } else {
               scope.searchByGeometry();

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -550,13 +550,7 @@
                 }
               });
 
-            scope.searchableLayersFilter = function(layer) {
-              var layerBodId = layer.bodId;
-              return gaLayerFilters.selected(layer) &&
-                     layer.visible &&
-                     angular.isDefined(layerBodId) &&
-                     gaLayers.getLayerProperty(layerBodId, 'searchable');
-            };
+            scope.searchableLayersFilter = gaLayerFilters.searchable;
 
             scope.$watchCollection('layers | filter:searchableLayersFilter',
                 function(layers) {


### PR DESCRIPTION
This is to address https://github.com/geoadmin/mf-geoadmin3/issues/2019

Note ( @cedricmoullet  @ltclm ): we have a conflict. `ch.bazl.luftfahrthindernis` is not marked as a searchable layer yet in the db, so with this PR, we can't use the query tool with this layer (haha). So we would need to adapt that. But this would mean that we need to have a sphinx index also for it to be searchable in the search box (as all searchable layers have), but are we ready for this with sphinx? (data is updated on a regular basis).

Alternatively, we could use yet another new flag...but not sure about that, as we already have many quite similar (e.g. selectbyrectangle flag and queryable flag)