### PR TITLE
Add gaTime service

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -189,10 +189,6 @@ goog.require('ga_translation_service');
               }
             });
 
-            scope.$on('gaTimeSelectorChange', function(event, newYear) {
-              scope.options.currentYear = newYear;
-            });
-
             // Initializer the component if possible
             updateCatalogTree(gaTopic.get(), gaLang.get());
           }

--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -55,42 +55,6 @@ goog.require('ga_map_service');
       $rootScope, $translate, $window, gaBrowserSniffer, gaLayerFilters,
       gaLayerMetadataPopup, gaLayers) {
 
-    // Test if all layers have the same time property value.
-    var hasLayersSameTime = function(olLayers) {
-      if (olLayers.length == 0) {
-        return false;
-      }
-      var year;
-      for (var i = 0, ii = olLayers.length; i < ii; i++) {
-        if (!olLayers[i].timeEnabled || !olLayers[i].time) {
-          continue;
-        }
-
-        if (!year) {
-          year = parseInt(olLayers[i].time.substr(0, 4));
-        }
-
-        if (year > new Date().getFullYear()) {
-          return false;
-        }
-
-        if (year != parseInt(olLayers[i].time.substr(0, 4))) {
-          return false;
-        }
-      }
-      return year;
-    };
-
-    // Save the current time values of layers
-    var savedTime = {};
-    var setSavedTime = function(olLayers) {
-      olLayers.forEach(function(olLayer) {
-        if (olLayer.timeEnabled) {
-          savedTime[olLayer.id] = olLayer.time;
-        }
-      });
-    };
-
     // Timestamps list template
     var tpl =
       '<div class="ga-layer-timestamps">' +
@@ -156,12 +120,6 @@ goog.require('ga_map_service');
         $document.unbind('click', callback);
         win.unbind('resize', callback);
       }
-    };
-
-    var updateTimeSelectorStatus = function(layers, element) {
-      var year = hasLayersSameTime(layers);
-      $rootScope.$broadcast('gaTimeSelectorToggle', !!(year), year);
-      destroyPopover(null, element);
     };
 
     return {
@@ -255,8 +213,7 @@ goog.require('ga_map_service');
           if (angular.isDefined(time)) {
             layer.time = time;
           }
-          setSavedTime(scope.layers);
-          updateTimeSelectorStatus(scope.layers, element);
+          destroyPopover(null, element);
         };
 
         scope.useRange = (!gaBrowserSniffer.mobile && (!gaBrowserSniffer.msie ||
@@ -335,30 +292,6 @@ goog.require('ga_map_service');
               olLayer.label = gaLayers.getLayerProperty(olLayer.bodId, 'label');
             }
           });
-        });
-
-        // Callbacks used to save/retrieve user time values defined before
-        // activation/deactivation of TimeSelector.
-        scope.$on('gaTimeSelectorToggle', function(evt, active) {
-          if (active) {
-            setSavedTime(map.getLayers());
-          }
-        });
-        scope.$on('gaTimeSelectorChange', function(evt, year) {
-          // year=undefined means TimeSelector is deactivated
-          if (!angular.isDefined(year)) {
-            map.getLayers().forEach(function(olLayer, opt) {
-              if (olLayer.timeEnabled && savedTime[olLayer.id]) {
-                olLayer.time = savedTime[olLayer.id];
-              }
-            });
-            savedTime = {};
-          }
-        });
-
-        scope.$watchCollection('layers | filter:layerFilter',
-            function(olLayers) {
-          updateTimeSelectorStatus(olLayers, element);
         });
       }
     };

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -2,16 +2,21 @@ goog.provide('ga_print_directive');
 
 goog.require('ga_browsersniffer_service');
 goog.require('ga_print_style_service');
+goog.require('ga_time_service');
+
 (function() {
 
-  var module = angular.module('ga_print_directive',
-    ['ga_browsersniffer_service',
-     'pascalprecht.translate',
-     'ga_print_style_service']);
+  var module = angular.module('ga_print_directive', [
+    'ga_browsersniffer_service',
+    'pascalprecht.translate',
+    'ga_print_style_service',
+    'ga_time_service'
+  ]);
 
   module.controller('GaPrintDirectiveController', function($rootScope, $scope,
       $http, $q, $window, $translate, $timeout, gaLayers, gaMapUtils, 
-      gaPermalink, gaBrowserSniffer, gaWaitCursor, gaPrintStyleService) {
+      gaPermalink, gaBrowserSniffer, gaWaitCursor, gaPrintStyleService,
+      gaTime) {
 
     var pdfLegendsToDownload = [];
     var pdfLegendString = '_big.pdf';
@@ -22,7 +27,6 @@ goog.require('ga_print_style_service');
     var UNITS_RATIO = 39.37; // inches per meter
     var POLL_INTERVAL = 2000; //interval for multi-page prints (ms)
     var POLL_MAX_TIME = 600000; //ms (10 minutes)
-    var currentTime = undefined;
     var layersYears = [];
     var canceller;
     var currentMultiPrintId;
@@ -117,11 +121,6 @@ goog.require('ga_print_style_service');
 
       ctx.restore();
     };
-
-    // Listeners
-    $rootScope.$on('gaTimeSelectorChange', function(event, time) {
-      currentTime = time;
-    });
 
     // Encode ol.Layer to a basic js object
     var encodeLayer = function(layer, proj) {
@@ -466,7 +465,7 @@ goog.require('ga_print_style_service');
             });
           }
           // printing time series
-          if (config.timeEnabled && currentTime == undefined &&
+          if (config.timeEnabled && gaTime.get() == undefined &&
               multiPagesPrint) {
             enc['timestamps'] = config.timestamps;
           }

--- a/src/components/query/QueryDirective.js
+++ b/src/components/query/QueryDirective.js
@@ -542,7 +542,7 @@ goog.require('ga_storage_service');
         });
 
         var currentYear;
