### PR TITLE
Print: enable button when config is loaded. Adapt tests

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -22,13 +22,13 @@ goog.require('ga_print_style_service');
     var UNITS_RATIO = 39.37; // inches per meter
     var POLL_INTERVAL = 2000; //interval for multi-page prints (ms)
     var POLL_MAX_TIME = 600000; //ms (10 minutes)
-    var printConfigLoaded = false;
     var currentTime = undefined;
     var layersYears = [];
     var canceller;
     var currentMultiPrintId;
     var format = new ol.format.GeoJSON();
     var styleId = 0;
+    $scope.printConfigLoaded = false;
     $scope.options.multiprint = false;
     $scope.options.movie = false;
     $scope.options.printing = false;
@@ -1028,7 +1028,7 @@ goog.require('ga_print_style_service');
 
     $scope.$watch('active', function(newVal, oldVal) {
       if (newVal === true) {
-        if (!printConfigLoaded) {
+        if (!$scope.printConfigLoaded) {
           loadPrintConfig().success(function(data) {
             $scope.capabilities = data;
             angular.forEach($scope.capabilities.layouts, function(lay) {
@@ -1043,7 +1043,7 @@ goog.require('ga_print_style_service');
             $scope.options.legend = false;
             $scope.options.graticule = false;
             activate();
-            printConfigLoaded = true;
+            $scope.printConfigLoaded = true;
           });
         } else {
           activate();

--- a/src/components/print/partials/print.html
+++ b/src/components/print/partials/print.html
@@ -47,6 +47,7 @@
           class="btn btn-default col-xs-12"
           accesskey="p"
           ng-hide="options.printing"
+          ng-disabled="!printConfigLoaded"
           ng-click="submit()" translate>print_action</button>
   <!-- this span is purely for e2e testing purposes, to detect print success/failure in DOM -->
   <span ng-if="options.printsuccess"></span>

--- a/test/selenium/print_test.js
+++ b/test/selenium/print_test.js
@@ -13,6 +13,8 @@ var runTest = function(cap, driver, target) {
   driver.findElement(webdriver.By.xpath("//a[@id='printHeading']")).click();
   // Wait until print is opened and animation is finished
   driver.findElement(webdriver.By.xpath("//div[@id='print' and contains(@class, 'collapse in')]"));
+  // Wait until configuration is loaded
+  driver.findElement(webdriver.By.xpath("//*[@id='print']//option[@label='A4 portrait']"));
 
   // Selenium IE and FF are not able to handle menu selection
   if(!(cap.browser != "IE" || cap.browser != "Firefox")){
@@ -32,7 +34,7 @@ var runTest = function(cap, driver, target) {
 
   // Try Print
   driver.findElement(webdriver.By.xpath("//button[contains(text(), 'Erstelle PDF')]")).click();
-  // Does it success?
+  // Did it succeed?
   driver.findElement(webdriver.By.xpath("//span[@ng-if='options.printsuccess']"));
 }
 


### PR DESCRIPTION
This assures that you can print only after configuration has been loaded. In addition, it adapts the tests accordingly, which should render them more stable.

@oterral Prefarably for tomorrow.

