### PR TITLE
Keyboad navigation for search results

### DIFF
--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -226,13 +226,25 @@
           link: function($scope, element, attrs) {
             $scope.input = element.find('input');
 
-            $scope.key = function(evt) {
+            $scope.keydown = function(evt) {
+              //Enter key
               if (evt.keyCode == 13) {
                 if (evt.target && evt.target.blur) {
                   evt.target.blur();
                 }
               }
+              //Down Arrow, Tab Or PageDown
+              if (evt.keyCode == 9 || evt.keyCode == 40 || evt.keyCode == 34) {
+                //focus to first result
+                var firstRes = $(element).find('.ga-search-result').first();
+                if (firstRes.length === 1 &&
+                    firstRes[0].className.indexOf('ga-search-result') > -1) {
+                  evt.preventDefault();
+                  firstRes.focus();
+                }
+              }
             };
+
             // Result set announces their results (put here because we need
             // element)
             $scope.childoptions.announceResults = function(type, nr) {

--- a/src/components/search/partials/search.html
+++ b/src/components/search/partials/search.html
@@ -3,7 +3,7 @@
     <input class="input-small ga-search-input" type="search"
     placeholder="{{'search_placeholder' | translate}}" ng-model="query"
     autocapitalize="none" autocomplete="off" autocorrect="off"
-    ng-keyup="key($event)"
+    ng-keydown="keydown($event)"
     ng-blur="lostFocus($event)"
     ng-focus="onFocus()">
     <span class="ga-search-dropdown" ng-show="restat.sets()">

--- a/src/components/search/partials/searchtypes.html
+++ b/src/components/search/partials/searchtypes.html
@@ -11,7 +11,11 @@
   </span>
 
   <span class="ga-search-results">
-    <div class="ga-search-result" ng-repeat="res in results">
+    <div class="ga-search-result" tabindex="{{tabstart + i}}" ng-repeat="(i, res) in results"
+          ng-keydown="keydown($event, res)"
+          ng-focus="preview(res)"
+          ng-blur="removePreview($event, res)"
+          >
       <div class="ga-search-item"
           ng-mouseenter="preview(res)"
           ng-mouseleave="removePreview($event, res)"

--- a/src/components/search/style/search.less
+++ b/src/components/search/style/search.less
@@ -1,9 +1,8 @@
 @dropdown-background-color: #fff;
 @dropdown-link-color-hover-color: #fff;
-@dropdown-link-background-hover-color: #666;
-//@highlight-color: rgba(102, 102, 102, 0.5); //Bund Dark grey
+@dropdown-link-background-hover-color: #999;
+@dropdown-link-background-focus-color: #666;
 @highlight-color: rgba(255, 128, 0, 0.3); //Bund Orange
-//@highlight-color: tgba(254, 251, 6, 0.5); //Bund Yellow
 
 [ga-search] {
   position: relative;
@@ -90,10 +89,17 @@
         background-color: #E6E6E6;
         margin-top: 1px;
 
-        &:hover {
+        &:hover, &:focus {
           color: @dropdown-link-color-hover-color;
-          background-color: @dropdown-link-background-hover-color;
           border-top: 1px;
+        }
+
+        &:focus {
+          background-color: @dropdown-link-background-focus-color;
+        }
+
+        &:hover {
+          background-color: @dropdown-link-background-hover-color;
           cursor: pointer;
         }
 


### PR DESCRIPTION
This PR adds keyboard navigation to search results as wished by https://github.com/geoadmin/mf-geoadmin3/issues/2189

Following keys are supported:
`Down Arrow Key`: jumps down one entry in the list (if tapped in search box, jumps to first result)
`Up Arrow Key`: jumps up one entry in the list (if tapped at first result of first category, jumps to search box)
`PageDown Key` : jumps down a maximum of 5 entries in the list
`PageUp Key`: jumps up a maximum 5 entries in the list
`Tab`: jumps to first result of next category (if there are results in than 1 categories, otherwise same as `Down Arrow Key`)
`SHIFT-Tab`: jumps to last result of previous category (if there are results in more than 1 category, otherwise same sas `Up Arrow Key`)

The `Enter` key will select the element (same as clicking on the element).

Down/Up/PageDown/PageUp also jump categories when at end/start of list.

[TestLink](http://mf-geoadmin3.dev.bgdi.ch/gjn_search_keyboard)