### PR TITLE
Language selector: abbreviation text links instead of select box

### DIFF
--- a/src/components/translation/TranslationDirective.js
+++ b/src/components/translation/TranslationDirective.js
@@ -6,54 +6,53 @@
     'pascalprecht.translate'
   ]);
 
-  module.directive('gaTranslationSelector',
-      function($translate, $window, gaBrowserSniffer, gaPermalink) {
-          return {
-            restrict: 'A',
-            scope: {
-              options: '=gaTranslationSelectorOptions'
-            },
-            templateUrl: function() {
-              return 'components/translation/partials/translation' +
-                  ((gaBrowserSniffer.mobile) ? 'mobile' : 'desktop') + '.html';
-            },
-            link: function(scope, element, attrs) {
-              scope.$watch('lang', function(value) {
-                $translate.use(value).then(angular.noop, function(lang) {
-                  // failed to load lang from server, fallback to default code.
-                  scope.lang = scope.options.fallbackCode;
-                });
-                gaPermalink.updateParams({lang: value});
-              });
+  module.directive('gaTranslationSelector', function($translate, $window,
+      gaBrowserSniffer, gaPermalink) {
+    return {
+      restrict: 'A',
+      scope: {
+        options: '=gaTranslationSelectorOptions'
+      },
+      templateUrl: function() {
+        return 'components/translation/partials/translation' +
+            ((gaBrowserSniffer.mobile) ? 'mobile' : 'desktop') + '.html';
+      },
+      link: function(scope, element, attrs) {
+        scope.$watch('lang', function(value) {
+          $translate.use(value).then(angular.noop, function(lang) {
+            // failed to load lang from server, fallback to default code.
+            scope.lang = scope.options.fallbackCode;
+          });
+          gaPermalink.updateParams({lang: value});
+        });
 
-              function topicSupportsLang(topic, lang) {
-                var i;
-                var langs = topic.langs;
-                for (i = 0; i < langs.length; i++) {
-                  if (langs[i].value === lang) {
-                    return true;
-                  }
-                }
-                return false;
-              }
-
-              scope.$on('gaTopicChange', function(event, topic) {
-                if (!topicSupportsLang(topic, scope.lang)) {
-                  // fallback to default code
-                  scope.lang = scope.options.fallbackCode;
-                }
-                scope.options.langs = topic.langs;
-              });
-
-              scope.lang = gaPermalink.getParams().lang ||
-                  ($window.navigator.userLanguage ||
-                   $window.navigator.language).split('-')[0];
-
-              scope.selectLang = function(value) {
-                scope.lang = value;
-              };
-
+        function topicSupportsLang(topic, lang) {
+          var i;
+          var langs = topic.langs;
+          for (i = 0; i < langs.length; i++) {
+            if (langs[i].value === lang) {
+              return true;
             }
-          };
-      });
+          }
+          return false;
+        }
+
+        scope.$on('gaTopicChange', function(event, topic) {
+          if (!topicSupportsLang(topic, scope.lang)) {
+            // fallback to default code
+            scope.lang = scope.options.fallbackCode;
+          }
+          scope.options.langs = topic.langs;
+        });
+
+        scope.lang = gaPermalink.getParams().lang ||
+            ($window.navigator.userLanguage ||
+             $window.navigator.language).split('-')[0];
+
+        scope.selectLang = function(value) {
+          scope.lang = value;
+        };
+      }
+    };
+  });
 })();

