### PR TITLE
Remove i tags from lable (search)

### DIFF
--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -185,7 +185,7 @@ goog.provide('ga_search_service');
           return res;
         },
         cleanLabel: function(str) {
-          return str.replace(/(<b>|<\/b>)/gi, '');
+          return str.replace(/(<b>|<\/b>|<i>|<\/i>)/gi, '');
         }
       };
     };


### PR DESCRIPTION
This removes the <i> tags from the labels for the new (testing) swissnames category names. It can safely be merged as it works as well with old indices.