### PR TITLE
Remove safari tests on Windows

### DIFF
--- a/test/selenium/browsers.js
+++ b/test/selenium/browsers.js
@@ -43,8 +43,7 @@ var capabilities = [
     create('Windows', '7', '1280x1024', 'Firefox', '31.0'),
     create('Windows', '7', '1280x1024', 'Firefox', '32.0'),
     create('Windows', '7', '1280x1024', 'Firefox', '33.0'),
-    create('Windows', '8.1', '1280x1024', 'Firefox', '33.0'),
-    create('Windows', '7', '1280x1024', 'Safari', '5.1')
+    create('Windows', '8.1', '1280x1024', 'Firefox', '33.0')
 ];
 
 module.exports.capabilities = capabilities;


### PR DESCRIPTION
I bring out the axe and also remove the safari on windows tests...as @ponceta noted and the last jenkins tests https://jenkins.dev.bgdi.ch/job/geoadmin3/295/ show, this fails sometimes as well.

Self-Merge.