### PR TITLE
For https for in KML

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -21,6 +21,11 @@ AddOutputFilterByType DEFLATE application/json
   Header set X-UA-Compatible "IE=Edge"
 </IfModule>
 
+# Enabling CORS
+Header set Access-Control-Allow-Origin "*"
+Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS"
+Header always set Access-Control-Allow-Headers "x-requested-with, Content-Type, origin, authorization, accept, client-security-token"
+
 # Redirect no-slash target to slashed version
 RedirectMatch ^${apache_base_path}$ ${apache_base_path}/
 

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -445,14 +445,21 @@
       // Read a kml string then return a list of features.
       var readFeatures = function(kml) {
         // Replace all hrefs to prevent errors if image doesn't have
-        // CORS headers. Exception for google markers icons (lightblue.png,
-        // ltblue-dot.png, ltblu-pushpin.png, ...) to keep the OL3 magic for
-        // anchor origin.
-        // Test regex here: http://regex101.com/r/tF3vM0
+        // CORS headers. Exception for *admin.ch, *.bgdi.ch and google markers
+        // icons (lightblue.png, ltblue-dot.png, ltblu-pushpin.png, ...) to
+        // keep the OL3 magic for anchor origin.
+        // Test regex here: http://regex101.com/r/tF3vM0/3
         // List of google icons: http://www.lass.it/Web/viewer.aspx?id=4
         kml = kml.replace(
           /<href>http(?!(s?):\/\/(maps\.(?:google|gstatic)\.com.*(blue|green|orange|pink|purple|red|yellow|pushpin).*\.png|.*(bgdi|admin)\.ch))/g,
           '<href>' + gaGlobalOptions.ogcproxyUrl + 'http'
+        );
+
+        // Replace all http hrefs from *.admin.ch or *.bgdi.ch by https
+        // Test regex here: http://regex101.com/r/fY7wB3/3
+        kml = kml.replace(
+          /<href>http(?!(s))(?=:\/\/(.*(bgdi|admin)\.ch))/g,
+          '<href>https'
         );
 
         var all = [];

--- a/test/specs/ThrottleService.spec.js
+++ b/test/specs/ThrottleService.spec.js
@@ -13,10 +13,10 @@ describe('ga_throttle_service', function() {
   it('throttles', inject(function($timeout) {
     var funcThrottled = gaThrottle.throttle(function() {
       cpt++;
-    }, 100);
+    }, 99);
     var funcThrottledNoTrail = gaThrottle.throttle(function() {
       cptNoTrail++;
-    }, 100, true);
+    }, 99, true);
     while (now < last) {
       funcThrottled();
       funcThrottledNoTrail();


### PR DESCRIPTION
Only for icons that comes form *.admin.ch or *.bgdi.ch.

This PR also fixes the ThrottleService test.

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_https2/)