### PR TITLE
Display correct cursor on layer group

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -173,8 +173,13 @@
 
             // Test if the layer is a queryable bod layer
             function isQueryableBodLayer(olLayer) {
-              return (olLayer.bodId &&
-                  gaLayers.getLayerProperty(olLayer.bodId, 'queryable'));
+              var bodId = olLayer.bodId;
+              if (bodId) {
+                bodId = gaLayers.getLayerProperty(bodId, 'parentLayerId') ||
+                    bodId;
+              }
+              return (bodId &&
+                  gaLayers.getLayerProperty(bodId, 'queryable'));
             };
 
             // Get all the queryable layers


### PR DESCRIPTION
Fix #2264 

[Test](http://mf-geoadmin3.dev.bgdi.ch/teo_fix_2264/?lang=fr&topic=luftbilder&bgLayer=ch.swisstopo.pixelkarte-grau&X=193523.56&Y=604917.27&zoom=7&layers=ch.bfs.gebaeude_wohnungs_register,ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe&catalogNodes=1179,1180,1186&layers_timestamp=,99991231,99991231)