### PR TITLE
Replace sn25 with gazetteer in locations search (preview)

### DIFF
--- a/src/components/search/partials/searchtypes.html
+++ b/src/components/search/partials/searchtypes.html
@@ -19,7 +19,8 @@
          ng-mouseenter="preview(res)"
          ng-mouseleave="out()">
       <div class="ga-search-item"
-           ng-bind-html="prepareLabel(res.attrs)">
+           ng-bind-html="prepareLabel(res.attrs)"
+           title="{{cleanLabel(res.attrs)}}">
       </div>
       <i class="icon-info-sign"
          ng-if="type === 'layers'"

--- a/src/components/search/style/search.less
+++ b/src/components/search/style/search.less
@@ -86,6 +86,12 @@
   }
 
   .ga-search-results-container {
+
+    .ga-search-item {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
     
     .ga-search-results {
       overflow-y: auto;


### PR DESCRIPTION
Switches map.geo to use the new preview sphinx indices which replaces sn25 location entries with gazetteer location entries. With the new gazetter, labels might be quite long, therefore we strip the results with css (`text-overflow: ellipsis;`) and display full results as tooltip (title attribute).

https://github.com/geoadmin/mf-chsdi3/pull/1548 needs to be merged first.

We need review/test for tomorrows deploy.

As we can't deploy chsdi3 branches yet, please test [under my unstable account](https://mf-geoadmin3.dev.bgdi.ch/ltjeg/)