--- a/src/components/translation/TranslationDirective.js
+++ b/src/components/translation/TranslationDirective.js
@@ -7,14 +7,20 @@
   ]);
 
   module.directive('gaTranslationSelector',
-      function($translate, $window, gaPermalink) {
+      function($translate, $window, gaBrowserSniffer, gaPermalink) {
           return {
             restrict: 'A',
-            replace: true,
             scope: {
               options: '=gaTranslationSelectorOptions'
             },
-            templateUrl: 'components/translation/partials/translation.html',
+            templateUrl: function() {
+              if (gaBrowserSniffer.mobile) {
+                return 'components/translation/partials/translationmobile.html';
+              } else {
+                return 'components/translation/partials/' +
+                    'translationdesktop.html';
+              }
+            },
             link: function(scope, element, attrs) {
               scope.$watch('lang', function(value) {
                 $translate.use(value).then(angular.noop, function(lang) {
@@ -46,6 +52,11 @@
               scope.lang = gaPermalink.getParams().lang ||
                   ($window.navigator.userLanguage ||
                    $window.navigator.language).split('-')[0];
+
+              scope.selectLang = function(value) {
+                scope.lang = value;
+              };
+
             }
           };
       });

--- a/src/components/translation/TranslationDirective.js
+++ b/src/components/translation/TranslationDirective.js
@@ -14,12 +14,8 @@
               options: '=gaTranslationSelectorOptions'
             },
             templateUrl: function() {
-              if (gaBrowserSniffer.mobile) {
-                return 'components/translation/partials/translationmobile.html';
-              } else {
-                return 'components/translation/partials/' +
-                    'translationdesktop.html';
-              }
+              return 'components/translation/partials/translation' +
+                  ((gaBrowserSniffer.mobile) ? 'mobile' : 'desktop') + '.html';
             },
             link: function(scope, element, attrs) {
               scope.$watch('lang', function(value) {

--- a/src/components/translation/partials/translation.html
+++ b/src/components/translation/partials/translation.html
@@ -1,2 +1,0 @@
-<select ng-model="lang" ng-options="l.value as l.label for l in options.langs">
-</select>

--- a/src/components/translation/partials/translationdesktop.html
+++ b/src/components/translation/partials/translationdesktop.html
@@ -1,1 +1,3 @@
-<a href ng-class="{'ga-selected-link' : lang == l.value}" ng-click="selectLang(l.value)" ng-repeat="l in options.langs" class="ga-lang-links">{{ l.label }}</a>
+<a href="" ng-class="{'ga-selected-link' : lang == l.value}"
+   ng-click="selectLang(l.value)"
+   ng-repeat="l in options.langs">{{l.label}}</a>

--- a/src/components/translation/partials/translationdesktop.html
+++ b/src/components/translation/partials/translationdesktop.html
@@ -1,0 +1,1 @@
+<a href ng-class="{'ga-selected-link' : lang == l.value}" ng-click="selectLang(l.value)" ng-repeat="l in options.langs" class="ga-lang-links">{{ l.label }}</a>

--- a/src/components/translation/partials/translationmobile.html
+++ b/src/components/translation/partials/translationmobile.html
@@ -1,0 +1,1 @@
+<select ng-model="lang" ng-options="l.value as l.label for l in options.langs"></select>

--- a/src/components/translation/style/translation.less
+++ b/src/components/translation/style/translation.less
@@ -1,8 +1,9 @@
-  .ga-lang-links {
-    padding-left:3px;
+[ga-translation-selector] {
+  a {
+    padding-left: 3px;
   }
-
   .ga-selected-link {
-    color: #ff0000!important;
+    color: #ff0000;
   }
+}
 

--- a/src/components/translation/style/translation.less
+++ b/src/components/translation/style/translation.less
@@ -1,0 +1,8 @@
+  .ga-lang-links {
+    padding-left:3px;
+  }
+
+  .ga-selected-link {
+    color: #ff0000!important;
+  }
+

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -423,14 +423,8 @@ input[type=text][readonly] {
   & > div {
     display: inline-block;
   }
-  select {
-    height: 20px;
-    line-height: 20px;
-    padding: 1px .3em;
-  }
   a {
     font-size: 80%;
-    color: #333;
   }
 }
 

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -30,6 +30,7 @@
 @import "../components/offline/style/offline.less";
 @import "../components/query/style/query.less";
 @import "../components/timestampcontrol/style/timestampcontrol.less";
+@import "../components/translation/style/translation.less";
 
 
 @header-height: 89;


### PR DESCRIPTION
This PR change select box for language change to links on desktop (see #2394). Mobile behavior stay unchanged.

[Test link](https://mf-geoadmin3.dev.bgdi.ch/kan_lang_change_links/)