### PR TITLE
Add https to geo admin links

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ determine which URL to test.
 
 Run it manually:
 
-    node test/selenium/tests.js -t http://map.geo.admin.ch
+    node test/selenium/tests.js -t https://map.geo.admin.ch
 
 This runs it with the given target URL.
 
@@ -173,7 +173,7 @@ The command adds a branch specific configuration to
 behaves exactly the same as any user specific deploy.
 
 Sample path:
-http://mf-geoadmin3.int.bgdi.ch/dev_bottombar/prod
+https://mf-geoadmin3.int.bgdi.ch/dev_bottombar/prod
 
 Please only use integration url for external communication (including here on 
 github), even though the exact same structure is also available on our test 

--- a/rc_branch.mako
+++ b/rc_branch.mako
@@ -1,3 +1,3 @@
 export APACHE_BASE_PATH=/${apache_base_path}
 export API_URL=//mf-chsdi3.${deploy_target}.bgdi.ch
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/${apache_base_path}
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/${apache_base_path}

--- a/rc_ci
+++ b/rc_ci
@@ -2,5 +2,5 @@ export KEEP_VERSION=false
 export DEPLOY_TARGET=ci
 export API_URL=//mf-chsdi3.ci.bgdi.ch
 export APACHE_BASE_PATH=
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.ci.bgdi.ch
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.ci.bgdi.ch
 export VARNISH_HOSTS=()

--- a/rc_demo
+++ b/rc_demo
@@ -1,4 +1,4 @@
 export DEPLOY_TARGET=demo
 export API_URL=//mf-chsdi3.demo.bgdi.ch
 export APACHE_BASE_PATH=
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.demo.bgdi.ch
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.demo.bgdi.ch

--- a/rc_dev
+++ b/rc_dev
@@ -2,5 +2,5 @@ export KEEP_VERSION=false
 export DEPLOY_TARGET=dev
 export API_URL=//mf-chsdi3.dev.bgdi.ch
 export APACHE_BASE_PATH=
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch
 export VARNISH_HOSTS=()

--- a/rc_int
+++ b/rc_int
@@ -2,5 +2,5 @@ export KEEP_VERSION=true
 export DEPLOY_TARGET=int
 export API_URL=//mf-chsdi3.int.bgdi.ch
 export APACHE_BASE_PATH=
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.int.bgdi.ch
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.int.bgdi.ch
 export VARNISH_HOSTS=(ip-10-220-6-55.eu-west-1.compute.internal)

--- a/rc_ltclm
+++ b/rc_ltclm
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltclm
 export APACHE_BASE_PATH=/ltclm
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltclm
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltclm

--- a/rc_ltfap
+++ b/rc_ltfap
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltfap
 export APACHE_BASE_PATH=/ltfap
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltfap
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltfap

--- a/rc_ltfoa
+++ b/rc_ltfoa
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltfoa
 export APACHE_BASE_PATH=/ltfoa
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltfoa
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltfoa

--- a/rc_ltgal
+++ b/rc_ltgal
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltgal
 export APACHE_BASE_PATH=/ltgal
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltgal
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltgal

--- a/rc_ltgud
+++ b/rc_ltgud
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltgud
 export APACHE_BASE_PATH=/ltgud
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltgud
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltgud

--- a/rc_ltjeg
+++ b/rc_ltjeg
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltjeg
 export APACHE_BASE_PATH=/ltjeg
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltjeg
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltjeg

--- a/rc_ltkan
+++ b/rc_ltkan
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltkan
 export APACHE_BASE_PATH=/ltkan
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltkan
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltkan

--- a/rc_ltmoc
+++ b/rc_ltmoc
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltmoc
 export APACHE_BASE_PATH=/ltmoc
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltmoc
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltmoc

--- a/rc_ltmom
+++ b/rc_ltmom
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltmom
 export APACHE_BASE_PATH=/ltmom
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltmom
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltmom

--- a/rc_ltpoa
+++ b/rc_ltpoa
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltpoa
 export APACHE_BASE_PATH=/ltpoa
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltpoa
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltpoa

--- a/rc_ltteo
+++ b/rc_ltteo
@@ -1,3 +1,3 @@
 export API_URL=//mf-chsdi3.dev.bgdi.ch/ltteo
 export APACHE_BASE_PATH=/ltteo
-export BROWSERSTACK_TARGETURL=http://mf-geoadmin3.dev.bgdi.ch/ltteo
+export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltteo

