### PR TITLE
Fix profile display on FF

### DIFF
--- a/src/components/measure/style/measure.less
+++ b/src/components/measure/style/measure.less
@@ -4,6 +4,7 @@
   .ga-measure-panel-group {
     display: inline-block;
     width: 225px;
+    float: left;
   }
 
   .ga-measure-text {


### PR DESCRIPTION
Because of a silghtly different implementation of the box model profile is hidden on FF.

https://github.com/geoadmin/mf-chsdi3/pull/1425