-        scope.$on('gaTimeSelectorChange', function(event, newYear) {
+        scope.$on('gaTimeChange', function(event, newYear) {
           if (newYear !== currentYear) {
             currentYear = newYear;
             if (scope.queryType == 0) {

--- a/src/components/timeselector/TimeSelectorModule.js
+++ b/src/components/timeselector/TimeSelectorModule.js
@@ -1,9 +1,12 @@
 goog.provide('ga_timeselector');
 
+goog.require('ga_time_service');
 goog.require('ga_timeselector_directive');
+
 (function() {
 
   angular.module('ga_timeselector', [
-    'ga_timeselector_directive'
+   'ga_timeselector_directive',
+   'ga_time_service'
   ]);
 })();

--- a/src/components/timeselector/TimeService.js
+++ b/src/components/timeselector/TimeService.js
@@ -1,0 +1,118 @@
+goog.provide('ga_time_service');
+
+goog.require('ga_permalink_service');
+
+(function() {
+
+  var module = angular.module('ga_time_service', [
+    'ga_permalink_service'
+  ]);
+
+  /**
+   * Time manager.
+   * Manage the global time of the application.
+   */
+  module.provider('gaTime', function() {
+
+    // Test if all visible and timeEnabled layers have the same time
+    // property value.
+    var hasLayersSameTime = function(olLayers) {
+      if (olLayers.length == 0) {
+        return false;
+      }
+      var year;
+      for (var i = 0, ii = olLayers.length; i < ii; i++) {
+        if (!olLayers[i].visible || !olLayers[i].timeEnabled ||
+            !olLayers[i].time) {
+          continue;
+        }
+
+        if (!year) {
+          year = parseInt(olLayers[i].time.substr(0, 4));
+        }
+
+        if (year > new Date().getFullYear()) {
+          return false;
+        }
+
+        if (year != parseInt(olLayers[i].time.substr(0, 4))) {
+          return false;
+        }
+      }
+      return year;
+    };
+
+    this.$get = function($rootScope, gaPermalink) {
+      var propDeregKey = {};
+
+      // Currently time is a number representing a year
+      // When defined this value is apllied on all timeEnabled layers
+      var time = parseFloat(gaPermalink.getParams().time);
+      if (isNaN(time)) {
+        time = undefined;
+      }
+
+      var Time = function() {
+
+        // This property active the auto update status. The main goal of this
+        // property is to deactiviate the auto display of the timeslector, when
+        // layers from permalink are not yet loaded.
+        this.allowStatusUpdate = false;
+
+        this.init = function(map) {
+          var that = this;
+          // Listen on layer's time property change
+          map.getLayers().on('add', function(evt) {
+            var olLayer = evt.element;
+            if (olLayer.timeEnabled) {
+              ol.Observable.unByKey(propDeregKey[olLayer.id]);
+              that.updateStatus(evt.target);
+              propDeregKey[olLayer.id] = olLayer.on('propertychange',
+                  function(evtProp) {
+                if (evtProp.key == 'visible' || (evtProp.key == 'time' &&
+                    angular.isDefined(evtProp.target.time) &&
+                    parseInt(evtProp.target.time.substr(0, 4)) != time)) {
+                  that.updateStatus(evt.target);
+                }
+              });
+            }
+          });
+          map.getLayers().on('remove', function(evt) {
+            var olLayer = evt.element;
+            ol.Observable.unByKey(propDeregKey[olLayer.id]);
+            if (olLayer.timeEnabled) {
+              that.updateStatus(evt.target);
+            }
+          });
+        };
+
+        this.updateStatus = function(olLayers) {
+          if (this.allowStatusUpdate) {
+            // This function automatically set time value when all timeEnabled
+            // layers have/don't have the same time property.
+            var year = hasLayersSameTime(olLayers.getArray());
+            this.set((year !== false) ? year : undefined);
+          }
+        };
+
+        this.get = function() {
+          return time;
+        };
+
+        this.set = function(year) {
+          if (year != time) {
+            var oldTime = time;
+            time = year;
+            if (time === undefined) {
+              gaPermalink.deleteParam('time');
+            } else {
+              gaPermalink.updateParams({time: time});
+            }
+            $rootScope.$broadcast('gaTimeChange', time, oldTime);
+          }
+        };
+       };
+       return new Time();
+    };
+  });
+})();

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -12,13 +12,14 @@ goog.require('ga_styles_service');
     'ga_popup_service',
     'ga_map_service',
     'ga_styles_service',
+    'ga_time_service',
     'pascalprecht.translate'
   ]);
 
   module.directive('gaTooltip',
       function($timeout, $http, $q, $translate, $sce, gaPopup, gaLayers,
           gaBrowserSniffer, gaDefinePropertiesForLayer, gaMapClick, gaDebounce,
-          gaPreviewFeatures, gaStyleFactory, gaMapUtils) {
+          gaPreviewFeatures, gaStyleFactory, gaMapUtils, gaTime) {
         var popupContent = '<div ng-repeat="htmlsnippet in options.htmls">' +
                             '<div ng-bind-html="htmlsnippet"></div>' +
                             '<div class="ga-tooltip-separator" ' +
@@ -41,7 +42,6 @@ goog.require('ga_styles_service');
                 vector,
                 vectorSource,
                 parser,
-                year,
                 listenerKey;
 
             parser = new ol.format.GeoJSON();
@@ -49,10 +49,6 @@ goog.require('ga_styles_service');
             $scope.$on('gaTopicChange', function(event, topic) {
               currentTopic = topic.id;
               initTooltip();
-            });
-
-            $scope.$on('gaTimeSelectorChange', function(event, currentyear) {
-              year = currentyear;
             });
 
             $scope.$on('gaTriggerTooltipRequest', function(event, data) {
@@ -278,7 +274,7 @@ goog.require('ga_styles_service');
 
                   // Only timeEnabled layers use the timeInstant parameter
                   if (layerToQuery.timeEnabled) {
-                    params.timeInstant = year ||
+                    params.timeInstant = gaTime.get() ||
                         yearFromString(layerToQuery.time);
                   }
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -264,11 +264,13 @@ itemscope itemtype="http://schema.org/WebApplication"
 
     <div ga-timestamp-control ga-timestamp-control-map="map"></div>
 
+% if device != 'embed':
     <div ng-controller="GaTimeSelectorController">
       <div ga-time-selector ga-time-selector-map="map"
            ga-time-selector-options="options">
       </div>
     </div>
+% endif
 
     <div ng-controller="GaTooltipController">
       <div ga-tooltip 

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -22,7 +22,7 @@ goog.require('ga_storage_service');
       $translate, $window, $document, gaBrowserSniffer, gaHistory,
       gaFeaturesPermalinkManager, gaLayersPermalinkManager, gaMapUtils,
       gaRealtimeLayersManager, gaNetworkStatus, gaPermalink, gaStorage,
-      gaGlobalOptions, gaBackground) {
+      gaGlobalOptions, gaBackground, gaTime) {
 
     var createMap = function() {
       var toolbar = $('#zoomButtons')[0];
@@ -138,11 +138,15 @@ goog.require('ga_storage_service');
     // specify a condition
     var keyboardPan = new ol.interaction.KeyboardPan({
       condition: function() {
-        return (!$scope.time);
+        return (!gaTime.get());
       }
     });
     $scope.map.addInteraction(keyboardPan);
     $scope.map.addInteraction(new ol.interaction.KeyboardZoom());
+
+    // Start managing global time parameter, when all permalink layers are
+    // added.
+    gaTime.init($scope.map);
 
     // Load the background if the "bgLayer" parameter exist.
     gaBackground.init($scope.map);
@@ -198,8 +202,9 @@ goog.require('ga_storage_service');
       $('meta[name="application-name"]').attr('content', title);
     });
 
-    $rootScope.$on('gaTimeSelectorChange', function(event, year) {
-      $scope.time = year;
+    $scope.time = gaTime.get();
+    $rootScope.$on('gaTimeChange', function(event, time) {
+      $scope.time = time; // Used in embed page
     });
 
     // Create switch device url


### PR DESCRIPTION
Makes time management independent from component.

That adds:

 - Priority of `time` parameter over `layer_timestamps` parameter
 - Manage only visible timeEnabled layers

Before:
https://map.geo.admin.ch/?time=1992&layers=ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_schwarzweiss&layers_timestamp=19921231,20041231

After:
https://mf-geoadmin3.dev.bgdi.ch/teo_time/?time=1992&layers=ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_schwarzweiss&layers_timestamp=19921231,20041231

Fix #2105  and all time permalink problem I've seen.