### PR TITLE
Adding 3d dev switch

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -26,6 +26,12 @@ Header set Access-Control-Allow-Origin "*"
 Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS"
 Header always set Access-Control-Allow-Headers "x-requested-with, Content-Type, origin, authorization, accept, client-security-token"
 
+# To be removed once 3d goes live
+RedirectMatch ^${apache_base_path}/3d$ ${apache_base_path}/3d/
+RedirectMatch ^${apache_base_path}/3d/src$ ${apache_base_path}/src/?dev3d=true
+RedirectMatch ^${apache_base_path}/3d/$ ${apache_base_path}/?dev3d=true
+# end of 3d dev specific stuff
+
 # Redirect no-slash target to slashed version
 RedirectMatch ^${apache_base_path}$ ${apache_base_path}/
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -139,6 +139,10 @@ itemscope itemtype="http://schema.org/WebApplication"
         IE9Fix.call(this);
       </script>
     <![endif]-->
+
+    <!-- to be removed once 3d is live -->
+    <div class="corner-ribbon top-left sticky red shadow" ng-if="globals.dev3d">3D - ALPHA</div>
+
     <div ng-controller="GaSeoController">
       <div ga-seo ga-seo-options="options" ga-seo-map="map"></div>
     </div>
@@ -683,6 +687,8 @@ itemscope itemtype="http://schema.org/WebApplication"
         var pathname = location.pathname.replace(/(index|mobile|embed)\.html$/g, '');
 
         module.constant('gaGlobalOptions', {
+          //dev3d to be removed once 3d goes live
+          dev3d : !!window.location.search.match(/(dev3d=true)/),
           mapUrl : location.origin + '${apache_base_path}',
           apiUrl : location.protocol + '${api_url}',
           publicUrl : location.protocol + '${public_url}',

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -155,6 +155,7 @@ goog.require('ga_storage_service');
     });
 
     $scope.globals = {
+      dev3d: gaGlobalOptions.dev3d,
       searchFocused: false,
       homescreen: false,
       tablet: gaBrowserSniffer.mobile && !gaBrowserSniffer.phone,

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -1523,4 +1523,77 @@ body:not(.embed) {
   }
 }
 
+/* Corner ribbons, from http://codepen.io/eode9/pen/twkKm */
+.corner-ribbon{
+  width: 200px;
+  background: #e43;
+  position: absolute;
+  top: 25px;
+  left: -50px;
+  text-align: center;
+  line-height: 50px;
+  letter-spacing: 1px;
+  color: #f0f0f0;
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+  z-index: 10000;
+}
+
+/* Custom styles */
+
+.corner-ribbon.sticky{
+  position: fixed;
+}
+
+.corner-ribbon.shadow{
+  box-shadow: 0 0 3px rgba(0,0,0,.3);
+}
+
+/* Different positions */
+
+.corner-ribbon.top-left{
+  top: 25px;
+  left: -50px;
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+}
+
+.corner-ribbon.top-right{
+  top: 25px;
+  right: -50px;
+  left: auto;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+}
+
+.corner-ribbon.bottom-left{
+  top: auto;
+  bottom: 25px;
+  left: -50px;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+}
+
+.corner-ribbon.bottom-right{
+  top: auto;
+  right: -50px;
+  bottom: 25px;
+  left: auto;
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+/* Colors */
+
+.corner-ribbon.white{background: #f0f0f0; color: #555;}
+.corner-ribbon.black{background: #333;}
+.corner-ribbon.grey{background: #999;}
+.corner-ribbon.blue{background: #39d;}
+.corner-ribbon.green{background: #2c7;}
+.corner-ribbon.turquoise{background: #1b9;}
+.corner-ribbon.purple{background: #95b;}
+.corner-ribbon.red{background: red; color: white;}
+.corner-ribbon.orange{background: #e82;}
+.corner-ribbon.yellow{background: #ec0;}}
+
+
+
 @import "print.less";


### PR DESCRIPTION
This adds a global dev3d switch indicating that the page is loaded with 3d features enabled. See discussion https://github.com/geoadmin/mf-geoadmin3/pull/2554

It also adds a ALPHA ribbon in top left corner to indicate status.

To load page with dev3d switch, you can do (replace user specifc url part accordingly):
https://mf-geoadmin3.dev.bgdi.ch/ltjeg/3d
https://mf-geoadmin3.dev.bgdi.ch/ltjeg/?dev3d=true

For source mode
https://mf-geoadmin3.dev.bgdi.ch/ltjeg/src/3d
https://mf-geoadmin3.dev.bgdi.ch/ltjeg/src/?dev3d=true

Switch should be used to exclude 3d specific code from current page. Use either `gaGlobalOptions.dev3d` or `scope.globals.dev3d` to check state in-code.