--- a/rc_prod
+++ b/rc_prod
@@ -2,5 +2,5 @@ export KEEP_VERSION=true
 export DEPLOY_TARGET=prod
 export API_URL=//api3.geo.admin.ch
 export APACHE_BASE_PATH=
-export BROWSERSTACK_TARGETURL=http://map.geo.admin.ch
+export BROWSERSTACK_TARGETURL=https://map.geo.admin.ch
 export VARNISH_HOSTS=(ip-10-220-5-136.eu-west-1.compute.internal ip-10-220-6-61.eu-west-1.compute.internal)

--- a/scripts/robots.mako-dot-txt
+++ b/scripts/robots.mako-dot-txt
@@ -4,8 +4,8 @@ User-agent: *
 
 Disallow: /checker
 
-Sitemap: http://map.geo.admin.ch/sitemap_addresses.xml
-Sitemap: http://map.geo.admin.ch/sitemap_index.xml
+Sitemap: https://map.geo.admin.ch/sitemap_addresses.xml
+Sitemap: https://map.geo.admin.ch/sitemap_index.xml
 
 % else:
 

--- a/src/components/catalogtree/example/index.html
+++ b/src/components/catalogtree/example/index.html
@@ -104,14 +104,14 @@
 
         module.config(['gaLayersProvider', function(gaLayersProvider) {
            gaLayersProvider.wmtsGetTileUrlTemplate =
-               'http://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
+               'https://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
                '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
            gaLayersProvider.layersConfigUrlTemplate =
-               'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
+               'https://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
                '?lang={Lang}';
            gaLayersProvider.legendUrlTemplate =
-               'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/{Layer}/legend' +
+               'https://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/{Layer}/legend' +
                '?lang={Lang}';
         }]);
 
