### PR TITLE
Close drop down on blur

### DIFF
--- a/src/components/search/partials/search.html
+++ b/src/components/search/partials/search.html
@@ -5,14 +5,14 @@
     placeholder="{{'search_placeholder' | translate}}" ng-model="query"
     autocapitalize="none" autocomplete="off" autocorrect="off"
     ng-keydown="keydown($event)"
-    ng-blur="lostFocus($event)"
+    ng-blur="lostFocus()"
     ng-focus="onFocus()"
     ng-disabled="!childoptions.currentTopic">
     <i class="icon-search"></i>
     <button class="icon-remove-sign ga-icon ga-btn" ng-click="clearInput()"
        ng-mousedown="preClear($event)" ng-hide="query==''"></button>
 
-    <span class="ga-search-dropdown" ng-show="restat.sets()">
+    <span class="ga-search-dropdown" ng-show="showDropDown()">
       <!-- locations -->
       <div ng-class="'ga-search-' + restat.sets()">
         <div ga-search-locations ga-search-locations-options="childoptions" ga-search-locations-map="map"></div>
@@ -27,4 +27,4 @@
       </div>
     </span> <!-- dropdown -->
   </span> <!-- input container -->
-  </form>
+</form>


### PR DESCRIPTION
This PR is introduced mainly to fix https://github.com/geoadmin/mf-geoadmin3/issues/25111

Note that I had to use a timeout for the click on the result items as the blur event on the input is fired before the click. (If you have other suggestions..)

Behavior is the same as before for swissearch and keyboard nav, the only change is that the dropdown list now closes when the input loses focus. In other words, we don't need to clear the query or select an entry for the dropdown list to disappear.