### PR TITLE
Fullscreen mode: search title is not visible enough

### DIFF
--- a/src/style/app.less
+++ b/src/style/app.less
@@ -187,6 +187,12 @@ button.ga-btn, .ol-control button {
 
   #search-container {
     width: 80%;
+
+    a {
+      background-color: rgba(255, 255, 255, 1);
+      border-radius: 3px;
+      padding: 1px 6px;
+    }
   }
   
   &.ga-full-screen-no-inputs #search-container, 


### PR DESCRIPTION
[Test link](https://mf-geoadmin3.dev.bgdi.ch/kan_fullscreen_search_title)

I set the background color as plain white. It is not 'style consistent' with the attribution label (which has a slight transparent bg but it gives the best contrast with any background layer behind it. 