### PR TITLE
Remove useless export

### DIFF
--- a/scripts/ga-ol3-tilegrid.exports
+++ b/scripts/ga-ol3-tilegrid.exports
@@ -1,5 +1,3 @@
 goog.exportProperty(ol.tilegrid.TileGrid.prototype, 'getTileRangeForExtentAndZ',
     ol.tilegrid.TileGrid.prototype.getTileRangeForExtentAndZ);
-goog.exportProperty(ol.tilegrid.TileGrid.prototype, 'getResolutions',
-    ol.tilegrid.TileGrid.prototype.getResolutions);
 


### PR DESCRIPTION
According the api doc getResolutions is stable now and exported:

https://github.com/openlayers/ol3/blob/b6adeea4f4cb31fbd0976ad1d91e70c1c66f39c7/src/ol/tilegrid/tilegrid.js#L188