### PR TITLE
Search only enabled when topic is loaded

### DIFF
--- a/src/components/search/partials/search.html
+++ b/src/components/search/partials/search.html
@@ -5,7 +5,8 @@
     autocapitalize="none" autocomplete="off" autocorrect="off"
     ng-keydown="keydown($event)"
     ng-blur="lostFocus($event)"
-    ng-focus="onFocus()">
+    ng-focus="onFocus()"
+    ng-disabled="!childoptions.currentTopic">
     <span class="ga-search-dropdown" ng-show="restat.sets()">
       <!-- footer -->
       <div class="ga-search-footer clearfix">


### PR DESCRIPTION
This PR assures that search requests are only send when a topic is loaded. Without this fix, the client
sometimes sends search requests with topic 'undefined', resulting in uneeded traffic and 400 response from back-end

See also: https://logs.bgdi.ch/kibana/#/dashboard/elasticsearch/undefined%20topic