### PR TITLE
Fix layers on topic change

### DIFF
--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -288,8 +288,27 @@
           });
         });
 
+        var removeNonTopicLayers = function(topicId) {
+          // Assemble first to not remove from the iterated over array
+          var layersToRemove = [];
+          scope.map.getLayers().forEach(function(olLayer) {
+            var l = gaLayers.getLayer(olLayer.bodId);
+            var regex = new RegExp('(^|,)(ech|' + topicId + ')(,|$)', 'g');
+            if (l &&
+                l.topics &&
+                !regex.test(l.topics) &&
+                !olLayer.background) {
+              layersToRemove.push(olLayer);
+            }
+          });
+          layersToRemove.forEach(function(olLayer) {
+            scope.removeLayer(olLayer);
+          });
+        };
         // Change layers label when topic changes
         scope.$on('gaLayersChange', function(evt, data) {
+          removeNonTopicLayers(data.topicId);
+
           map.getLayers().forEach(function(olLayer) {
             if (scope.isBodLayer(olLayer)) {
               olLayer.label = gaLayers.getLayerProperty(olLayer.bodId, 'label');


### PR DESCRIPTION
https://github.com/geoadmin/mf-geoadmin3/issues/2075 showed that we introduced a regression on topic change. On topic change, all layers which are part of topic ech should remain in the layer section. On the other hand, layers that are not part of the new topic or topic ech should be removed.

This was originally done with https://github.com/geoadmin/mf-geoadmin3/commit/b4e1ab22c0172e7a1a0b0c218baa6c5cf1fc9fc3#diff-cc254e043ae817085972191ba79441de , then knowingly removed with https://github.com/geoadmin/mf-geoadmin3/commit/20aef49ebd4bd3fc11330ce3c74331b6f869fdee#diff-cc254e043ae817085972191ba79441de , but I forgot about it because back-end needed to be adapted (see https://github.com/geoadmin/mf-chsdi3/pull/1085) as we switched to 'all' topic for layersConfig because of offline. Oh well...