### PR TITLE
Use background layers provided by the current topic

### DIFF
--- a/src/components/backgroundselector/BackgroundSelectorDirective.js
+++ b/src/components/backgroundselector/BackgroundSelectorDirective.js
@@ -24,6 +24,7 @@
           scope.isBackgroundSelectorClosed = true;
           var mobile = gaBrowserSniffer.mobile;
           scope.desktop = !gaBrowserSniffer.embed && !mobile;
+          scope.backgroundLayers = [];
 
           if (mobile) {
             elt.addClass('ga-bg-mobile');
@@ -35,11 +36,7 @@
           var isOfflineToOnline = false;
           var currentTopic;
 
-          var defaultBgOrder = [
-              {id: 'ch.swisstopo.swissimage', label: 'bg_luftbild'},
-              {id: 'ch.swisstopo.pixelkarte-farbe', label: 'bg_pixel_color'},
-              {id: 'ch.swisstopo.pixelkarte-grau', label: 'bg_pixel_grey'},
-              {id: 'voidLayer', label: 'void_layer'}];
+          var defaultBgOrder = [];
 
           scope.backgroundLayers = defaultBgOrder.slice(0);
 
@@ -65,6 +62,21 @@
             }
           }
 
+         scope.$on('gaLayersLoaded', function() {
+           defaultBgOrder = [];
+            gaLayers.getBackgroundLayers().forEach(function(bgLayer) {
+              defaultBgOrder.push({
+                id: bgLayer.id,
+                label: bgLayer.label
+              });
+            });
+            defaultBgOrder.push({
+              id: 'voidLayer',
+              label: 'void_layer'
+            });
+            scope.backgroundLayers = defaultBgOrder.slice(0);
+          });
+
           scope.$on('gaLayersChange', function(event, data) {
 
             // Determine the current background layer. Strategy:
@@ -87,7 +99,12 @@
             }
             if ((!bgLayer && !scope.currentLayer) ||
               (currentTopic && (currentTopic != data.topicId))) {
-              bgLayer = gaLayers.getBackgroundLayers()[0].id;
+              var bgLayers = gaLayers.getBackgroundLayers();
+              if (bgLayers.length > 0) {
+                bgLayer = bgLayers[0].id;
+              } else {
+                bgLayer = 'voidLayer';
+              }
               scope.backgroundLayers = defaultBgOrder.slice(0);
             }
             if (bgLayer && !isOfflineToOnline) {

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -757,6 +757,7 @@
 
           var promise = $http.get(url).then(function(response) {
             layers = response.data;
+            $rootScope.$broadcast('gaLayersLoaded');
           }, function(response) {
             layers = undefined;
           });


### PR DESCRIPTION
- Choice of background layers is not hard coded
- Topics without background layers don't create an error
- Add a signal which is broadcasted when layers are loaded. Necessary to
know when we can access the list of background layers.