### PR TITLE
Restart instead of start apache in hook

### DIFF
--- a/deploy/hooks/post-restore
+++ b/deploy/hooks/post-restore
@@ -5,7 +5,7 @@
 #            section in config file)
 #
 if [ -x /etc/init.d/apache2 ]; then
-    sudo /etc/init.d/apache2 start
+    sudo /etc/init.d/apache2 restart
 fi
 
 exit 0


### PR DESCRIPTION
We have observed that during deploy, puppet might start apache in the wrong moment. So instead of start after the deploy, we are using restart to assure that the just deployed configuration is taken into account.