### PR TITLE
QRcodeUrl: need to match the printing area

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -8,8 +8,8 @@
      'pascalprecht.translate']);
 
   module.controller('GaPrintDirectiveController', function($rootScope, $scope,
-      $http, $q, $window, $translate, $timeout, gaLayers, gaPermalink,
-      gaBrowserSniffer, gaWaitCursor) {
+      $http, $q, $window, $translate, $timeout, gaLayers, gaMapUtils, 
+      gaPermalink, gaBrowserSniffer, gaWaitCursor) {
 
     var pdfLegendsToDownload = [];
     var pdfLegendString = '_big.pdf';
@@ -568,6 +568,20 @@
       }
     };
 
+    var getZoomFromScale = function(scale) {
+      var i, len;
+      var resolution = scale / UNITS_RATIO / POINTS_PER_INCH;
+      var resolutions = gaMapUtils.viewResolutions;
+      for (i = 0, len = resolutions.length; i < len; i++) {
+        if (resolutions[i] < resolution) {
+          break;
+        }
+      }
+      var zoom = Math.max(0, i - 1);
+
+      return zoom;
+    };
+
     var getNearestScale = function(target, scales) {
       var nearest = null;
       angular.forEach(scales, function(scale) {
@@ -630,6 +644,8 @@
       defaultPage['lang' + lang] = true;
       var qrcodeUrl = $scope.options.qrcodeUrl +
           encodeURIComponent(gaPermalink.getHref());
+      var print_zoom = getZoomFromScale($scope.scale.value);
+      qrcodeUrl = qrcodeUrl.replace(/zoom%3D(\d{1,2})/, 'zoom%3D' + print_zoom);
       var encLayers = [];
       var encLegends;
       var attributions = [];


### PR DESCRIPTION
The QRcode has to zoom a approx. zoom level of the printing area with may be very different from the application's permalink. The X and Y are however the same (printing area is centered).

Fix https://github.com/geoadmin/mf-geoadmin3/issues/2067