### PR TITLE
Improving makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,12 +157,6 @@ fastclick: .build-artefacts/fastclick .build-artefacts/closure-compiler/compiler
 	cp .build-artefacts/fastclick/lib/fastclick.js src/lib/fastclick.js
 	java -jar .build-artefacts/closure-compiler/compiler.jar src/lib/fastclick.js --compilation_level SIMPLE_OPTIMIZATIONS --js_output_file  src/lib/fastclick.min.js
 
-.PHONY: localforage
-localforage: .build-artefacts/localforage
-	cd .build-artefacts/localforage && git reset HEAD --hard
-	cp .build-artefacts/localforage/dist/localforage.js src/lib/localforage.js
-	cp .build-artefacts/localforage/dist/localforage.min.js src/lib/localforage.min.js
-
 .PHONY: filesaver
 filesaver: .build-artefacts/filesaver
 	cp .build-artefacts/filesaver/FileSaver.js src/lib/filesaver.js
@@ -270,11 +264,13 @@ test/karma-conf-prod.js: test/karma-conf.mako.js .build-artefacts/python-venv/bi
 node_modules: ANGULAR_JS = angular.js angular.min.js
 node_modules: ANGULAR_TRANSLATE_JS = angular-translate.js angular-translate.min.js 
 node_modules: ANGULAR_TRANSLATE_LOADER_JS = angular-translate-loader-static-files.js angular-translate-loader-static-files.min.js 
+node_modules: LOCALFORAGE = localforage.js localforage.min.js
 node_modules: package.json
 	npm install
 	cp $(addprefix node_modules/angular/,$(ANGULAR_JS)) src/lib/;
 	cp $(addprefix node_modules/angular-translate/dist/,$(ANGULAR_TRANSLATE_JS)) src/lib/;
 	cp $(addprefix node_modules/angular-translate/dist/angular-translate-loader-static-files/,$(ANGULAR_TRANSLATE_LOADER_JS)) src/lib/;
+	cp $(addprefix node_modules/localforage/dist/,$(LOCALFORAGE)) src/lib;
 
 
 .build-artefacts/app.js: .build-artefacts/js-files .build-artefacts/closure-compiler/compiler.jar .build-artefacts/externs/angular.js .build-artefacts/externs/jquery.js
@@ -384,9 +380,6 @@ scripts/00-$(GIT_BRANCH).conf: scripts/00-branch.mako-dot-conf .build-artefacts/
 
 .build-artefacts/fastclick:
 	git clone https://github.com/ftlabs/fastclick.git $@ && cd $@ && git checkout v1.0.6
-
-.build-artefacts/localforage:
-	git clone https://github.com/mozilla/localForage.git $@ && cd $@ && git checkout 1.0.1
 
 .build-artefacts/filesaver:
 	git clone https://github.com/eligrey/FileSaver.js.git $@

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GIT_LAST_BRANCH := $(shell if [ -f .build-artefacts/last-git-branch ]; then cat 
 DEPLOY_ROOT_DIR := /var/www/vhosts/mf-geoadmin3/private/branch
 DEPLOY_TARGET ?= 'dev'
 LAST_DEPLOY_TARGET := $(shell if [ -f .build-artefacts/last-deploy-target ]; then cat .build-artefacts/last-deploy-target 2> /dev/null; else echo '-none-'; fi)
-OL3_VERSION = tags/v3.4.0
+OL3_VERSION ?= tags/v3.4.0
 
 ## Python interpreter can't have space in path name
 ## So prepend all python scripts with python cmd

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ GIT_LAST_BRANCH := $(shell if [ -f .build-artefacts/last-git-branch ]; then cat 
 DEPLOY_ROOT_DIR := /var/www/vhosts/mf-geoadmin3/private/branch
 DEPLOY_TARGET ?= 'dev'
 LAST_DEPLOY_TARGET := $(shell if [ -f .build-artefacts/last-deploy-target ]; then cat .build-artefacts/last-deploy-target 2> /dev/null; else echo '-none-'; fi)
+OL3_VERSION = tags/v3.4.0
 
 ## Python interpreter can't have space in path name
 ## So prepend all python scripts with python cmd
@@ -140,6 +141,7 @@ ol: OL_JS = ol.js ol-debug.js
 ol: scripts/ol-geoadmin.json .build-artefacts/ol3 .build-artefacts/ol-requirements-installation.timestamp
 	cd .build-artefacts/ol3; \
 	git reset HEAD --hard; \
+	git checkout $(OL3_VERSION); \
 	git show; \
 	cat ../../scripts/ga-ol3-style.exports >> src/ol/style/style.js; \
 	cat ../../scripts/ga-ol3-tilegrid.exports >> src/ol/tilegrid/tilegrid.js; \
@@ -147,7 +149,7 @@ ol: scripts/ol-geoadmin.json .build-artefacts/ol3 .build-artefacts/ol-requiremen
 	npm install; \
 	node tasks/build.js config/ol-debug.json build/ol-debug.js; \
 	node tasks/build.js ../../scripts/ol-geoadmin.json build/ol.js; \
-  cd ../../; \
+	cd ../../; \
 	cp $(addprefix .build-artefacts/ol3/build/,$(OL_JS)) src/lib/;
 
 .PHONY: fastclick
@@ -375,7 +377,7 @@ scripts/00-$(GIT_BRANCH).conf: scripts/00-branch.mako-dot-conf .build-artefacts/
 	test $(DEPLOY_TARGET) != $(LAST_DEPLOY_TARGET) && echo $(DEPLOY_TARGET) > .build-artefacts/last-deploy-target || :
 
 .build-artefacts/ol3:
-	git clone https://github.com/openlayers/ol3.git $@ && cd $@ && git checkout v3.4.0
+	git clone https://github.com/openlayers/ol3.git $@
 
 .build-artefacts/bootstrap:
 	git clone https://github.com/twbs/bootstrap.git $@ && cd $@ && git checkout v3.3.1

--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ Use `make ol` to update the `ol.js` and `ol-debug.js` files.
 
 Add the correct version tag
 
-https://github.com/geoadmin/mf-geoadmin3/blob/master/Makefile#L370
+https://github.com/geoadmin/mf-geoadmin3/blob/master/Makefile#20
+
+You can also use an argument to test a new version of ol3, for instance you can do:
+
+    make OL3_VERSION="632205d902f8dcc1f03eb1dd1736d26a1b3ac2a3" ol
 
 Remember to update the API and API doc at the same time to keep coherency.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "commander": "2.2.0",
     "browserstack-webdriver": "2.41.1",
     "angular": "1.3.5",
-    "angular-translate": "2.4.2"
+    "angular-translate": "2.4.2",
+    "localforage": "1.0.1"
   }
 }
 


### PR DESCRIPTION
Before, one needed to use `make cleanall` and then rebuild the whole thing and finally make ol to update ol3 if ol3 folder already existed in `.build-artefacts` before hand.

This PR makes it now possible to update ol3 by simply changing the OL3_VERSION (It can be a commit, a tag reference etc...) variable or by editing ` scripts/ol-geoadmin.json`.

I also added localforage to package.json similarly to what has been done with angularjs.

