### PR TITLE
Cancel previous catalog request if antother is launched

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -103,6 +103,7 @@ goog.require('ga_translation_service');
               }
             };
             var lastUrlUsed;
+            var canceller;
             var updateCatalogTree = function(topic, lang) {
               // If topics are not yet loaded, we do nothing
               if (!topic) {
@@ -117,7 +118,12 @@ goog.require('ga_translation_service');
                 labelsOnly = true;
               }
               lastUrlUsed = url;
+              if (canceller) {
+                canceller.resolve();
+              }
+              canceller = $q.defer();
               $http.get(url, {
+                timeout: canceller.promise,
                 cache: true,
                 params: {
                   'lang': lang


### PR DESCRIPTION
DE catalog was not loaded when we opens Gewiss in IT, this PR cancel previous catalog requests

Fix #2512 

@procrastinatio does it seems ok for you?

https://mf-geoadmin3.dev.bgdi.ch/teo_catalog/?topic=gewiss&lang=it