### PR TITLE
Use publicUrl to match files from our storage service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ LAST_APACHE_BASE_PATH := $(shell if [ -f .build-artefacts/last-apache-base-path 
 API_URL ?= //mf-chsdi3.dev.bgdi.ch
 LAST_API_URL := $(shell if [ -f .build-artefacts/last-api-url ]; then cat .build-artefacts/last-api-url 2> /dev/null; else echo '-none-'; fi)
 PUBLIC_URL ?= //public.dev.bgdi.ch
+PUBLIC_URL_REGEXP ?= https?:\/\/public\..*(bgdi|admin)\.ch.*
+ADMIN_URL_REGEXP ?= ^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)
 LESS_PARAMETERS ?= '-ru'
 KEEP_VERSION ?= 'false'
 LAST_VERSION := $(shell if [ -f .build-artefacts/last-version ]; then cat .build-artefacts/last-version 2> /dev/null; else echo '-none-'; fi)
@@ -280,6 +282,8 @@ define buildpage
 		--var "resolutions"="$(RESOLUTIONS)" \
 		--var "public_url=$(PUBLIC_URL)" \
 		--var "default_elevation_model=${DEFAULT_ELEVATION_MODEL}" \
+		--var "admin_url_regexp=$(ADMIN_URL_REGEXP)" \
+		--var "public_url_regexp=$(PUBLIC_URL_REGEXP)" \
 		--var "default_epsg"="$(DEFAULT_EPSG)" \
 		--var "default_epsg_extend"="$(DEFAULT_EPSG_EXTEND)" $< > $@
 endef

--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -5,7 +5,7 @@ goog.provide('ga_urlutils_service');
 
   module.provider('gaUrlUtils', function() {
 
-    this.$get = function() {
+    this.$get = function(gaGlobalOptions) {
 
       var UrlUtils = function() {
 
@@ -14,12 +14,6 @@ goog.provide('ga_urlutils_service');
         var URL_REGEXP =
             /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
 
-        var URL_ADMIN_REGEXP =
-            /^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)/;
-
-        var URL_PUBLIC_REGEXP =
-            /^https?:\/\/public\..*(bgdi|geo\.admin)\.ch.*/;
-
         // Test validity of a URL
         this.isValid = function(url) {
           return (!!url && url.length > 0 && URL_REGEXP.test(url));
@@ -27,12 +21,18 @@ goog.provide('ga_urlutils_service');
 
         // Test if the URL comes from a friendly site
         this.isAdminValid = function(url) {
-          return (this.isValid(url) && URL_ADMIN_REGEXP.test(url));
+          return (this.isValid(url) &&
+                  gaGlobalOptions.adminUrlRegexp.test(url));
         };
 
         // Test if the URL comes from a third party site
         this.isThirdPartyValid = function(url) {
-          return !this.isAdminValid(url) || URL_PUBLIC_REGEXP.test(url);
+          return !this.isAdminValid(url) ||
+                  this.isPublicValid(url);
+        };
+
+        this.isPublicValid = function(url) {
+          return gaGlobalOptions.publicUrlRegexp.test(url);
         };
 
         this.transformIfAgnostic = function(url) {

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1239,6 +1239,13 @@ goog.require('ga_urlutils_service');
           if (id instanceof ol.layer.Layer) {
             id = olLayerOrId.id;
           }
+
+          // id for KML layers is like KML||<url> We must remove KML|| before
+          // testing the validity of the url.
+          if (id && id.indexOf('KML||') == 0) {
+            id = id.substring(5);
+          }
+
           return this.isKmlLayer(olLayerOrId) &&
                   gaUrlUtils.isPublicValid(id);
         },

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1239,8 +1239,8 @@ goog.require('ga_urlutils_service');
           if (id instanceof ol.layer.Layer) {
             id = olLayerOrId.id;
           }
-          var regex = /https?:\/\/public\..*(\.admin\.ch|\.bgdi\.ch)\/.*/;
-          return this.isKmlLayer(olLayerOrId) && regex.test(id);
+          return this.isKmlLayer(olLayerOrId) &&
+                  gaUrlUtils.isPublicValid(id);
         },
 
         // Test if a layer is an external WMS layer added by th ImportWMS tool

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -686,6 +686,8 @@ itemscope itemtype="http://schema.org/WebApplication"
           mapUrl : location.origin + '${apache_base_path}',
           apiUrl : location.protocol + '${api_url}',
           publicUrl : location.protocol + '${public_url}',
+          publicUrlRegexp: new RegExp('${public_url_regexp}'),
+          adminUrlRegexp: new RegExp('${admin_url_regexp}'),
           cachedApiUrl: location.protocol + '${api_url}' + cacheAdd,
           resourceUrl: location.origin + pathname + '${versionslashed}',
           ogcproxyUrl : location.protocol + '${api_url}' + '/ogcproxy?url=',

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -5,7 +5,7 @@ beforeEach(function() {
   module(function($provide) {
     var location = {
       host: 'map.admin.ch',
-      hostname: 'map.geo.admin.ch', 
+      hostname: 'map.geo.admin.ch',
       href: 'http://map.geo.admin.ch/?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=207277.79&Y=690852.63&zoom=1',
       origin: 'http://map.geo.admin.ch',
       pathname: '/',
@@ -36,8 +36,9 @@ beforeEach(function() {
       ],
       defaultTopicId: 'sometopic',
       translationFallbackCode: 'somelang',
-      defaultExtent: [420000, 30000,900000, 350000],
-      defaultResolution: 500.0
+      defaultResolution: 500.0,
+      publicUrlRegexp: /^https?:\/\/public\..*(bgdi|admin)\.ch.*/,
+      adminUrlRegexp: /^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)/
     });
   });
 
@@ -84,7 +85,7 @@ beforeEach(function() {
     gaProfileProvider.profileUrl =
         gaGlobalOptions.apiUrl + '/rest/services/profile.json';
   });
-  
+
   module(function(gaQueryProvider, gaGlobalOptions) {
     gaQueryProvider.dpUrl = gaGlobalOptions.resourceUrl +
         'lib/bootstrap-datetimepicker.min.js';

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -48,6 +48,16 @@ describe('ga_urlutils_service', function() {
     expect(gaUrlUtils.isThirdPartyValid('https://wms.geo.admin.ch')).to.be(false);
   });
 
+  it('verifies public valid', function() {
+    expect(gaUrlUtils.isPublicValid('http://public.geo.admin.ch')).to.be(true);
+    expect(gaUrlUtils.isPublicValid('http://public.geo.bgdi.ch')).to.be(true);
+    expect(gaUrlUtils.isPublicValid('http://public.geo.admin.ch/auie')).to.be(true);
+    expect(gaUrlUtils.isPublicValid('http://public.geo.bgdi.ch/auie')).to.be(true);
+    expect(gaUrlUtils.isPublicValid('http://heig.ch')).to.be(false);
+    expect(gaUrlUtils.isPublicValid('http://bgdi.ch')).to.be(false);
+    expect(gaUrlUtils.isPublicValid('ftp://wms.geo.admin.ch')).to.be(false);
+  });
+
   it('appends parameter string', function() {
     var url = 'http://wms.admin.ch';
     url = gaUrlUtils.append(url, 'SERVICE=WMS');


### PR DESCRIPTION
I directly use publicUrl so it can only match one domain. I don't know if you have the case where files can come from both public.admin.ch and public.bgdi.ch. If so, let me know, I will update the pull request.