### PR TITLE
Fix tests with implicit wait

### DIFF
--- a/test/selenium/kml_test.js
+++ b/test/selenium/kml_test.js
@@ -29,18 +29,14 @@ var runTest = function(cap, driver, target) {
   // Close popup
   driver.findElement(webdriver.By.xpath("//*[@id='import-kml-popup']//button[@ng-click='close($event)']")).click();
 
+  driver.findElement(webdriver.By.xpath("//*[@id='toptools']//a[contains(@href,'" + POSITION_TO_KML + "')]"))
+
   // Was the URL in the address bar adapted?
   if(!(cap.browser == "IE" && cap.browser_version == "9.0")) {
-    // Check if url is adapted to KML presence and KML position
-    driver.wait(function() {
-      return driver.getCurrentUrl().then(function(url) {
-        assert.ok(url.indexOf(QUERYSTRING_KML) > -1);
-        assert.ok(url.indexOf(POSITION_TO_KML) > -1);
-        return true;
-      });
-    }, 2000);
+    driver.getCurrentUrl().then(function(url) {
+      assert.ok(url.indexOf(POSITION_TO_KML) > -1);
+    });
   }
-
   // Go to the KML linkedURL
   driver.get(target + '/?lang=de&layers='+QUERYSTRING_KML);
   //wait until topics related stuff is loaded.

--- a/test/selenium/search_test.js
+++ b/test/selenium/search_test.js
@@ -10,26 +10,14 @@ var runTest = function(cap, driver, target){
   driver.findElement(webdriver.By.xpath("//*[@type='search']")).sendKeys('Bern');
   // Click on the field "Bern (BE)"
   driver.findElement(webdriver.By.xpath("//*[contains(text(), 'Bern')]")).click();
-  // Any link with the adapted URL? (there should be many)
-  driver.findElement(webdriver.By.xpath("//a[contains(@href, '" + QUERYSTRING_OF_BERN + "')]"));
+  // Specifically search if href of links is updated
+  driver.findElement(webdriver.By.xpath("//*[@id='toptools']//a[contains(@href,'" + QUERYSTRING_OF_BERN + "')]"))
   // Was the URL in the address bar adapted?
   if(!(cap.browser == "IE" && cap.browser_version == "9.0")) {
-    // Check if url is adapted to reflect Bern location
-    driver.wait(function() {
-        return driver.getCurrentUrl().then(function(url) {
-            assert.ok(url.indexOf(QUERYSTRING_OF_BERN) > -1);
-            return true;
-        });
-    }, 1000);
+    driver.getCurrentUrl().then(function(url) {
+      assert.ok(url.indexOf(QUERYSTRING_OF_BERN) > -1);
+    });
   }
-  // And have a look at the permanent Link
-  // driver.findElement(webdriver.By.xpath("//*[@ng-model='permalinkValue']")).getAttribute("value").then(function(val){
-  // driver.findElement(webdriver.By.xpath("//*[@id='toptools']//a[contains(@href,'http')]")).getAttribute("href");
-  driver.findElement(webdriver.By.xpath("//*[@id='toptools']//a[contains(@href,'http')]")).getAttribute("href").then(function(val){
-      //The perma Link should point to Bern
-      assert.ok(val.indexOf(QUERYSTRING_OF_BERN) > -1);
-  });
-  // We click on the "share" button what closes the share menu
 }
 
 module.exports.runTest = runTest;

--- a/test/selenium/tests.js
+++ b/test/selenium/tests.js
@@ -42,7 +42,7 @@ var RunFullTests = function(cap) {
 }
 
 //run tests for all browser (3 last version of IE, Chrome, Firefox) 
-browsers.capabilities.forEach(function(cap){
+browsers.capabilities.forEach(function(cap) {
   //we build the driver only once for all tests per browser.
   var driver = new webdriver.Builder().
     usingServer('http://hub.browserstack.com/wd/hub').
@@ -50,13 +50,13 @@ browsers.capabilities.forEach(function(cap){
     build();
     
   //show a link for each browser + version for visual results.
-  driver.getSession().then(function(sess){
+  driver.getSession().then(function(sess) {
     console.log("running all tests for: " + cap.browser + "(" + cap.browser_version + ") on " + cap.os + " " + cap.os_version);
-    console.log("  See more results or https://www.browserstack.com/automate/builds/dddb1242fb9f3ffe297b057e6da2ea964b4caf1a/sessions/"+sess.id_);
+    console.log("  See more results or https://www.browserstack.com/automate/builds/dddb1242fb9f3ffe297b057e6da2ea964b4caf1a/sessions/" + sess.id_);
   });
 
   //run all the tests
-  try{
+  try {
     startTest.runTest(cap, driver, cmd.target);
     if (RunFullTests(cap)) {
       searchTest.runTest(cap, driver, cmd.target);
@@ -68,12 +68,12 @@ browsers.capabilities.forEach(function(cap){
       //which leaves the page in a browser dependant state
       printTest.runTest(cap, driver, cmd.target);
     }
-  }catch(err){
+  } catch(err) {
     //we need this block for the finally, as we definitly want to quit the driver, otherwise it stays idle for ~2 min blocking the next testrun.
     throw err;
     driver.quit();
   }
-  finally{
+  finally {
     driver.quit();
   }
 });

--- a/test/selenium/wms_test.js
+++ b/test/selenium/wms_test.js
@@ -42,15 +42,13 @@ var runTest = function(cap, driver, target) {
   // Close popup
   driver.findElement(webdriver.By.xpath("//*[@id='import-wms-popup']//button[@ng-click='close($event)']")).click();
 
+  driver.findElement(webdriver.By.xpath("//*[@id='toptools']//a[contains(@href,'" + QUERYSTRING_WMS + "')]"))
   // Was the URL in the address bar adapted?
   if(!(cap.browser == "IE" && cap.browser_version == "9.0")) {
     // Check if url is adapted to WMS layer
-    driver.wait(function() {
-      return driver.getCurrentUrl().then(function(url) {
-        assert.ok(url.indexOf(QUERYSTRING_WMS) > -1);
-        return true;
-      });
-    }, 1000);
+    driver.getCurrentUrl().then(function(url) {
+      assert.ok(url.indexOf(QUERYSTRING_WMS) > -1);
+    });
   }
 
   // Go to the WMS layer page


### PR DESCRIPTION
kml tests, which had implicit waits, made up 60% of our browserstack failures.

This PR tries to improve this by removing the implicit waits and instead to rely on a feature of the permalink service. On permalink change, the permalink service first adapts the URL in the address bar and then issues a `gaPermalinkChange` event.

We use this feature in our tests now by checking for the changed permalink value in the document first using seleniums standard `findElement` approach. After this is sucessfuly, we can then check the page URL directly without having to wait.

@oterral Care to take a quick look and merge. It would get rid of some annoying build failures.