### PR TITLE
Get rid of mobile parameter for  the redirect to main map in the embed page

### DIFF
--- a/src/components/permalink/PermalinkService.js
+++ b/src/components/permalink/PermalinkService.js
@@ -68,6 +68,12 @@
             return baseEmbed + '?' + gaUrlUtils.toKeyValue(newParams);
           };
 
+          // The main href is the embed permalink but without the name of
+          // the html page.
+          this.getMainHref = function(p) {
+            return this.getEmbedHref(p).replace(/\/embed\.html\?/, '/?');
+          };
+
           this.getParams = function() {
             return params;
           };

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -195,7 +195,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         <div ga-attribution ga-attribution-map="map"></div>
       </div>
   % if device == 'embed':
-      <a ng-cloak translate-cloak id="bigMapLink" target="_blank" ng-href="{{deviceSwitcherHref}}">
+      <a ng-cloak translate-cloak id="bigMapLink" target="_blank" ng-href="{{toMainHref}}">
         <div>
           <img src="${versionslashed}img/logo.ch.small.png" alt="small_logo" draggable="false"/>
           <span translate-values="{{host}}" translate>view_on_mapgeoadminch</span>

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -134,10 +134,12 @@
       });
 
       // Create switch device url
-      var switchToMobile = '' + !(gaBrowserSniffer.mobile || gaBrowserSniffer.embed);
+      var switchToMobile = '' + !gaBrowserSniffer.mobile;
       $scope.host = {url: $window.location.host}; // only use in embed.html 
+      $scope.toMainHref = gaPermalink.getMainHref();
       $scope.deviceSwitcherHref = gaPermalink.getHref({ mobile: switchToMobile });
       $rootScope.$on('gaPermalinkChange', function() {
+        $scope.toMainHref = gaPermalink.getMainHref();
         $scope.deviceSwitcherHref = gaPermalink.getHref({ mobile: switchToMobile });
       });
 

--- a/test/specs/permalink/PermalinkService.spec.js
+++ b/test/specs/permalink/PermalinkService.spec.js
@@ -95,4 +95,46 @@ describe('ga_permalink_service', function() {
       expect(permalink.getEmbedHref()).to.be(embedUrl);
     });
   });
+  
+  describe('correctly creates main url', function() {
+    var win, url = '//some-hostname:443/some/path/?some=key&value=pairs';
+    
+    beforeEach(function() {
+      inject(function($injector) {
+        win = $injector.get('$window');
+      });
+    });
+
+    it('without / at the end', function() {
+      expect(permalink.getMainHref()).to.be(url);
+    });
+    it('with / at the end', function() {
+      win.location.pathname += '/';
+      expect(permalink.getMainHref()).to.be(url);
+    });
+    it('with index.html at the end', function() {
+      win.location.pathname += '/index.html';
+      expect(permalink.getMainHref()).to.be(url);
+    });
+    it('with mobile.html at the end', function() {
+      win.location.pathname += '/mobile.html';
+      expect(permalink.getMainHref()).to.be(url);
+    });
+    it('with embed.html at the end', function() {
+      win.location.pathname += '/embed.html';
+      expect(permalink.getMainHref()).to.be(url);
+    }); 
+    it('with mobile param defined', function() {
+      win.location.pathname += '/embed.html';
+      permalink.updateParams({mobile: false});
+      expect(permalink.getMainHref()).to.be(url);
+      permalink.updateParams({mobile: 'true'});
+      expect(permalink.getMainHref()).to.be(url);
+      permalink.updateParams({mobile: ''});
+      expect(permalink.getMainHref()).to.be(url);
+      permalink.updateParams({mobile: null});
+      expect(permalink.getMainHref()).to.be(url);
+    });
+  });
+
 });


### PR DESCRIPTION
As mention @gjn  the big map link in the embed page always redirect to desktop version. This PR fixes that


[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_bigmap_link/)