### PR TITLE
No cache for main pages

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -60,3 +60,15 @@ RewriteRule ^${apache_base_path}/sitemap_(.*)\.xml http:${api_url}/${version}/si
     Header unset Last-Modified
 </Location>
 
+# Assure main pages are not cached with headers set according to
+# http://stackoverflow.com/questions/49547/making-sure-a-web-page-is-not-cached-across-all-browser
+<LocationMatch ^${apache_base_path}/(index.html|mobile.html|embed.html)$>
+    Header unset Cache-Control
+    Header unset Pragma
+    Header unset Expires
+    Header unset Last-Modified
+    Header unset Vary
+    Header set Cache-Control "no-cache, no-store, must-revalidate"
+    Header set Pragma "no-cache"
+    Header set Expires 0
+</LocationMatch>


### PR DESCRIPTION
Assures that our main pages (index.html, mobile.html and embed.html) are not cached by all browsers, according to http://stackoverflow.com/questions/49547/making-sure-a-web-page-is-not-cached-across-all-browser