### PR TITLE
Different handling of topic loading at application start

### DIFF
--- a/src/components/topic/TopicDirective.js
+++ b/src/components/topic/TopicDirective.js
@@ -43,15 +43,17 @@ goog.require('ga_topic_service');
               }
             });
 
-            scope.$on('gaTopicChange', function(evt, newTopic) {
-              if (!scope.activeTopic) {
-                scope.topics = gaTopic.getTopics();
-                scope.$applyAsync(function() {
-                  element.find('.ga-topic-item').tooltip({
-                    placement: 'bottom'
-                  });
+            gaTopic.getTopics().then(function(topics) {
+              scope.topics = topics;
+              scope.activeTopic = gaTopic.get();
+              scope.$applyAsync(function() {
+                element.find('.ga-topic-item').tooltip({
+                  placement: 'bottom'
                 });
-              }
+              });
+            });
+
+            scope.$on('gaTopicChange', function(evt, newTopic) {
               if (scope.activeTopic != newTopic) {
                 scope.activeTopic = newTopic;
               }

--- a/src/components/topic/TopicService.js
+++ b/src/components/topic/TopicService.js
@@ -60,7 +60,9 @@ goog.require('ga_permalink');
       var Topic = function(topicsUrl) {
 
         // We load the topics configuration
-        loadTopics(topicsUrl).then(function(fetchedTopics) {
+        var topicsP = loadTopics(topicsUrl);
+
+        topicsP.then(function(fetchedTopics) {
           topics = fetchedTopics;
           topic = getTopicById(gaPermalink.getParams().topic, true);
           if (topic) {
@@ -68,8 +70,9 @@ goog.require('ga_permalink');
           }
         });
 
+        // Returns a promise that is resolved when topics are loaded
         this.getTopics = function() {
-          return topics;
+          return topicsP;
         };
 
         this.set = function(newTopic, force) {

--- a/test/specs/topic/TopicDirective.spec.js
+++ b/test/specs/topic/TopicDirective.spec.js
@@ -1,5 +1,5 @@
 describe('ga_topic_directive', function() {
-  var element, $rootScope, $compile, topics;
+  var element, $rootScope, $compile, $q, topics, def;
 
   beforeEach(function() {
     topics = [{
@@ -12,18 +12,24 @@ describe('ga_topic_directive', function() {
       $provide.value('gaTopic', new (function() {
         var topic = topics[0];
         this.getTopics = function() {
-          return topics;
+          return def.promise;
+        };
+        this.get = function() {
+          return topic;
         };
         this.set = function(newTopic) {
           topic = newTopic;
-        }
+        };
       })());
     });
 
-    inject(function(_$rootScope_, _$compile_) {
+    inject(function(_$rootScope_, _$compile_, $q) {
       $rootScope = _$rootScope_;
       $compile = _$compile_;
+      def = $q.defer();
     });
+
+
   });
    
   describe('uses template by default (desktop)', function() {
@@ -42,6 +48,7 @@ describe('ga_topic_directive', function() {
     describe('loads a topic', function() {
 
       beforeEach(function() {
+        def.resolve(topics);
         $rootScope.$broadcast('gaTopicChange', topics[0]);
         $rootScope.$digest();
       });
@@ -95,6 +102,7 @@ describe('ga_topic_directive', function() {
     describe('loads a topic', function() {
 
       beforeEach(function() {
+        def.resolve(topics);
         $rootScope.$broadcast('gaTopicChange', topics[0]);
         $rootScope.$digest();
       });

--- a/test/specs/topic/TopicService.spec.js
+++ b/test/specs/topic/TopicService.spec.js
@@ -66,7 +66,9 @@ describe('ga_topic_service', function() {
     });
 
     it('has loaded topics', function() {
-      expect(gaTopic.getTopics().length).to.be(2);
+      gaTopic.getTopics().then(function(tps) {
+        expect(tps.length).to.be(2);
+      });
     });
 
     it('has loaded the default topic', function() {


### PR DESCRIPTION
This is an alternative to https://github.com/geoadmin/mf-geoadmin3/pull/2520

Before, we handled 2 concerns (application init when topics are loaded and topic changes) in one broddcast. This could lead to timing issues as described by @Jenselme in his PR.

This PR tries to separate those 2 concerns. It distinguishes application init and topic changes.
