### PR TITLE
[WIP] Prevent broadcasting while some directives or controller may not be initialized

### DIFF
--- a/src/components/topic/TopicService.js
+++ b/src/components/topic/TopicService.js
@@ -11,7 +11,8 @@ goog.require('ga_permalink');
    * Topics manager
    */
   module.provider('gaTopic', function() {
-    this.$get = function($rootScope, $http, $q, gaPermalink, gaGlobalOptions) {
+    this.$get = function($rootScope, $http, $q, $timeout, gaPermalink,
+        gaGlobalOptions) {
       var topic; // The current topic
       var topics = []; // The list of topics available
 
@@ -66,7 +67,10 @@ goog.require('ga_permalink');
           topics = topics;
           topic = getTopicById(gaPermalink.getParams().topic, true);
           if (topic) {
-            broadcast();
+            // We must wait for all the directive to be completely initialized
+            // before broadcasting. Otherwise, we may broadcast while nothing
+            // is initialized to recieve the message.
+            $timeout(broadcast);
           }
         });
 

--- a/test/specs/topic/TopicService.spec.js
+++ b/test/specs/topic/TopicService.spec.js
@@ -1,5 +1,6 @@
 describe('ga_topic_service', function() {
-  var gaTopic, $httpBackend, $rootScope, gaGlobalOptions, topicPermalink, gaPermalink,
+  var gaTopic, $httpBackend, $rootScope, $timeout, gaGlobalOptions, topicPermalink,
+  gaPermalink,
       expectedUrl = 'http://api3.geo.admin.ch/123456/rest/services',
       topics = [{
         "langs": "de,fr,it",
@@ -39,6 +40,7 @@ describe('ga_topic_service', function() {
     inject(function($injector) {
       $httpBackend = $injector.get('$httpBackend');
       $rootScope = $injector.get('$rootScope');
+      $timeout = $injector.get('$timeout');
       gaGlobalOptions = $injector.get('gaGlobalOptions');
       gaTopic = $injector.get('gaTopic');
       gaPermalink = $injector.get('gaPermalink');
@@ -63,6 +65,7 @@ describe('ga_topic_service', function() {
         cpt++;
       });
       $httpBackend.flush();
+      $timeout.flush();
     });
 
     it('has loaded topics', function() {
@@ -116,6 +119,7 @@ describe('ga_topic_service', function() {
     beforeEach(function() {
       topicPermalink = 'anothertopic';
       $httpBackend.flush();
+      $timeout.flush();
     });
 
     it('loads the topic from permalink if exist', function() {
@@ -128,6 +132,7 @@ describe('ga_topic_service', function() {
     beforeEach(function() {
       topicPermalink = 'topicnotexisting';
       $httpBackend.flush();
+      $timeout.flush();
     });
 
     it('loads the default topic if the topic in permalink doesn t exist', function() {


### PR DESCRIPTION
We must wait for all the directive to be completely initialized before broadcasting. Otherwise, we may broadcast while nothing is initialized to receive the message.

The $broadcast which is done in TopicService may happen before the directives are initialized. We add a $timeout to wait for complete DOM initialization to be sure all components that must listen to $broadcast('gaTopicChange') are ready.