### PR TITLE
Display an alert message when popup has not been created

### DIFF
--- a/src/components/PrintService.js
+++ b/src/components/PrintService.js
@@ -1,6 +1,9 @@
 (function() {
   goog.provide('ga_print_service');
-  var module = angular.module('ga_print_service', []);
+
+  var module = angular.module('ga_print_service', [
+    'pascalprecht.translate'
+  ]);
 
   module.provider('gaPrintService', function() {
     var windowPrint;
@@ -21,7 +24,7 @@
       return '<link href="' + cssLink + '" rel="stylesheet" type="text/css">';
     };
 
-    this.$get = function($window) {
+    this.$get = function($window, $translate) {
       var Print = function() {
         this.htmlPrintout = function(body, head, onLoad) {
           $window.printOnLoad = onLoad || function(windowPrint) {
@@ -31,6 +34,10 @@
             windowPrint.close();
           }
           windowPrint = $window.open('', 'printout', 'height=400, width=600');
+          if (!windowPrint) {
+            alert($translate.instant('popup_blocked'));
+            return;
+          }
           windowPrint.document.write(buildHtml(body, head));
           windowPrint.document.close();
         };

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -210,6 +210,7 @@
 	"paste_url": "URL einfügen",
 	"permalink": "Permalink",
 	"plz": "PLZ",
+	"popup_blocked": "Eine Einstellung Ihres Browsers verhindert das Öffnen von neuen Fenstern. Bitte passen Sie Ihre Browsereinstellungen entsprechend an.",
 	"position": "Position",
 	"print": "Drucken",
 	"print_action": "Drucken",

--- a/src/locales/empty.json
+++ b/src/locales/empty.json
@@ -301,5 +301,6 @@
   "obstacle_deleted_last_2_weeks": "",
   "no_searchable_layer": "",
   "gewiss": "",
-  "mgdi": ""
+  "mgdi": "",
+  "popup_blocked": ""
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -210,6 +210,7 @@
 	"paste_url": "Paste URL",
 	"permalink": "Permalink",
 	"plz": "ZIP",
+	"popup_blocked": "Your browser does block pop-up windows. Please check your browser settings.",
 	"position": "Position",
 	"print": "Print",
 	"print_action": "Print",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -210,6 +210,7 @@
 	"paste_url": "Coller URL",
 	"permalink": "Permalien",
 	"plz": "NPA",
+	"popup_blocked": "Le navigateur empêche l'ouverture d'une nouvelle fenêtre. Veuillez vérifier les paramètres de sécurité de votre navigateur.",
 	"position": "Position",
 	"print": "Impression",
 	"print_action": "Imprimer",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -210,6 +210,7 @@
 	"paste_url": "Incolla URL",
 	"permalink": "Permalink",
 	"plz": "NPA",
+	"popup_blocked": "Il browser ha impedito l'apertura di una nuova finestra. Si prega di verificare le impostazioni di sicurezza.",
 	"position": "Posizione",
 	"print": "Stampa",
 	"print_action": "Stampare",

--- a/src/locales/rm.json
+++ b/src/locales/rm.json
@@ -210,6 +210,7 @@
 	"paste_url": "Encollar l'URL",
 	"permalink": "Permalink",
 	"plz": "PLZ",
+	"popup_blocked": "Der Browser von Pop-Ups wird von Ihrem Browser unterdrückt. Bitte passen Sie Ihre Browsereinstellungen entsprechend an.",
 	"position": "Posiziun",
 	"print": "Stampar",
 	"print_action": "Stampar",


### PR DESCRIPTION
Fix #1528


[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_popup_blocked/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=188000.00&Y=721000.00&zoom=1&catalogNodes=457,477&layers=ch.bafu.biogeographische_regionen&layers_opacity=0.75)


Probably not fully cross-browser and ad-blocker but works for native popup blocker of Safari and Chrome.

