### PR TITLE
Restore selected predefined query when the visibility of a layer change

### DIFF
--- a/src/components/query/QueryDirective.js
+++ b/src/components/query/QueryDirective.js
@@ -374,6 +374,13 @@
                 });
               });
             });
+
+            // Apply a predefined query if exist
+            if ($scope.queryPredef &&
+                $scope.queryPredef.id == query.id &&
+                $scope.queryPredef.layer == layer) {
+              $scope.applyQueryPredef($scope.queryPredef);
+            }
           });
           predef = predef.concat(queries);
         }


### PR DESCRIPTION
Fix #2005

[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_fix_2005/?lang=fr&topic=aviation&bgLayer=ch.swisstopo.pixelkarte-grau&X=145897.52&Y=592930.03&zoom=4&catalogNodes=1379,1381,1514&layers=ch.bazl.luftfahrthindernis,ch.swisstopo.fixpunkte-hfp1)