### PR TITLE
Keep the correct layer order when we highlight an object  from permalink

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1367,7 +1367,7 @@
           });
         });
 
-        var deregister = scope.$on('gaLayersChange', function() {
+        var deregister = $rootScope.$on('gaLayersChange', function() {
           var allowThirdData = false;
           var confirmedOnce = false;
           var nbLayersToAdd = layerSpecs.length;


### PR DESCRIPTION
Fix #2271 listening  `gaLayersChange`event on $rootScope to keep the correct execution order