### PR TITLE
Take animation into account for print tests

### DIFF
--- a/test/selenium/print_test.js
+++ b/test/selenium/print_test.js
@@ -5,8 +5,8 @@ var webdriver = require('browserstack-webdriver');
 var runTest = function(cap, driver, target) {
   // Click on "Drucken"
   driver.findElement(webdriver.By.xpath("//a[@id='printHeading']")).click();
-  // Wait 1 sec for the menu to pull down
-  driver.findElement(webdriver.By.xpath("//a[@id='printHeading' and @aria-expanded='true']"));
+  // Wait until print is opened and animation is finished
+  driver.findElement(webdriver.By.xpath("//div[@id='print' and contains(@class, 'collapse in')]"));
   // Try Print
   driver.findElement(webdriver.By.xpath("//button[contains(text(), 'Drucken')]")).click();
   // Is it success?


### PR DESCRIPTION
This addresses a part of https://github.com/geoadmin/mf-geoadmin3/issues/2148

It takes into account that the opening element is animated and waits until the animation is finished before clicking the print button. This should get rid of a couple of false positives from browserstack.