### PR TITLE
Adapt varnish insances for flushing after deploy

### DIFF
--- a/rc_int
+++ b/rc_int
@@ -4,4 +4,4 @@ export API_URL=//mf-chsdi3.int.bgdi.ch
 export PUBLIC_URL=//public.int.bgdi.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.int.bgdi.ch
-export VARNISH_HOSTS=(ip-10-220-6-55.eu-west-1.compute.internal)
+export VARNISH_HOSTS=(ip-10-220-6-234.eu-west-1.compute.internal ip-10-220-4-93.eu-west-1.compute.internal)

--- a/rc_prod
+++ b/rc_prod
@@ -4,4 +4,4 @@ export API_URL=//api3.geo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=https://map.geo.admin.ch
-export VARNISH_HOSTS=(p-10-220-6-39.eu-west-1.compute.internal ip-10-220-5-181.eu-west-1.compute.internal)
+export VARNISH_HOSTS=(ip-10-220-6-39.eu-west-1.compute.internal ip-10-220-5-181.eu-west-1.compute.internal)

--- a/rc_prod
+++ b/rc_prod
@@ -4,4 +4,4 @@ export API_URL=//api3.geo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=https://map.geo.admin.ch
-export VARNISH_HOSTS=(ip-10-220-5-136.eu-west-1.compute.internal ip-10-220-6-61.eu-west-1.compute.internal)
+export VARNISH_HOSTS=(p-10-220-6-39.eu-west-1.compute.internal ip-10-220-5-181.eu-west-1.compute.internal)


### PR DESCRIPTION
This adaps the varnish instances to those running version 4 (active since today). The flushvarnish command runs without errors, but I'm not sure if it's really working.

