### PR TITLE
More compact measure tool, more space for profile

### DIFF
--- a/src/components/measure/MeasureDirective.js
+++ b/src/components/measure/MeasureDirective.js
@@ -87,6 +87,7 @@
             style: scope.options.drawStyleFunction
           });
 
+
           // Activate the component: add listeners, last features drawn and draw
           // interaction.
           var activate = function() {
@@ -94,6 +95,14 @@
             scope.map.addLayer(layer);
             scope.map.addInteraction(drawArea);
             featuresOverlay.setMap(scope.map);
+
+            // Controls the display of the show profile button
+            var nbDrawnFeatures = layer.getSource().getFeatures().length;
+            if (nbDrawnFeatures > 0) {
+              scope.isEmptyDrawing = false;
+            } else {
+              scope.isEmptyDrawing = true;
+            }
 
             // Add events
             deregister = [
@@ -105,7 +114,9 @@
               drawArea.on('drawstart', function(evt) {
                 var nbPoint = 1;
                 var isSnapOnLastPoint = false;
-
+                scope.$apply(function() {
+                  scope.isEmptyDrawing = true;
+                });
                 // Clear the layer
                 layer.getSource().clear();
 
@@ -133,6 +144,16 @@
                     if (nbPoint != lineCoords.length) {
                       // A point is added
                       nbPoint++;
+                      // Controls the display of the show profile button
+                      if (nbPoint < 3 && !scope.isEmptyDrawing) {
+                        scope.$apply(function() {
+                          scope.isEmptyDrawing = true;
+                        });
+                      } else if (nbPoint >= 3 && scope.isEmptyDrawing) {
+                        scope.$apply(function() {
+                          scope.isEmptyDrawing = false;
+                        });
+                      }
 
                       // Update the profile
                       if (scope.options.isProfileActive) {
@@ -181,7 +202,6 @@
               }),
 
               drawArea.on('drawend', function(evt) {
-
                 if (!isFinishOnFirstPoint) {
                   // The sketchFeatureArea is automatically closed by the draw
                   // interaction even if the user has finished drawing on the

--- a/src/components/measure/partials/measure.html
+++ b/src/components/measure/partials/measure.html
@@ -1,33 +1,35 @@
 <div class="ga-measure">
-  <div class="ga-measure-panel"> 
-    <div class="ga-measure-text">
-      <div class="hidden-print ga-measure-info" translate>measure_instruction</div>
-      <div class="ga-measure-info">
-        <p class="pull-left">{{'distance_label' | translate}}: </p> 
-        <p class="pull-right">{{distance | measure}}</p>
-      </div>
-      <div class="ga-measure-info">
-        <p class="pull-left">{{'surface_label' | translate}}: </p>
-        <p class="pull-right">{{surface | measure:'area':['km&sup2', ' m&sup2']}}</p>
-      </div>
-      <div class="ga-measure-info">
-        <p class="pull-left">{{'azimuth_label' | translate}}: </p>
-        <p class="pull-right">{{azimuth | number:2}} &deg</p>
+  <div class="ga-measure-panel-group">
+    <div class="ga-measure-panel">
+      <div class="ga-measure-text">
+        <div class="hidden-print ga-measure-info ga-measure-instruction" translate>measure_instruction</div>
+        <div class="ga-measure-info">
+          <p class="pull-left">{{'distance_label' | translate}}: </p>
+          <p class="pull-right">{{distance | measure}}</p>
+        </div>
+        <div class="ga-measure-info">
+          <p class="pull-left">{{'surface_label' | translate}}: </p>
+          <p class="pull-right">{{surface | measure:'area':['km&sup2', ' m&sup2']}}</p>
+        </div>
+        <div class="ga-measure-info">
+          <p class="pull-left">{{'azimuth_label' | translate}}: </p>
+          <p class="pull-right">{{azimuth | number:2}} &deg</p>
+        </div>
       </div>
     </div>
-  </div>
-  <div ng-show="options.isProfileActive" ga-profile ga-profile-options="options.profileOptions"></div>
-  <div class="ga-measure-buttons-panel" class="hidden-print">
-    <div>
-      <button ng-click="options.isProfileActive = !options.isProfileActive"
-      class="btn btn-default ga-measure-profile-bt ga-measure-button" data-loading-text="{{'wait_data_loading' |translate}}">{{(options.isProfileActive ? 'hide_profile' : 'display_profile') | translate}}</button></div>
-    <div>
-      <button class="btn btn-default ga-measure-button"
+    <div class="ga-measure-buttons-panel" class="hidden-print">
+      <button class="btn btn-default ga-measure-button pull-left"
               ng-disabled="!canExport()"
               ng-if="supportKmlExport"
               ng-click="exportKml()"
               translate>export_kml
       </button>
+      <button ng-click="options.isProfileActive = !options.isProfileActive"
+      class="btn btn-default ga-measure-profile-bt ga-measure-button pull-right"
+      data-loading-text="{{'wait_data_loading' |translate}}">
+        {{(options.isProfileActive ? 'hide_profile' : 'display_profile') | translate}}
+      </button>
     </div>
   </div>
+  <div ng-show="options.isProfileActive" ga-profile ga-profile-options="options.profileOptions"></div>
 </div>

--- a/src/components/measure/partials/measure.html
+++ b/src/components/measure/partials/measure.html
@@ -26,6 +26,7 @@
       </button>
       <button ng-click="options.isProfileActive = !options.isProfileActive"
       class="btn btn-default ga-measure-profile-bt ga-measure-button pull-right"
+      ng-show="!isEmptyDrawing"
       data-loading-text="{{'wait_data_loading' |translate}}">
         {{(options.isProfileActive ? 'hide_profile' : 'display_profile') | translate}}
       </button>

--- a/src/components/measure/style/measure.less
+++ b/src/components/measure/style/measure.less
@@ -1,21 +1,22 @@
 [ga-measure] {
   white-space: nowrap; 
-
+  .ga-measure-panel-group {
+    width: 225px;
+    float: left;
+    margin-right: 15px;
+  }
   .ga-measure-text {
     position: relative;
-    margin-bottom: 93px;
   }
   .ga-measure-buttons-panel {
     position: relative;
     padding: 5px 0px;
-    vertical-align: top;
-    display: inline-block;
-    width: 165px;
-    top: 25px;
+    display: block;
+    width: 100%;
+    top: 10px;
   }
   .ga-measure-button {
-    margin-bottom: 5px;
-    width: 100%;
+    font-size: 11px;
   }
   .ga-measure-info {
     border-bottom: 1px solid #E9E9E9;
@@ -28,8 +29,11 @@
   }
   .ga-measure-panel {
     padding-right: 30px;
-    display: inline-block;
+    display: block;
     vertical-align: top;
     width: 250px;
+  }
+  .ga-measure-instruction {
+    font-weight: bold;
   }
 }

--- a/src/js/MeasureController.js
+++ b/src/js/MeasureController.js
@@ -22,7 +22,7 @@
                 bottom: 40,
                 left: 60
               },
-              height: 250,
+              height: 188,
               elevationModel: 'COMB'
           },
           styleFunction: (function() {
@@ -143,12 +143,10 @@
         win.on('resize', function() {
           if (isProfileCreated) {
             if (!panel) {
-              panel = $('.ga-measure-panel');
-              panelBt =  $('.ga-measure-buttons-panel');
+              panel = $('.ga-measure-panel-group');
             }
-            // 62 padding and margins 
-            $scope.options.profileOptions.width = win.width() - panel.width() -
-                panelBt.width() - 62;
+            // 47 padding and margins
+            $scope.options.profileOptions.width = win.width() - panel.width() - 47;
             $rootScope.$emit('gaProfileDataUpdated', null, [
               $scope.options.profileOptions.width,
               $scope.options.profileOptions.height

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -792,7 +792,7 @@ a .ga-icon-separator {
   bottom: 26px;
   border-radius: 0;
   background-clip: initial;
-  height: 300px;
+  height: 240px;
 
   .ga-popup-content {
     max-height: inherit;


### PR DESCRIPTION
No functional change. Not tested on IE.

[Test Link] (http://mf-geoadmin3.dev.bgdi.ch/gal_profile_style/)

*Before*:
![profile_1_before](https://cloud.githubusercontent.com/assets/3306154/6390417/85698482-bdac-11e4-87d9-adff3d7e0e3f.png)
![profile_2_before](https://cloud.githubusercontent.com/assets/3306154/6390419/89ad8da4-bdac-11e4-8878-c0a99f7be7bc.png)

*After*:
![profile_1_after](https://cloud.githubusercontent.com/assets/3306154/6394501/2d184cc0-bdd2-11e4-9a25-b8d5a9b6a4b7.png)
![profile_2_after](https://cloud.githubusercontent.com/assets/3306154/6394506/316ab93e-bdd2-11e4-9404-367bdc6d19e7.png)

