### PR TITLE
Make kml test a little more tolerant

### DIFF
--- a/test/selenium/kml_test.js
+++ b/test/selenium/kml_test.js
@@ -38,7 +38,7 @@ var runTest = function(cap, driver, target) {
         assert.ok(url.indexOf(POSITION_TO_KML) > -1);
         return true;
       });
-    }, 1000);
+    }, 2000);
   }
 
   // Go to the KML linkedURL


### PR DESCRIPTION
Randomly, the kml test still fails. I assume our timeout is a little tight sometimes. I'll increase it.