### PR TITLE
Add ci configuration

### DIFF
--- a/rc_ci
+++ b/rc_ci
@@ -1,0 +1,6 @@
+export KEEP_VERSION=false
+export DEPLOY_TARGET=ci
+export API_URL=//mf-chsdi3.ci.bgdi.ch
+export APACHE_BASE_PATH=
+export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.ci.bgdi.ch
+export VARNISH_HOSTS=()


### PR DESCRIPTION
This adds a ci specific configuration. CI is our jenkins instance, where we'll run continous integration. We will have *.ci.bgdi.ch adresses for mf-geoadmin3 and mf-chsdi3.

Trivial self-merge.