### PR TITLE
Add languages to global options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ LAST_DEPLOY_TARGET := $(shell if [ -f .build-artefacts/last-deploy-target ]; the
 OL3_VERSION ?= v3.6.0
 DEFAULT_TOPIC_ID ?= ech
 TRANSLATION_FALLBACK_CODE ?= de
+LANGUAGES ?= '[\"de\", \"en\", \"fr\", \"it\", \"rm\"]'
 DEFAULT_EXTENT ?= '[420000, 30000, 900000, 350000]'
 DEFAULT_RESOLUTION ?= 500.0
 RESOLUTIONS ?= '[650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0, 2.5, 2.0, 1.0, 0.5, 0.25, 0.1]'
@@ -264,6 +265,7 @@ prd/geoadmin.appcache: src/geoadmin.mako.appcache \
 	    --var "version=$(VERSION)" \
 	    --var "deploy_target=$(DEPLOY_TARGET)" \
 	    --var "apache_base_path=$(APACHE_BASE_PATH)" \
+	    --var "languages=$(LANGUAGES)" \
 	    --var "api_url=$(API_URL)" \
 	    --var "public_url=$(PUBLIC_URL)" $< > $@
 
@@ -277,6 +279,7 @@ define buildpage
 		--var "api_url=$(API_URL)" \
 		--var "default_topic_id=$(DEFAULT_TOPIC_ID)" \
 		--var "translation_fallback_code=$(TRANSLATION_FALLBACK_CODE)" \
+		--var "languages=$(LANGUAGES)" \
 		--var "default_extent"="$(DEFAULT_EXTENT)" \
 		--var "default_resolution"="$(DEFAULT_RESOLUTION)" \
 		--var "resolutions"="$(RESOLUTIONS)" \

--- a/src/components/translation/TranslationService.js
+++ b/src/components/translation/TranslationService.js
@@ -19,6 +19,10 @@ goog.require('ga_topic_service');
           ($window.navigator.userLanguage ||
           $window.navigator.language).split('-')[0];
 
+      if (gaGlobalOptions.languages.indexOf(lang) === -1) {
+        lang = gaGlobalOptions.translationFallbackCode;
+      }
+
       // Verify if a language is supported by the current topic
       var isLangSupportedByTopic = function(lang, topic) {
         if (!topic) {

--- a/src/geoadmin.mako.appcache
+++ b/src/geoadmin.mako.appcache
@@ -1,6 +1,11 @@
+<%page args="languages" />
 <%
+  import json
   defaultLanguage = 'en'
-  languages = ('de', 'en', 'fr', 'it', 'rm')
+  # The languages variable must contain simple quote to be correctly parsed in
+  # index.html but here it prevents python to parse the JSON. So we manually
+  # remove them.
+  languages = json.loads(languages[1:-1])
 %>CACHE MANIFEST
 # Version ${version}
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -707,7 +707,8 @@ itemscope itemtype="http://schema.org/WebApplication"
           resolutions: JSON.parse(${resolutions}),
           defaultEpsg: '${default_epsg}',
           defaultEpsgExtent: JSON.parse(${default_epsg_extend}),
-          defaultElevationModel: '${default_elevation_model}'
+          defaultElevationModel: '${default_elevation_model}',
+          languages: JSON.parse(${languages})
         });
 
         module.config(function($translateProvider, gaGlobalOptions) {

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -36,6 +36,7 @@ beforeEach(function() {
       ],
       defaultTopicId: 'sometopic',
       translationFallbackCode: 'somelang',
+      languages: ['de', 'fr', 'it', 'en', 'rm', 'somelang'],
       defaultResolution: 500.0,
       publicUrlRegexp: /^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*/,
       adminUrlRegexp: /^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)/

--- a/test/specs/translation/TranslationService.spec.js
+++ b/test/specs/translation/TranslationService.spec.js
@@ -75,7 +75,6 @@ describe('ga_translation_service', function() {
     $httpBackend.whenGET('locales/en.json').respond({});
     $httpBackend.whenGET('locales/it.json').respond({});
     $httpBackend.whenGET('locales/rm.json').respond({});
-    $httpBackend.whenGET('locales/langnotexisting.json').respond(404, '');
   });
 
   afterEach(function () {
@@ -114,14 +113,11 @@ describe('ga_translation_service', function() {
     });
 
     it('defines a wrong language in the permlink then load the default language (topic not yet loaded)', function() {
-      expect(gaLang.get()).to.be(langPermalink);
-      $httpBackend.expectGET('locales/' + langPermalink + '.json');
+      expect(gaLang.get()).to.be(gaGlobalOptions.translationFallbackCode);
       $httpBackend.expectGET('locales/' + gaGlobalOptions.translationFallbackCode + '.json');
       $httpBackend.flush();
       expect(gaLang.get()).to.be(gaGlobalOptions.translationFallbackCode);
-      // TODO: The $translateChangeEnd event shouldn't be triggered for the non
-      // existing language
-      expect(cpt).to.be(2);
+      expect(cpt).to.be(1);
       expect(gaPermalink.getParams().lang).to.be(gaGlobalOptions.translationFallbackCode);
 
       // We set a lang not available in the topic


### PR DESCRIPTION
TranslationService will use the list of languages if the topics are not
leaded yet. So we are sure to use the fallback language if the lang in
permalink or most likely the language we get from the web browser is not
supported. Without this, the loading of layerConfig.json migth fail and
thus the portail will be unsuable.

This assumes that the default topic is available for the fallback
language.