### PR TITLE
Block user selection

### DIFF
--- a/src/components/importkml/ImportKmlDirective.js
+++ b/src/components/importkml/ImportKmlDirective.js
@@ -192,7 +192,7 @@
   );
 
   module.directive('gaImportKml',
-      function($log, $compile, $translate, gaBrowserSniffer,
+      function($log, $compile, $document, $translate, gaBrowserSniffer,
           gaUrlUtils) {
         return {
           restrict: 'A',
@@ -247,6 +247,10 @@
                   '<div class="ga-import-kml-drop-zone">' +
                   '  <div translate>drop_me_here</div>' +
                   '</div>');
+
+              // Block drag of all elements by default to avoid unwanted display
+              // of dropzone.
+              $document.on('dragstart', function() {return false;});
 
               // Hide the drop zone on click, used when for some reasons unknown
               // the element stays displayed. See:

--- a/src/components/map/style/map.less
+++ b/src/components/map/style/map.less
@@ -4,7 +4,11 @@
   height: 100%;
   background-color: #f9f9f9;
   background-image: data-uri('mapbg.png');
-
+  
+  .ol-viewport .ol-unselectable {
+    .ga-user-select(none);
+  }
+  
   .ol-dragbox {
     position:absolute;
     border: 1px solid #2E2F2F;

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -46,12 +46,21 @@
   display: none;
 }
 
+.ga-user-select(@val) {
+  user-select: @val;
+  -ms-user-select: @val;
+  -moz-user-select: @val;
+  -khtml-user-select: @val;
+  -webkit-user-select: @val;
+  -webkit-touch-callout: @val;
+}
+
 html, body {
-    height: 100%;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
 }
 
 input::-ms-clear {
@@ -1141,11 +1150,6 @@ input[type=range] {
 .ga-checkbox {
   cursor: pointer;
   -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   
   input[type=checkbox] {
     cursor: inherit;


### PR DESCRIPTION
Fix #2165 

This PR blocks by default all the elements selection  and drag, except input text fileds, for those we block only the dragstart event, 

[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_select/?lang=fr&topic=aviation&bgLayer=ch.swisstopo.pixelkarte-grau&X=175118.05&Y=657684.04&zoom=3&catalogNodes=1379,1381,1514,1515)

Still WIP because I don't know if we really want that.