### PR TITLE
Fix #2163: don't print contextpopup overlay

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -717,6 +717,12 @@
       var resolution = $scope.map.getView().getResolution();
 
       overlays.forEach(function(overlay) {
+        var elt = overlay.getElement();
+        // We print only overlay added by the MarkerOverlayService
+        // or by crosshair permalink
+        if ($(elt).hasClass('popover')) {
+          return;
+        }
         var center = overlay.getPosition();
         var offset = 5 * resolution;
         if (center) {


### PR DESCRIPTION
Fix #2163 

[test](http://mf-geoadmin3.dev.bgdi.ch/teo_fix_marker/)