### PR TITLE
[WIP] Change cursor style when a queryable layer is available

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -765,7 +765,8 @@
                     layer.minResolution),
                 tileLoadFunction: tileLoadFunction,
                 url: getWmtsGetTileUrl(layer.serverLayerName,
-                  layer.format)
+                  layer.format),
+                crossOrigin: 'anonymous'
               });
             }
             olLayer = new ol.layer.Tile({
@@ -797,6 +798,7 @@
                   url: wmsUrl,
                   params: wmsParams,
                   attributions: attributions,
+                  crossOrigin: 'anonymous',
                   ratio: 1
                 });
               }
@@ -814,6 +816,7 @@
                   params: wmsParams,
                   attributions: attributions,
                   gutter: layer.gutter || 0,
+                  crossOrigin: 'anonymous',
                   tileGrid: gaTileGrid.get(layer.resolutions,
                       layer.minResolution, 'wms'),
                   tileLoadFunction: tileLoadFunction

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -81,8 +81,20 @@
 
             // Change cursor style on mouse move, only on desktop
             var updateCursorStyle = function(evt) {
-              var feature = findVectorFeature(map.getEventPixel(evt));
-              map.getTarget().style.cursor = (feature) ? 'pointer' : '';
+              var feature, pixel = map.getEventPixel(evt);
+              var hasQueryableLayer = map.forEachLayerAtPixel(pixel,
+                  function() {
+                    return true;
+                  },
+                  undefined,
+                  function(layer) {
+                    return isQueryableBodLayer(layer);
+                  });
+              if (!hasQueryableLayer) {
+                feature = findVectorFeature(pixel);
+              }
+              map.getTarget().style.cursor = (hasQueryableLayer || feature) ?
+                  'pointer' : '';
             };
             var updateCursorStyleDebounced = gaDebounce.debounce(
                 updateCursorStyle, 10, false, false);


### PR DESCRIPTION

Fix #878

[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_cursor/?lang=fr&topic=luftbilder&bgLayer=ch.swisstopo.pixelkarte-grau&X=121948.74&Y=647906.61&zoom=4&layers=ch.bazl.luftfahrthindernis,ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe&catalogNodes=1179,1180,1186&layers_timestamp=,99991231,99991231)

