### PR TITLE
For profiles, use POST and geometry in body of request

### DIFF
--- a/src/components/profile/ProfileService.js
+++ b/src/components/profile/ProfileService.js
@@ -103,10 +103,25 @@
           return data;
         };
 
+        var coordinatesToString = function(coordinates) {
+          var res = '[';
+          for (var i = 0; i < coordinates.length; i++) {
+            var coord = coordinates[i];
+            if (i !== 0) {
+              res += ',';
+            }
+            res += '[';
+            res += coord[0].toFixed(1) + ',' + coord[1].toFixed(1);
+            res += ']';
+          }
+          res += ']';
+          return res;
+        };
+
         this.get = function(feature, callback) {
           var coordinates = feature.getGeometry().getCoordinates();
           var wkt = '{"type":"LineString","coordinates":' +
-                    angular.toJson(coordinates) + '}';
+                    coordinatesToString(coordinates) + '}';
 
           //cancel old request
           cancel();


### PR DESCRIPTION
This changes the usage of the profile service. We use POST now and transfer the geometry as part of the request body instead of in the URL. Therefore, we avoid very large URLS in any case.

[Test here](https://mf-geoadmin3.dev.bgdi.ch/gjn_profile_post)

In any case, using POST with geometry in the body of the request seem to be the more reasonable approach anyway as the URL is not meant to transfer data...