### PR TITLE
Varnish hosts for v3/v4 setup

### DIFF
--- a/rc_prod
+++ b/rc_prod
@@ -4,4 +4,4 @@ export API_URL=//api3.geo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=https://map.geo.admin.ch
-export VARNISH_HOSTS=(ip-10-220-6-39.eu-west-1.compute.internal ip-10-220-5-181.eu-west-1.compute.internal)
+export VARNISH_HOSTS=(ip-10-220-6-39.eu-west-1.compute.internal ip-10-220-5-181.eu-west-1.compute.internal ip-10-220-6-61.eu-west-1.compute.internal ip-10-220-5-136.eu-west-1.compute.internal)


### PR DESCRIPTION
We should assure to reset both v3 and v4 varnish instances, as it's not clear when the actual switch will take place.