### PR TITLE
Fix display default input text value for a predefined query on IE9

### DIFF
--- a/src/components/PlaceholderDirective.js
+++ b/src/components/PlaceholderDirective.js
@@ -50,6 +50,12 @@
           if (elt.val() == '') {
             displayPlaceholder(elt);
           }
+        }).change(function(evt) {
+          var elt = $(evt.target);
+          if (elt.val() != elt.attr('placeholder')) {
+            elt.css('color', 'inherit');
+            isPlaceHolderDisplayed = false;
+          }
         });
 
         attrs.$observe('placeholder', function() {

--- a/src/components/query/QueryDirective.js
+++ b/src/components/query/QueryDirective.js
@@ -531,6 +531,12 @@
           if (data) {
             data.destroy();
           }
+          if (filter.value && gaBrowserSniffer.msie <= 9) {
+            // We manually set then trigger a change event to update correctly
+            // the placeholder directive
+            input.val(filter.value);
+            input.change();
+          }
           if (filter.attribute && filter.attribute.inputType == 'date') {
             input.datetimepicker({
               pickDate: true,


### PR DESCRIPTION
Fix  #2045

Test [here](http://mf-geoadmin3.dev.bgdi.ch/teo_fix_ie9/?lang=fr&topic=aviation&bgLayer=ch.swisstopo.pixelkarte-grau&X=190000.00&Y=660000.00&zoom=1&catalogNodes=1379,1381,1514&layers=ch.bazl.luftfahrthindernis)

It's a little bit hackish, I think it could be better.
