### PR TITLE
Use cached and debounce for search requests

### DIFF
--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -79,7 +79,7 @@
 
   module.controller('GaSearchTypesController',
     function($scope, $http, $q, $sce, gaUrlUtils, gaSearchLabels,
-             gaBrowserSniffer, gaMarkerOverlay) {
+             gaBrowserSniffer, gaMarkerOverlay, gaDebounce) {
 
       var canceler;
 
@@ -91,7 +91,7 @@
         }
       };
 
-      var triggerSearch = function() {
+      var triggerSearch = gaDebounce.debounce(function() {
         if (!$scope.doSearch()) {
           $scope.options.announceResults($scope.type, 0);
           return;
@@ -115,7 +115,8 @@
             $scope.options.announceResults($scope.type, 0);
           }
         });
-      };
+      }, 133, false, false);
+      // 133 filters out 'stuck key' events while staying responsive
 
       $scope.doSearch = function() {
         return true;

--- a/src/js/SearchController.js
+++ b/src/js/SearchController.js
@@ -7,7 +7,7 @@
       function($scope, gaGlobalOptions) {
         var topicPlaceHolder = '--DUMMYTOPIC--';
         $scope.options = {
-          searchUrl: gaGlobalOptions.apiUrl + '/rest/services/' +
+          searchUrl: gaGlobalOptions.cachedApiUrl + '/rest/services/' +
               topicPlaceHolder + '/SearchServer?',
           featureUrl: gaGlobalOptions.cachedApiUrl +
               '/rest/services/{Topic}/MapServer/{Layer}/{Feature}',


### PR DESCRIPTION
This PR adresses the flaws our current search exposes in the back-end. It does 2 things to limit the number of (bogus) requests on the back-end:

1. caches the search requests
2. debounces the search requests to adress 'stuck key' events

Note that the debounce add a little delay between typing and the requests, rendering the UI a tad less responsive. It's a compromise that is hardly felt (we use 133ms debouncing).

Caching is used on all levels (browsers, proxies, varnish) for same requests. The cache will be reset when mf-geoadmin3 is deployed.

The Testlink uses https://github.com/geoadmin/mf-chsdi3/pull/1363 in the back-end, which adds another measure to protect the search back-end (the maximum number of words in the requests)

[TestLink](http://mf-geoadmin3.dev.bgdi.ch/gjn_debounce_searchrequests)