### PR TITLE
Add gaBackground service

### DIFF
--- a/src/components/backgroundselector/BackgroundSelectorDirective.js
+++ b/src/components/backgroundselector/BackgroundSelectorDirective.js
@@ -1,19 +1,19 @@
 goog.provide('ga_backgroundselector_directive');
 
+goog.require('ga_background_service');
 goog.require('ga_map');
 goog.require('ga_permalink');
 goog.require('ga_topic_service');
+
 (function() {
 
   var module = angular.module('ga_backgroundselector_directive', [
     'ga_map',
-    'ga_permalink',
-    'ga_topic_service'
+    'ga_background_service'
   ]);
 
   module.directive('gaBackgroundSelector',
-    function($document, $rootScope, gaPermalink, gaLayers, gaLayerFilters,
-        gaBrowserSniffer, $q, gaTopic, gaGlobalOptions) {
+    function($document, $rootScope, gaBrowserSniffer, gaBackground) {
       return {
         restrict: 'A',
         templateUrl:
@@ -25,6 +25,7 @@ goog.require('ga_topic_service');
           scope.isBackgroundSelectorClosed = true;
           var mobile = gaBrowserSniffer.mobile;
           scope.desktop = !gaBrowserSniffer.embed && !mobile;
+          scope.backgroundLayers = gaBackground.getBackgrounds();
 
           if (mobile) {
             elt.addClass('ga-bg-mobile');
@@ -32,148 +33,50 @@ goog.require('ga_topic_service');
             elt.addClass('ga-bg-desktop');
           }
 
-          var map = scope.map;
-          var isOfflineToOnline = false;
-
-          var defaultBgOrder = [
-              {id: 'ch.swisstopo.swissimage', label: 'bg_luftbild'},
-              {id: 'ch.swisstopo.pixelkarte-farbe', label: 'bg_pixel_color'},
-              {id: 'ch.swisstopo.pixelkarte-grau', label: 'bg_pixel_grey'},
-              {id: 'voidLayer', label: 'void_layer'}];
-
-          // to be moved in defaultBgOrder once 3d is live
-          if (gaGlobalOptions.dev3d && gaBrowserSniffer.webgl) {
-            defaultBgOrder.splice(3, 0,
-                {id: 'ch.swisstopo.terrain.3d', label: 'terrain_layer'});
-          }
-          scope.backgroundLayers = defaultBgOrder.slice(0);
-
-          function setCurrentLayer(layerid) {
-            if (layerid) {
-              var layers = map.getLayers();
-              if (layerid == 'voidLayer') {
-                if (layers.getLength() > 0 &&
-                    layers.item(0).background === true) {
-                  layers.removeAt(0);
-                }
-              } else if (gaLayers.getLayer(layerid)) {
-                var layer = gaLayers.getOlLayerById(layerid);
-                layer.background = true;
-                layer.displayInLayerManager = false;
-                if (layers.item(0) && layers.item(0).background) {
-                  layers.setAt(0, layer);
-                } else {
-                  layers.insertAt(0, layer);
-                }
-              }
-              $rootScope.$broadcast('gaBgChange', layerid);
-              gaPermalink.updateParams({bgLayer: layerid});
-            }
-          };
-          var isValidBgLayer = function(bgLayerId) {
-            var isValid = false;
-            angular.forEach(scope.backgroundLayers, function(bgLayer) {
-              if (bgLayer.id == bgLayerId) {
-                isValid = true;
-              }
-            });
-            return isValid;
-          };
-          var updateBgLayer = function(topic) {
-            // Determine the current background layer. Strategy:
-            //
-            // On application load (then on topic change) event
-            // we look at the permalink. If there's a bgLayer parameter
-            // in the permalink we use that as the initial background
-            // layer.
-            //
-            // Specific use case when we go offline to online, in this use
-            // case we want to keep the current bg layer.
-            var bgLayer;
-            if (!topic) {
-              bgLayer = gaPermalink.getParams().bgLayer;
-              if (!isValidBgLayer(bgLayer)) {
-                bgLayer = undefined;
-              }
-            }
-            if ((!bgLayer && !scope.currentLayer) || topic) {
-              var bgLayers = gaTopic.get().backgroundLayers;
-              bgLayer = (bgLayers.length) ?
-                  bgLayers[0] : defaultBgOrder[0].id;
-              scope.backgroundLayers = defaultBgOrder.slice(0);
-            }
-            if (bgLayer && !isOfflineToOnline) {
-              scope.currentLayer = bgLayer;
-            }
-            isOfflineToOnline = false;
-
-          };
           scope.$watch('currentLayer', function(newVal, oldVal) {
             if (oldVal !== newVal) {
-              setCurrentLayer(newVal);
+              gaBackground.set(scope.map, newVal);
             }
           });
 
-          scope.activateBackgroundLayer = function(layerid) {
+          scope.activateBackgroundLayer = function(bgLayer) {
             if (scope.isBackgroundSelectorClosed) {
               scope.isBackgroundSelectorClosed = false;
-              scope.backgroundLayers = defaultBgOrder.slice(0);
             } else {
               scope.isBackgroundSelectorClosed = true;
-              if (scope.currentLayer != layerid) {
-                scope.currentLayer = layerid;
+              if (scope.currentLayer != bgLayer) {
+                scope.currentLayer = bgLayer;
               }
             }
           };
 
           scope.toggleMenu = function() {
-            if (scope.isBackgroundSelectorClosed) {
-              scope.isBackgroundSelectorClosed = false;
-            } else {
-              scope.isBackgroundSelectorClosed = true;
-            }
+            scope.isBackgroundSelectorClosed =
+                !scope.isBackgroundSelectorClosed;
           };
-
-          // We must know when the app goes from offline to online.
-          scope.$on('gaNetworkStatusChange', function(evt, offline) {
-            isOfflineToOnline = !offline;
-          });
-
-          // If another omponent add a background layer, update the
-          // selectbox.
-          scope.layers = scope.map.getLayers().getArray();
-          scope.layerFilter = gaLayerFilters.background;
-          scope.$watchCollection('layers | filter:layerFilter',
-            function(arr) {
-              if (arr.length == 2 ||
-                  (scope.currentLayer == 'voidLayer' && arr.length == 1)) {
-                scope.currentLayer = arr[arr.length - 1].id;
-                scope.map.removeLayer(arr[arr.length - 1]);
-              }
-            });
 
           scope.getClass = function(layer, index) {
             if (layer) {
+              var selected = (scope.currentLayer &&
+                  layer.id == scope.currentLayer.id);
               var splitLayer = layer.id.split('.');
-              return 'ga-' + splitLayer[splitLayer.length - 1] +
+              return (selected ? 'ga-bg-highlight ' : '') +
+                'ga-' + splitLayer[splitLayer.length - 1] +
                 ' ' + ((!scope.isBackgroundSelectorClosed) ?
                 'ga-bg-layer-' + index : '');
             }
           };
 
-          // Initialize the component when topics and layers config are
-          // loaded
-          $q.all([gaTopic.loadConfig(), gaLayers.loadConfig()]).
-              then(function() {
-            updateBgLayer();
+          scope.$on('gaBgChange', function(evt, newBg) {
+            if (!scope.currentLayer || newBg.id != scope.currentLayer.id) {
+              scope.currentLayer = newBg;
+            }
+          });
 
-            scope.$on('gaTopicChange', function(event, newTopic) {
-              updateBgLayer(newTopic);
-            });
-
-            scope.$on('gaPermalinkChange', function(event) {
+          scope.$on('gaPermalinkChange', function(evt, newBg) {
+            if (!scope.isBackgroundSelectorClosed) {
               scope.isBackgroundSelectorClosed = true;
-            });
+            }
           });
         }
       };

--- a/src/components/backgroundselector/BackgroundSelectorModule.js
+++ b/src/components/backgroundselector/BackgroundSelectorModule.js
@@ -1,9 +1,11 @@
 goog.provide('ga_backgroundselector');
 
+goog.require('ga_background_service');
 goog.require('ga_backgroundselector_directive');
 (function() {
 
   angular.module('ga_backgroundselector', [
-    'ga_backgroundselector_directive'
+    'ga_backgroundselector_directive',
+    'ga_background_service'
   ]);
 })();

--- a/src/components/backgroundselector/BackgroundService.js
+++ b/src/components/backgroundselector/BackgroundService.js
@@ -28,7 +28,7 @@ goog.require('ga_permalink');
       // to be moved in defaultBgOrder once 3d is live
       if (gaGlobalOptions.dev3d && gaBrowserSniffer.webgl) {
         bgs.splice(3, 0, {id: 'ch.swisstopo.terrain.3d',
-            label: 'terrain_layer'});
+            label: 'terrain_layer', is3d: true});
       }
 
       var getBgById = function(id) {
@@ -94,7 +94,7 @@ goog.require('ga_permalink');
             if (newBg) {
               bg = newBg;
               var layers = map.getLayers();
-              if (bg.id == 'voidLayer') {
+              if (bg.id == 'voidLayer' || bg.is3d) {
                 if (layers.getLength() > 0 &&
                     layers.item(0).background === true) {
                   layers.removeAt(0);

--- a/src/components/backgroundselector/BackgroundService.js
+++ b/src/components/backgroundselector/BackgroundService.js
@@ -1,0 +1,124 @@
+goog.provide('ga_background_service');
+
+goog.require('ga_map_service');
+goog.require('ga_permalink');
+
+(function() {
+
+  var module = angular.module('ga_background_service', [
+    'ga_permalink',
+    'ga_map_service'
+  ]);
+
+  /**
+   * Backgrounds manager
+   */
+  module.provider('gaBackground', function() {
+    this.$get = function($rootScope, $q, gaTopic, gaLayers, gaPermalink,
+        gaGlobalOptions, gaBrowserSniffer) {
+      var isOfflineToOnline = false;
+      var bg; // The current background
+      var bgs = [ // The list of backgrounds available
+        {id: 'ch.swisstopo.swissimage', label: 'bg_luftbild'},
+        {id: 'ch.swisstopo.pixelkarte-farbe', label: 'bg_pixel_color'},
+        {id: 'ch.swisstopo.pixelkarte-grau', label: 'bg_pixel_grey'},
+        {id: 'voidLayer', label: 'void_layer'}
+      ];
+
+      // to be moved in defaultBgOrder once 3d is live
+      if (gaGlobalOptions.dev3d && gaBrowserSniffer.webgl) {
+        bgs.splice(3, 0, {id: 'ch.swisstopo.terrain.3d',
+            label: 'terrain_layer'});
+      }
+
+      var getBgById = function(id) {
+        for (var i = 0, ii = bgs.length; i < ii; i++) {
+          if (bgs[i].id == id) {
+            return bgs[i];
+          }
+        }
+      };
+
+      var getBgByTopic = function(topic) {
+        var topicBgs = topic.backgroundLayers;
+        var topicBg = (topicBgs.length) ? getBgById(topicBgs[0]) : bgs[0];
+        if (topicBg && !isOfflineToOnline) {
+           return topicBg;
+        }
+      };
+
+      var broadcast = function() {
+        if (gaPermalink.getParams().bgLayer != bg.id) {
+          gaPermalink.updateParams({bgLayer: bg.id});
+        }
+        $rootScope.$broadcast('gaBgChange', bg);
+      };
+
+      var Background = function() {
+
+        this.init = function(map) {
+          var that = this;
+          // Initialize the service when topics and layers config are
+          // loaded
+          $q.all([gaTopic.loadConfig(), gaLayers.loadConfig()]).
+              then(function() {
+            var initBg = getBgById(gaPermalink.getParams().bgLayer);
+            if (!initBg) {
+              initBg = getBgByTopic(gaTopic.get());
+            }
+            that.set(map, initBg);
+            $rootScope.$on('gaTopicChange', function(evt, newTopic) {
+              that.set(map, getBgByTopic(newTopic));
+              isOfflineToOnline = false;
+            });
+            // We must know when the app goes from offline to online.
+            $rootScope.$on('gaNetworkStatusChange', function(evt, offline) {
+              isOfflineToOnline = !offline;
+            });
+          });
+        };
+
+        this.getBackgrounds = function() {
+          return bgs;
+        };
+
+        this.set = function(map, newBg) {
+          if (map && newBg) {
+            this.setById(map, newBg.id);
+          }
+        };
+
+        this.setById = function(map, newBgId) {
+          if (map && (!bg || newBgId != bg.id)) {
+            var newBg = getBgById(newBgId, false);
+            if (newBg) {
+              bg = newBg;
+              var layers = map.getLayers();
+              if (bg.id == 'voidLayer') {
+                if (layers.getLength() > 0 &&
+                    layers.item(0).background === true) {
+                  layers.removeAt(0);
+                }
+              } else {
+                var layer = gaLayers.getOlLayerById(bg.id);
+                layer.background = true;
+                layer.displayInLayerManager = false;
+                if (layers.item(0) && layers.item(0).background) {
+                  layers.setAt(0, layer);
+                } else {
+                  layers.insertAt(0, layer);
+                }
+              }
+              broadcast();
+             }
+          }
+        };
+
+        this.get = function() {
+          return bg;
+        };
+      };
+      return new Background();
+    };
+  });
+})();

--- a/src/components/backgroundselector/partials/backgroundselector.html
+++ b/src/components/backgroundselector/partials/backgroundselector.html
@@ -1,7 +1,6 @@
 <div ng-repeat="layer in backgroundLayers"
-     ng-click="activateBackgroundLayer(layer.id)"
-     class="ga-bg-layer {{getClass(layer, $index)}}"
-     ng-class="{'ga-bg-highlight': (layer.id == currentLayer)}">
+     ng-click="activateBackgroundLayer(layer)"
+     class="ga-bg-layer {{getClass(layer, $index)}}">
   <div ng-if="::desktop" class="ga-bg-layer-text" translate>{{layer.label}}</div>
 </div>
 <div ng-click="toggleMenu()" class="ga-bg-layer-bt"

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -2,7 +2,6 @@ goog.provide('ga_map_service');
 
 goog.require('ga_measure_service');
 goog.require('ga_networkstatus_service');
-goog.require('ga_offline_service');
 goog.require('ga_storage_service');
 goog.require('ga_styles_from_literals_service');
 goog.require('ga_styles_service');

--- a/src/components/offline/OfflineService.js
+++ b/src/components/offline/OfflineService.js
@@ -1,5 +1,6 @@
 goog.provide('ga_offline_service');
 
+goog.require('ga_background_service');
 goog.require('ga_storage_service');
 goog.require('ga_styles_service');
 (function() {
@@ -7,7 +8,8 @@ goog.require('ga_styles_service');
   var module = angular.module('ga_offline_service', [
     'ga_debounce_service',
     'ga_storage_service',
-    'ga_styles_service'
+    'ga_styles_service',
+    'ga_background_service'
   ]);
 
   /**
@@ -65,7 +67,7 @@ goog.require('ga_styles_service');
 
     this.$get = function($http, $rootScope, $timeout, $translate, $window,
         gaBrowserSniffer, gaGlobalOptions, gaLayers, gaMapUtils,
-        gaStorage, gaStyleFactory, gaUrlUtils) {
+        gaStorage, gaStyleFactory, gaUrlUtils, gaBackground) {
 
       // Defines if a layer is cacheable at a specific data zoom level.
       var isCacheableLayer = function(layer, z) {
@@ -342,7 +344,11 @@ goog.require('ga_styles_service');
                 olLayer = gaLayers.getOlLayerById(bodId);
                 if (olLayer) {
                   olLayer.background = (bg[i] === 'true');
-                  map.addLayer(olLayer);
+                  if (olLayer.background) {
+                    gaBackground.setById(map, bodId);
+                  } else {
+                    map.addLayer(olLayer);
+                  }
                 } else {
                   // TODO: The layer doesn't exist
                   continue;

--- a/src/components/topic/TopicDirective.js
+++ b/src/components/topic/TopicDirective.js
@@ -32,17 +32,6 @@ goog.require('ga_topic_service');
               }
             });
 
-            // TODO: Verify if it's the good place for this
-            $rootScope.$on('gaNetworkStatusChange', function(evt, offline) {
-              // When page is loaded directly in  offline mode we use the
-              // default (ech) topic, so when we go back to online mode
-              // we must reload the correct topic. The event reload the catalog
-              // too.
-              if (!offline) {
-                gaTopic.set(scope.activeTopic, true);
-              }
-            });
-
             gaTopic.loadConfig().then(function() {
               scope.topics = gaTopic.getTopics();
               scope.activeTopic = gaTopic.get();

--- a/src/components/topic/TopicDirective.js
+++ b/src/components/topic/TopicDirective.js
@@ -51,14 +51,13 @@ goog.require('ga_topic_service');
                   placement: 'bottom'
                 });
               });
+              scope.$on('gaTopicChange', function(evt, newTopic) {
+                if (scope.activeTopic != newTopic) {
+                  scope.activeTopic = newTopic;
+                }
+              });
             });
-
-            scope.$on('gaTopicChange', function(evt, newTopic) {
-              if (scope.activeTopic != newTopic) {
-                scope.activeTopic = newTopic;
-              }
-            });
-         }
-       };
+          }
+        };
       });
 })();

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -230,12 +230,11 @@ itemscope itemtype="http://schema.org/WebApplication"
     </div>
 % endif
 
+% if device != 'embed':
     <div ng-cloak ga-background-selector
          ga-background-selector-map="map"
-         ng-hide="globals.embed || globals.offline">
+         ng-hide="globals.offline">
     </div>
-
-% if device != 'embed':
     <div ng-cloak translate-cloak id="footer" class="navbar navbar-fixed-bottom">
       <div  class="pull-left" ga-scale-line ga-scale-line-map="map"></div>
   % if device == 'desktop':

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -110,8 +110,8 @@ goog.require('ga_storage_service');
     $scope.map = createMap();
 
     if (gaGlobalOptions.dev3d && gaBrowserSniffer.webgl) {
-      $rootScope.$on('gaBgChange', function(evt, newBgLayerId) {
-        $scope.globals.is3dActive = newBgLayerId == 'ch.swisstopo.terrain.3d';
+      $rootScope.$on('gaBgChange', function(evt, newBg) {
+        $scope.globals.is3dActive = !!newBg.is3d;
       });
       $scope.map.on('change:target', function(event) {
         if (!!$scope.map.getTargetElement()) {

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -1,5 +1,6 @@
 goog.provide('ga_main_controller');
 
+goog.require('ga_background_service');
 goog.require('ga_map');
 goog.require('ga_networkstatus_service');
 goog.require('ga_storage_service');
@@ -10,7 +11,8 @@ goog.require('ga_storage_service');
     'pascalprecht.translate',
     'ga_map',
     'ga_networkstatus_service',
-    'ga_storage_service'
+    'ga_storage_service',
+    'ga_background_service'
   ]);
 
   /**
@@ -20,7 +22,7 @@ goog.require('ga_storage_service');
       $translate, $window, $document, gaBrowserSniffer, gaHistory,
       gaFeaturesPermalinkManager, gaLayersPermalinkManager, gaMapUtils,
       gaRealtimeLayersManager, gaNetworkStatus, gaPermalink, gaStorage,
-      gaGlobalOptions) {
+      gaGlobalOptions, gaBackground) {
 
     var createMap = function() {
       var toolbar = $('#zoomButtons')[0];
@@ -141,6 +143,9 @@ goog.require('ga_storage_service');
     });
     $scope.map.addInteraction(keyboardPan);
     $scope.map.addInteraction(new ol.interaction.KeyboardZoom());
+
+    // Load the background if the "bgLayer" parameter exist.
+    gaBackground.init($scope.map);
 
     // Activate the "layers" parameter permalink manager for the map.
     gaLayersPermalinkManager($scope.map);


### PR DESCRIPTION
This PR adds a `gaBackground` service to manage the background layer. 

Fix part of #2105

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_bglayer_service)


