### PR TITLE
Change the way html files are generated from the templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,20 +203,35 @@ prd/geoadmin.appcache: src/geoadmin.mako.appcache .build-artefacts/python-venv/b
 	mkdir -p $(dir $@);
 	${PYTHON_CMD} .build-artefacts/python-venv/bin/mako-render --var "version=$(VERSION)" --var "deploy_target=$(DEPLOY_TARGET)" --var "apache_base_path=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
 
-prd/index.html: src/index.mako.html .build-artefacts/python-venv/bin/mako-render .build-artefacts/python-venv/bin/htmlmin .build-artefacts/last-api-url .build-artefacts/last-apache-base-path .build-artefacts/last-version
+prd/index.html: src/index.mako.html \
+	    .build-artefacts/python-venv/bin/mako-render \
+	    node_modules \
+	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-apache-base-path \
+	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	${PYTHON_CMD} .build-artefacts/python-venv/bin/mako-render --var "device=desktop" --var "mode=prod" --var "version=$(VERSION)" --var "versionslashed=$(VERSION)/" --var "apache_base_path=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
-	${PYTHON_CMD} .build-artefacts/python-venv/bin/htmlmin --remove-comments --keep-optional-attribute-quotes $@ $@
+	./node_modules/html-minifier/cli.js --remove-comments $@ $@
 
-prd/mobile.html: src/index.mako.html .build-artefacts/python-venv/bin/mako-render .build-artefacts/python-venv/bin/htmlmin .build-artefacts/last-api-url .build-artefacts/last-apache-base-path .build-artefacts/last-version
+prd/mobile.html: src/index.mako.html \
+	    .build-artefacts/python-venv/bin/mako-render \
+	    node_modules \
+	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-apache-base-path \
+	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	${PYTHON_CMD} .build-artefacts/python-venv/bin/mako-render --var "device=mobile" --var "mode=prod" --var "version=$(VERSION)" --var "versionslashed=$(VERSION)/" --var "apache_base_path=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
-	${PYTHON_CMD} .build-artefacts/python-venv/bin/htmlmin --remove-comments --keep-optional-attribute-quotes $@ $@
+	./node_modules/html-minifier/cli.js --remove-comments $@ $@
 
-prd/embed.html: src/index.mako.html .build-artefacts/python-venv/bin/mako-render .build-artefacts/python-venv/bin/htmlmin .build-artefacts/last-api-url .build-artefacts/last-apache-base-path .build-artefacts/last-version
+prd/embed.html: src/index.mako.html \
+	    .build-artefacts/python-venv/bin/mako-render \
+	    node_modules \
+	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-apache-base-path \
+	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	${PYTHON_CMD} .build-artefacts/python-venv/bin/mako-render --var "device=embed" --var "mode=prod" --var "version=$(VERSION)" --var "versionslashed=$(VERSION)/" --var "apache_base_path=$(APACHE_BASE_PATH)" --var "api_url=$(API_URL)" $< > $@
-	${PYTHON_CMD} .build-artefacts/python-venv/bin/htmlmin --remove-comments --keep-optional-attribute-quotes $@ $@
+	./node_modules/html-minifier/cli.js --remove-comments $@ $@
 
 prd/img/: src/img/*
 	mkdir -p $@
@@ -273,7 +288,10 @@ node_modules: package.json
 	cp $(addprefix node_modules/localforage/dist/,$(LOCALFORAGE)) src/lib;
 
 
-.build-artefacts/app.js: .build-artefacts/js-files .build-artefacts/closure-compiler/compiler.jar .build-artefacts/externs/angular.js .build-artefacts/externs/jquery.js
+.build-artefacts/app.js: .build-artefacts/js-files \
+	    .build-artefacts/closure-compiler/compiler.jar \
+	    .build-artefacts/externs/angular.js \
+	    .build-artefacts/externs/jquery.js
 	mkdir -p $(dir $@)
 	java -jar .build-artefacts/closure-compiler/compiler.jar $(SRC_JS_FILES_FOR_COMPILER) --compilation_level SIMPLE_OPTIMIZATIONS --jscomp_error checkVars --externs externs/ol.js --externs .build-artefacts/externs/angular.js --externs .build-artefacts/externs/jquery.js --js_output_file $@
 
@@ -298,10 +316,6 @@ $(addprefix .build-artefacts/annotated/, $(SRC_JS_FILES) src/TemplateCacheModule
 	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install "Mako==1.0.0"
 	touch $@
 	cp scripts/cmd.py .build-artefacts/python-venv/local/lib/python2.7/site-packages/mako/cmd.py
-
-.build-artefacts/python-venv/bin/htmlmin: .build-artefacts/python-venv
-	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install "htmlmin"
-	touch $@
 
 .build-artefacts/translate-requirements-installation.timestamp: .build-artefacts/python-venv
 	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install "PyYAML==3.10"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "browserstack-webdriver": "2.41.1",
     "angular": "1.3.5",
     "angular-translate": "2.4.2",
-    "localforage": "1.0.1"
+    "localforage": "1.0.1",
+    "html-minifier": "0.7.2"
   }
 }
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -7,7 +7,7 @@ itemscope itemtype="http://schema.org/WebApplication"
 % endif
 >
   <head>
-    <!--![if !HTML5]>
+    <!--[if !HTML5]>
     <meta http-equiv="X-UA-Compatible" content="IE=9,IE=10,IE=edge,chrome=1"/>
     <![endif]-->
 % if device == 'desktop':
@@ -118,7 +118,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           'embed': globals.embed
         }">
     <!-- The below conditional is ignored by >= IE10 and all other browsers -->
-    <!--![if IE]>
+    <!--[if IE]>
       <script>
        (function(){
        var msgDocumentMode = "";
@@ -618,7 +618,7 @@ itemscope itemtype="http://schema.org/WebApplication"
     <script src="${versionslashed}lib/build.js"></script>
     <!-- For <= IE9, we load it explicitely as XDomain does not support
          dynamic/lazy loading of javascript -->
-    <!--![if IE]>
+    <!--[if IE]>
     <script src="${versionslashed}lib/bootstrap-datetimepicker.min.js"></script>
     <script src="${versionslashed}lib/d3-3.3.1.min.js"></script>
     <script src="${versionslashed}lib/jQuery.XDomainRequest.js"></script>

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 <!DOCTYPE html>
 <html ng-app="ga" ng-controller="GaMainController"
 itemscope itemtype="http://schema.org/WebApplication"


### PR DESCRIPTION
- Switch to a mako (installed on the system) on python3 to avoid encoding problem. Your patched version of cmp.py is not needed any more.
- Use html-minifier (a nodejs module) to minify HTML instead of htmlmin (python)

If you want only parts of these modification, feel free to ask me to remove some commits.