### PR TITLE
Explicit wait on alert message in wms tests

### DIFF
--- a/test/selenium/wms_test.js
+++ b/test/selenium/wms_test.js
@@ -27,6 +27,14 @@ var runTest = function(cap, driver, target) {
   driver.findElement(webdriver.By.xpath("//*[@id='import-wms-popup']//div[contains(text(),'AGNES')]")).click();
   // Click on "Layer hinzufügen"
   driver.findElement(webdriver.By.xpath("//*[@id='import-wms-popup']//button[contains(text(),'Layer hinzufügen')]")).click();
+  driver.wait(function() {
+    try {
+      driver.switchTo().alert();
+      return true;
+    }
+    catch (e) {
+    }
+  }, 2000);
   // Accept the alert
   driver.switchTo().alert().accept();
   // Check if the WMS was correctly parsed


### PR DESCRIPTION
All in the title. This is to prevent errors that occur from time to time in IE10/IE11 in browserstack, as here: https://jenkins.ci.bgdi.ch/job/geoadmin3/76/console