### PR TITLE
Update profile drawing on move

### DIFF
--- a/src/components/measure/MeasureDirective.js
+++ b/src/components/measure/MeasureDirective.js
@@ -162,6 +162,12 @@
                       }
 
                     } else {
+                      // Update the profile
+                      if (scope.options.isProfileActive) {
+                        updateProfileDebounced();
+                      }
+
+
                       // We update features and measures
                       var lastPoint = lineCoords[lineCoords.length - 1];
                       var lastPoint2 = lineCoords[lineCoords.length - 2];


### PR DESCRIPTION
This PR updates the drawn profile (in measurement tool) while moving the mouse around. Before, the profile was only adapted when a point was added by a click.

[Testlink](mf-geoadmin3.dev.bgdi.ch/gjn_update_profile_on_move)

@davidoesch @cedricmoullet Thougts?

Note: this will increase traffic to our profile service; hard to tell by how much.