### PR TITLE
Do not use cached ur for legend 

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -737,7 +737,7 @@ itemscope itemtype="http://schema.org/WebApplication"
               gaGlobalOptions.cachedApiUrl + '/rest/services/all/MapServer/layersConfig?lang={Lang}';
 
           gaLayersProvider.legendUrlTemplate =
-              gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/MapServer/{Layer}/legend?lang={Lang}';
+              gaGlobalOptions.apiUrl + '/rest/services/{Topic}/MapServer/{Layer}/legend?lang={Lang}';
         });
 
         module.config(function(gaExportKmlProvider, gaGlobalOptions) {


### PR DESCRIPTION
`cachedApiUrl`is updated at every `deploy`and hold in cache for one year, whicle `apiUrl` is never cached.

Some legends (BAZL's _luftfahrthindernis_) use the BOD table `datenstand` which is updated and deployed every 4 hours. So its content may change.

See https://github.com/geoadmin/mf-chsdi3/issues/1511