### PR TITLE
Print time enabled layer with no data

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -659,7 +659,8 @@
 
       // Transform layers to literal
       angular.forEach(layers, function(layer) {
-        if (layer.visible) {
+        if (layer.visible && (!layer.timeEnabled ||
+            angular.isDefined(layer.time))) {
           var attribution = layer.attribution;
           if (attribution !== undefined &&
               attributions.indexOf(attribution) == -1) {


### PR DESCRIPTION
Do not print time enabled layer which do not have data for defined year

See https://github.com/geoadmin/mf-geoadmin3/issues/2214


[Test link](http://mf-geoadmin3.dev.bgdi.ch/mom_print_year_none/src/?X=190000.00&Y=660000.00&zoom=1&lang=de&topic=inspire&bgLayer=ch.swisstopo.pixelkarte-farbe&layers_timestamp=19651231,&layers=ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe&time=1965)