### PR TITLE
Considering min- and max-resolution for geojson layer

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -918,6 +918,8 @@
             var fullUrl = gaGlobalOptions.ogcproxyUrl + layer.geojsonUrl;
             var olSource = new ol.source.Vector();
             olLayer = new ol.layer.Vector({
+              minResolution: layer.minResolution,
+              maxResolution: layer.maxResolution,
               source: olSource
             });
             var setLayerSource = function() {
@@ -958,6 +960,7 @@
             olLayer.geojsonUrl = layer.geojsonUrl;
             olLayer.updateDelay = layer.updateDelay;
           }
+
           return olLayer;
         };
 


### PR DESCRIPTION
In order to test:

Build `mf-geoadmin3`using your own `http://mf-chsdi3.dev.bgdi.ch/mom_geojson_scale` for service (export API_URL...). It is using the `bod_ltmom_master`DB. You may want change and edit values in `layerjs`if you want.


I have modified the `bod`DB (in `bod_ltmom_ master`) as follow:

layer    | min. res | max. res
----------|-----------|-------------
ch.bafu.hydroweb-messstationen_gefahren | 0.01  | 100
ch.bafu.hydroweb-messstationen_grundwasser  | 100  |  --
ch.bafu.hydroweb-messstationen_temperatur  | --  | 100
ch.bafu.hydroweb-messstationen_zustand  | -- | --


Note, It breaks the geo.admin.ch rule staing that a layer is visible at all scales
