### PR TITLE
Remove zeitreihen hack

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -874,12 +874,12 @@
           }
 
           if (!angular.isDefined(yearStr)) {
-            var timeBehaviour = this.getLayerProperty(bodId,
-                'timeBehaviour');
-            yearStr = (timeBehaviour === 'all' || timestamps.length == 0) ?
-                undefined : timestamps[0];
-            if (bodId == 'ch.swisstopo.zeitreihen') {
-              yearStr = '18641231';
+            var timeBehaviour = this.getLayerProperty(bodId, 'timeBehaviour');
+            //check if specific 4/6/8 digit timestamp is specified
+            if (/^\d{4}$|^\d{6}$|^\d{8}$/.test(timeBehaviour)) {
+                yearStr = timeBehaviour;
+            } else if (timeBehaviour !== 'all' && timestamps.length) {
+                yearStr = timestamps[0];
             }
           }
 


### PR DESCRIPTION
DB has been adapted. timeBehaviour parameter now contains the timestamp that we want to have per default. This could/can be used for different layers also. As of now, only 8 digit timestamps are supported.

The other timeBevhaviour possible valures ('last' and 'all') don't change behaviour.

This is for https://github.com/geoadmin/mf-geoadmin3/issues/2027