### PR TITLE
Using source instead of layer to get extent in preview zoom function

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1571,7 +1571,7 @@
         // extent.
         this.zoom = function(map, feature) {
           var extent = getMinimalExtent((feature) ?
-              feature.getGeometry().getExtent() : vector.getExtent());
+              feature.getGeometry().getExtent() : source.getExtent());
           map.getView().fitExtent(extent, map.getSize());
         };
       };


### PR DESCRIPTION
This fixes the bug when having a feature specified in the PL that it didn't zoom in to the selected feature. This is a regression introduced by an update of openlayers.

[Old behaviour](http://map.geo.admin.ch?ch.swisstopo.lubis-luftbilder_farbe=20057110772469&lang=de&topic=luftbilder)

[New behaviour](http://mf-geoadmin3.dev.bgdi.ch/gjn_feature_in_pl?ch.swisstopo.lubis-luftbilder_farbe=20057110772469&lang=de&topic=luftbilder)

@alcapat or @daguer : this could be a good test case for you to add to browserstack tests. If you need help doing it, just ask @ponceta or me.