### PR TITLE
Display features after closing the tooltip

### DIFF
--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -91,19 +91,26 @@
             var fromMouseDown = false;
             scope.tree = {};
 
+            var drawFeature = function(f) {
+              loadGeojson(scope, f).then(function() {
+                if (f.geojson) {
+                  gaPreviewFeatures.add(map,
+                      parser.readFeature(f.geojson));
+                }
+              });
+            };
+
+            // Draw the current results
+            var drawFeatures = function() {
+              for (var i = 0, ii = scope.features.length; i < ii; i++) {
+                drawFeature(scope.features[i]);
+              }
+            };
+
             var updateTree = function(features) {
               gaPreviewFeatures.clearHighlight();
               gaPreviewFeatures.clear(map);
               var res = features, tree = {};
-
-              var drawFeature = function(f) {
-                loadGeojson(scope, f).then(function() {
-                  if (f.geojson) {
-                    gaPreviewFeatures.add(map,
-                        parser.readFeature(f.geojson));
-                  }
-                });
-              };
 
               if (features) {
                 for (var i = 0, li = res.length; i < li; i++) {
@@ -172,6 +179,7 @@
                     onCloseCB: function() {
                       if (scope.isFeatureSelected(feature)) {
                         featureSelected = null;
+                        drawFeatures();
                       }
                     }
                   });

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -550,12 +550,11 @@ itemscope itemtype="http://schema.org/WebApplication"
               <div ng-show='printInProgress' class='pull-right'>{{printProgressPercentage}}%</div>
             </a>
             <div id="collapseTwo"
-                 class="panel-collapse collapse"
-                 ng-switch="options.features.length">
-              <div ng-switch-when="0" class="panel-body">
+                 class="panel-collapse collapse">
+              <div ng-show="options.features.length == 0" class="panel-body">
                 <div class="ga-no-result" translate>no_feature_results</div>
               </div>
-              <div ng-switch-default
+              <div ng-show="options.features.length > 0"
                    ga-featuretree 
                    ga-featuretree-map="map"
                    ga-featuretree-options="options" 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -542,7 +542,7 @@ itemscope itemtype="http://schema.org/WebApplication"
               </div>
             </div>
           </div>
-          <div class="panel panel-default" ga-collapsible-trigger="(result.length > 0)">
+          <div class="panel panel-default">
             <a class="panel-heading collapsed" data-toggle="collapse" data-parent="#accordion" href="#accordion-tree"
                ga-collapsible-show="options.featuresShown">
               <span translate>items</span> ({{options.features.length}})

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -530,10 +530,10 @@ itemscope itemtype="http://schema.org/WebApplication"
            id="featuretree-popup">
         <div class="panel-group" id="accordion">
           <div class="panel panel-default">
-            <a class="panel-heading" data-toggle="collapse" data-parent="#accordion" href="#collapseOne">
+            <a class="panel-heading" data-toggle="collapse" data-parent="#accordion" href="#accordion-query">
               <span translate>queries</span>
             </a>
-            <div id="collapseOne" class="panel-collapse collapse in">
+            <div id="accordion-query" class="panel-collapse collapse in">
               <div class="panel-body"
                    ga-query
                    ga-query-map="map"
@@ -543,13 +543,12 @@ itemscope itemtype="http://schema.org/WebApplication"
             </div>
           </div>
           <div class="panel panel-default" ga-collapsible-trigger="(result.length > 0)">
-            <a class="panel-heading collapsed" id="headingTwo" data-toggle="collapse"
-            data-parent="#accordion" href="#collapseTwo"
-            ga-collapsible-show="options.featuresShown">
+            <a class="panel-heading collapsed" data-toggle="collapse" data-parent="#accordion" href="#accordion-tree"
+               ga-collapsible-show="options.featuresShown">
               <span translate>items</span> ({{options.features.length}})
               <div ng-show='printInProgress' class='pull-right'>{{printProgressPercentage}}%</div>
             </a>
-            <div id="collapseTwo"
+            <div id="accordion-tree"
                  class="panel-collapse collapse">
               <div ng-show="options.features.length == 0" class="panel-body">
                 <div class="ga-no-result" translate>no_feature_results</div>


### PR DESCRIPTION
Fix #2036 

The 2nd commit fixes also some bad behavior (features not removed on the map when results list was emptied)



[test](http://mf-geoadmin3.dev.bgdi.ch/teo_fix_2036/?lang=fr&topic=luftbilder&bgLayer=ch.swisstopo.pixelkarte-grau&X=75289.94&Y=739017.59&zoom=4&catalogNodes=1179,1180,1186&layers_timestamp=99991231)