### PR TITLE
[Zeitreihen] Force default timestamp for zeitreihen layer

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -875,6 +875,9 @@
                 'timeBehaviour');
             yearStr = (timeBehaviour === 'all' || timestamps.length == 0) ?
                 undefined : timestamps[0];
+            if (bodId == 'ch.swisstopo.zeitreihen') {
+              yearStr = '18641231';
+            }
           }
 
           for (var i = 0, ii = timestamps.length; i < ii; i++) {


### PR DESCRIPTION
This is for https://github.com/geoadmin/mf-geoadmin3/issues/1928

I consider this a dirty hack. We should come up with a solution for layers that don't have the last timestamp as default timestamp.

We already have the 'timeBehaviour' parameter (with `all` and `last` settings) which we could extend to include a specific timestamp to be transmitted with the layers configuration.