### PR TITLE
Fix close button css for popovers and modal

### DIFF
--- a/src/components/contextpopup/partials/contextpopup.html
+++ b/src/components/contextpopup/partials/contextpopup.html
@@ -1,46 +1,47 @@
 <div class="popover bottom">
   <div class="arrow"></div>
-  <div class="popover-inner">
-      <h4 class="popover-title"><span translate>position</span><button type="button" class="close" ng-click="hidePopover()">&times;</button></h4>
-      <div class="popover-content">
-          <table>
-              <tbody>
-              <tr>
-                  <td>CH1903 / LV03</td>
-                  <td><a href="{{contextPermalink}}"
-                         target="_blank">{{coord21781}}</a></td>
-              </tr>
-              <tr>
-                  <td>CH1903+ / LV95</td>
-                  <td>{{coord2056}}</td>
-              </tr>
-              <tr>
-                  <td>WGS 84 (long/lat)</td>
-                  <td>{{coord4326}}</td>
-              </tr>
-              <tr>
-                  <td>UTM</td>
-                  <td>{{coordutm}}</td>
-              </tr>
-              <tr>
-                  <td>MGRS</td>
-                  <td>{{coordmgrs}}</td>
-              </tr>
-              <tr ng-hide="!altitude">
-                  <td translate>elevation</td>
-                  <td>{{altitude}} [m]</td>
-              </tr>
-              <tr>
-                  <td></td>
-                  <td><a href="{{crosshairPermalink}}" target="_blank" translate>link_bowl_crosshair</a></td>
-              </tr>
-              <tr ng-if="showQR()">
-                <td align="center" colspan="2">
-                  <img draggable="false" ng-src="{{qrcodeUrl}}" style="width: 124px; height: 124px;" class="qrcode">
-                </td>
-              </tr>
-              </tbody>
-          </table>
-      </div>
+  <div class="popover-title">
+    <span translate>position</span>
+    <button type="button" class="ga-icon ga-btn icon-remove" ng-click="hidePopover()"></button>
+  </div>
+  <div class="popover-content">
+      <table>
+          <tbody>
+          <tr>
+              <td>CH1903 / LV03</td>
+              <td><a href="{{contextPermalink}}"
+                     target="_blank">{{coord21781}}</a></td>
+          </tr>
+          <tr>
+              <td>CH1903+ / LV95</td>
+              <td>{{coord2056}}</td>
+          </tr>
+          <tr>
+              <td>WGS 84 (long/lat)</td>
+              <td>{{coord4326}}</td>
+          </tr>
+          <tr>
+              <td>UTM</td>
+              <td>{{coordutm}}</td>
+          </tr>
+          <tr>
+              <td>MGRS</td>
+              <td>{{coordmgrs}}</td>
+          </tr>
+          <tr ng-hide="!altitude">
+              <td translate>elevation</td>
+              <td>{{altitude}} [m]</td>
+          </tr>
+          <tr>
+              <td></td>
+              <td><a href="{{crosshairPermalink}}" target="_blank" translate>link_bowl_crosshair</a></td>
+          </tr>
+          <tr ng-if="showQR()">
+            <td align="center" colspan="2">
+              <img draggable="false" ng-src="{{qrcodeUrl}}" class="ga-qrcode">
+            </td>
+          </tr>
+          </tbody>
+      </table>
   </div>
 </div>

--- a/src/components/contextpopup/style/contextpopup.less
+++ b/src/components/contextpopup/style/contextpopup.less
@@ -1,5 +1,5 @@
 @context-popup-width: 300;
-
+@qrcode-size: 124px;
 [ga-context-popup] {
   left: unit(-@context-popup-width/2, px);
   width: unit(@context-popup-width, px);
@@ -9,5 +9,10 @@
   
   table {
     width: 100%;
+  }
+
+  .ga-qrcode {
+    width: @qrcode-size;
+    height: @qrcode-size;
   }
 }

--- a/src/components/offline/partials/offline-menu.html
+++ b/src/components/offline/partials/offline-menu.html
@@ -3,8 +3,8 @@
      <div class="modal-dialog" ga-draggable=".modal-header">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">&times;</button>
           <h4 class="modal-title" translate>offline_modal_title</h4>
+          <button type="button" class="ga-icon ga-btn icon-remove" data-dismiss="modal"></button>
         </div>
         <div class="modal-body">
           <span ng-show="hasOfflineData">

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -598,15 +598,13 @@ $zopim(function() {
            'tr': (globals.ios >= 8)
          }">
       <div class="arrow"></div>
-      <h3 class="popover-title">
+      <div class="popover-title">
         <span translate>homescreen_title</span>
-        <button type="button" class="close" ng-click="globals.homescreen=false">&times;</button>
-      </h3>
+        <button type="button" class="ga-icon ga-btn icon-remove" ng-click="globals.homescreen=false"></button>
+      </div>
       <div class="popover-content">
-        <p>
-          <i class=icon-share></i>&nbsp;
-          <span translate>homescreen_content</span>
-        </p>
+        <i class=icon-share></i>&nbsp;
+        <span translate>homescreen_content</span>
       </div>
     </div>
 % endif

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -838,6 +838,31 @@ a .ga-icon-separator {
   }
 }
 
+[ga-context-popup], [ga-offline-menu], .homescreen {
+  .popover-title, .modal-header {
+    position: relative;
+    padding-right: 0px;
+
+    .icon-remove {
+      position: absolute;
+      top: 0px;
+      right: 0px;
+      width: 38px;
+      height: 100%;
+      opacity: 0.3;
+      font-size: 18px;
+
+      &:hover {
+        opacity: 0.7;
+      }
+
+      &:active {
+       opacity: 1;
+      }
+    }
+  }
+}
+
 // ****** PULLDOWN’S LISTS
 .panel-subtitle() {
   border-bottom-width: 1px;


### PR DESCRIPTION
The close button of homescreen popovers, context-popup and modal offline menu were not correctly aligned, this PR fixes this applying the same css as popups.

[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_close/)

Before:

![before](https://cloud.githubusercontent.com/assets/621420/6003224/16871f6c-aafa-11e4-9d85-648001eb119f.png)


After:
![after](https://cloud.githubusercontent.com/assets/621420/6003227/1a5ae36c-aafa-11e4-81bb-4f07f1355af8.png)


TEst on desktop/mobile IE11, FF, defaut browser, chrome