### PR TITLE
[WIP] Remove OSX based browserstack tests

### DIFF
--- a/test/selenium/browsers.js
+++ b/test/selenium/browsers.js
@@ -44,10 +44,7 @@ var capabilities = [
     create('Windows', '7', '1280x1024', 'Firefox', '32.0'),
     create('Windows', '7', '1280x1024', 'Firefox', '33.0'),
     create('Windows', '8.1', '1280x1024', 'Firefox', '33.0'),
-    create('Windows', '7', '1280x1024', 'Safari', '5.1'),
-    create('OS X', 'lion', '1280x1024', 'Safari', '6.0'),
-    create('OS X', 'mavericks', '1280x1024', 'Safari', '7.0'),
-    create('OS X', 'yosemite', '1280x1024', 'Safari','8.0')
+    create('Windows', '7', '1280x1024', 'Safari', '5.1')
 ];
 
 module.exports.capabilities = capabilities;


### PR DESCRIPTION
See https://github.com/geoadmin/mf-geoadmin3/issues/2148. Browserstack tests on OSX fail randomly in about 50% of the cases. We have decided to remove those tests until they are more reliable.

I've added an entry to test the application on safari/OSX combination in our deploy document: https://docs.google.com/spreadsheets/d/1AvE8jntCcaxGtNapkhjIRQwXOmdahNuiD8zwRP2uYII/edit#gid=0

