### PR TITLE
Remove form from index page (https related)

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -151,7 +151,7 @@ itemscope itemtype="http://schema.org/WebApplication"
 % endif      
       </div>
 % if device == 'desktop':
-      <form class="navbar-form pull-right hidden-xs">
+      <div class="navbar-form pull-right hidden-xs">
         <div id="background-selection">
           <div ga-background-layer-selector
             ga-background-layer-selector-map="map"></div>
@@ -168,7 +168,7 @@ itemscope itemtype="http://schema.org/WebApplication"
               ga-translation-selector-options="options"></div>
           </div>
         </div>
-      </form>
+      </div>
 % endif
       ## css animation doesnt work on pseudo element, let use this instead
       <div class="alert alert-danger" translate>offline_sorry</div>


### PR DESCRIPTION
When running our site with https through [1], it's not considered fully secure because we have an insecure form in the index file.

This PR removes the insecure from element and replaces it by div, getting rid of this error. We need this to not have an exclamation mark in the browser when accessing the site through https.

Does anyone know why we had a from in the first place?

[1] https://www.whynopadlock.com/ which allows to test any site for insecure elements.