@@ -170,7 +170,7 @@
         module.controller('CatalogTreeController', ['$rootScope', '$scope', '$http', 'gaLayers',
         function($rootScope, $scope, $http, gaLayers) {
 
-            var baseUrl = 'http://mf-chsdi3.dev.bgdi.ch/rest/services';
+            var baseUrl = 'https://mf-chsdi3.dev.bgdi.ch/rest/services';
             $scope.options = {
               catalogUrlTemplate: baseUrl + '/{Topic}/CatalogServer'
             };

--- a/src/components/featuretree/example/index.html
+++ b/src/components/featuretree/example/index.html
@@ -127,14 +127,14 @@
 
          module.config(['gaLayersProvider', function(gaLayersProvider) {
            gaLayersProvider.wmtsGetTileUrlTemplate =
-               'http://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
+               'https://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
                '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
            gaLayersProvider.layersConfigUrlTemplate =
-               'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
+               'https://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
                '?lang={Lang}';
            gaLayersProvider.legendUrlTemplate =
-               'http://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/{Layer}/legend' +
+               'https://mf-chsdi3.dev.bgdi.ch/rest/services/{Topic}/MapServer/{Layer}/legend' +
                '?lang={Lang}';
         }]);
 
@@ -194,7 +194,7 @@
         module.controller('FeatureTreeController', ['$scope',
           function($scope) {
 
-            var baseUrl = 'http://mf-geoadmin3.dev.bgdi.ch/main//rest/services';
+            var baseUrl = 'https://mf-geoadmin3.dev.bgdi.ch/main//rest/services';
 
             $scope.options = {
               msUrl: baseUrl + '/ech/MapServer',

--- a/src/components/importkml/example/index.html
+++ b/src/components/importkml/example/index.html
@@ -81,16 +81,16 @@
         ]);
 
         module.constant('gaGlobalOptions', {
-          serviceUrl : 'http://mf-chsdi3.dev.bgdi.ch'
+          serviceUrl : 'https://mf-chsdi3.dev.bgdi.ch'
         });
 
         module.config(['gaLayersProvider', function(gaLayersProvider) {
           gaLayersProvider.wmtsGetTileUrlTemplate =
-              'http://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
+              'https://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
               '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
-              'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
+              'https://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
               '?lang={Lang}';
         }]);
 

--- a/src/components/importwms/example/index.html
+++ b/src/components/importwms/example/index.html
@@ -84,16 +84,16 @@
         ]);
 
         module.constant('gaGlobalOptions', {
-          serviceUrl: 'http://mf-chsdi3.dev.bgdi.ch'
+          serviceUrl: 'https://mf-chsdi3.dev.bgdi.ch'
         });
         
         module.config(['gaLayersProvider', function(gaLayersProvider) {
           gaLayersProvider.wmtsGetTileUrlTemplate =
-              'http://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
+              'https://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
               '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
-              'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
+              'https://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
               '?lang={Lang}';
         }]);
 
@@ -133,7 +133,7 @@
                proxyUrl: gaGlobalOptions.serviceUrl + '/ogcproxy?url=',
                defaultGetCapParams: 'SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0',
                defaultWMSList: [
-                 'http://wms.geo.admin.ch/',
+                 'https://wms.geo.admin.ch/',
                  'http://ogc.heig-vd.ch/mapserver/wms?',
                  'http://www.wms.stadt-zuerich.ch/WMS-ZH-STZH-OGD/MapServer/WMSServer?',
                  'http://wms.geo.gl.ch/?',

--- a/src/components/map/example/index.html
+++ b/src/components/map/example/index.html
@@ -77,11 +77,11 @@
 
         module.config(['gaLayersProvider', function(gaLayersProvider) {
           gaLayersProvider.wmtsGetTileUrlTemplate =
-              'http://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
+              'https://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/' +
               '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
 
           gaLayersProvider.layersConfigUrlTemplate =
-            'http://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
+            'https://mf-chsdi3.dev.bgdi.ch/rest/services/all/MapServer/layersConfig' +
             '?lang={Lang}';
         }]);
 

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -698,7 +698,7 @@
       // Transform graticule to literal
       if ($scope.options.graticule) {
         var graticule = {
-          'baseURL': 'http://wms.geo.admin.ch/',
+          'baseURL': 'https://wms.geo.admin.ch/',
           'opacity': 1,
           'singleTile': true,
           'type': 'WMS',

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -50,7 +50,7 @@ itemscope itemtype="http://schema.org/WebApplication"
     <meta property="og:title" content="Swiss Geoportal"/>
     <meta property="og:description" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
     <meta property="og:type" content="WebApplication"/>
-    <meta property="og:url" content="http://map.geo.admin.ch"/>
+    <meta property="og:url" content="https://map.geo.admin.ch"/>
     <meta property="og:image" content="${versionslashed}img/logo_geoportal.png"/>
 
     <!-- Twitter Card Infos -->
@@ -60,7 +60,7 @@ itemscope itemtype="http://schema.org/WebApplication"
     <meta name="twitter:title" content="geo.admin.ch"/>
     <meta name="twitter:description" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
     <meta name="twitter:image" content="${versionslashed}img/logo_geoportal.png"/>
-    <meta name="twitter:url" content="http://map.geo.admin.ch"/>
+    <meta name="twitter:url" content="https://map.geo.admin.ch"/>
 
     <!-- Facebook Specific fb:admins and fb.appid -->
 

--- a/src/js/ImportWmsController.js
+++ b/src/js/ImportWmsController.js
@@ -9,7 +9,7 @@
          proxyUrl: gaGlobalOptions.ogcproxyUrl,
          defaultGetCapParams: 'SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0',
          defaultWMSList: [
-           'http://wms.geo.admin.ch/',
+           'https://wms.geo.admin.ch/',
            'http://ogc.heig-vd.ch/mapserver/wms?',
            'http://www.gis.stadt-zuerich.ch/maps/services/wms/WMS-ZH-STZH-OGD/MapServer/WMSServer?',
            'http://wms.geo.gl.ch/?',

--- a/test/specs/share/ShareDirective.spec.js
+++ b/test/specs/share/ShareDirective.spec.js
@@ -9,7 +9,7 @@ describe('ga_share_directive', function() {
 
     inject(function($rootScope, $compile) {
       $rootScope.options = {
-        serviceUrl: 'http://api.geo.admin.ch',
+        serviceUrl: 'https://api.geo.admin.ch',
         iframeSizes: [{
           label: 'small_size',
           value: [1, 1]


### PR DESCRIPTION
This enable to run tests against https and keeps https valid for geo admin wms

#2238 (HTTPS)
#2318 (WMS.geo.admin.ch)

https://mf-geoadmin3.dev.bgdi.ch/ltpoa/?X=198293.05&Y=614529.59&zoom=3&lang=fr&topic=ech&bgLayer=voidLayer&layers=WMS%7C%7CArri%C3%A8re-plan%20hydrologique%7C%7Chttps:%2F%2Fwms.geo.admin.ch%2F%7C%7Cch.bafu.hydrologie-hintergrundkarte,WMS%7C%7CCapacit%C3%A9%20de%20r%C3%A9tention%20hydrique%7C%7Chttps:%2F%2Fwms.geo.admin.ch%2F%7C%7Cch.blw.bodeneignung-wasserspeichervermoegen