### PR TITLE
Remove selectbyrectangle and use tooltip/queryableattributes

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1342,13 +1342,13 @@ goog.require('ga_urlutils_service');
                  layer.visible;
         },
         /**
-         * Keep selectByRectangle enabled layer
+         * Keep layers with potential tooltip
          */
-        selectByRectangle: function(layer) {
+        potentialTooltip: function(layer) {
           return layer.displayInLayerManager &&
                  layer.visible &&
                  layer.bodId &&
-                 gaLayers.getLayerProperty(layer.bodId, 'selectbyrectangle');
+                 gaLayers.getLayerProperty(layer.bodId, 'tooltip');
         },
         /**
          * Searchable layers
@@ -1358,6 +1358,18 @@ goog.require('ga_urlutils_service');
                  layer.visible &&
                  layer.bodId &&
                  gaLayers.getLayerProperty(layer.bodId, 'searchable');
+        },
+        /**
+         * Queryable layers (layers with queryable attributes)
+         */
+        queryable: function(layer) {
+          return layer.displayInLayerManager &&
+                 layer.visible &&
+                 layer.bodId &&
+                 gaLayers.getLayerProperty(layer.bodId,
+                                           'queryableAttributes') &&
+                 gaLayers.getLayerProperty(layer.bodId,
+                                           'queryableAttributes').length > 0;
         },
         /**
          * Keep only background layers

--- a/src/components/query/QueryDirective.js
+++ b/src/components/query/QueryDirective.js
@@ -17,8 +17,8 @@ goog.require('ga_storage_service');
     var geojson = new ol.format.GeoJSON();
     var stored;
     $scope.queryType = 1; // Filter attributes
-    $scope.searchableLayers = [];
-    $scope.selectByRectangleLayers = [];
+    $scope.queryableLayers = [];
+    $scope.tooltipLayers = [];
     $scope.queriesPredef = [];
     $scope.filters = [];
     $scope.featuresByLayer = {};
@@ -224,7 +224,7 @@ goog.require('ga_storage_service');
     $scope.searchByGeometry = function(layerBodId, offset) {
       $scope.queryType = 0;
 
-      if ($scope.selectByRectangleLayers.length == 0) {
+      if ($scope.tooltipLayers.length == 0) {
         resetResults();
         return;
       }
@@ -237,7 +237,7 @@ goog.require('ga_storage_service');
           offset: offset
         }, getGeometryParams());
 
-        var layersRequested = $scope.selectByRectangleLayers;
+        var layersRequested = $scope.tooltipLayers;
         if (layerBodId) {
           layersRequested = [
             gaMapUtils.getMapOverlayForBodId($scope.map, layerBodId)
@@ -317,23 +317,23 @@ goog.require('ga_storage_service');
 
     // Watcher/listener
     $scope.layers = $scope.map.getLayers().getArray();
-    $scope.selectByRectangleFilter = gaLayerFilters.selectByRectangle;
-    $scope.$watchCollection('layers | filter:selectByRectangleFilter',
+    $scope.tooltipFilter = gaLayerFilters.potentialTooltip;
+    $scope.$watchCollection('layers | filter:tooltipFilter',
         function(layers) {
-      $scope.selectByRectangleLayers = layers;
+      $scope.tooltipLayers = layers;
       if ($scope.isActive) {
         $scope.search();
       }
     });
 
-    $scope.searchableFilter = gaLayerFilters.searchable;
-    $scope.$watchCollection('layers | filter:searchableFilter',
+    $scope.queryableFilter = gaLayerFilters.queryable;
+    $scope.$watchCollection('layers | filter:queryableFilter',
         function(layers) {
-      $scope.searchableLayers = layers;
+      $scope.queryableLayers = layers;
 
       // Load new list of predefines queries and queryable attributes
       var predef = [];
-      angular.forEach($scope.searchableLayers, function(layer) {
+      angular.forEach($scope.queryableLayers, function(layer) {
         var queries = gaQuery.getPredefQueries(layer.bodId);
         if (queries) {
           angular.forEach(queries, function(query, idx) {
@@ -447,7 +447,7 @@ goog.require('ga_storage_service');
             scope.geometry = boxFeature.getGeometry();
             scope.useBbox = true;
 
-            if (scope.selectByRectangleLayers.length == 0) {
+            if (scope.tooltipLayers.length == 0) {
               scope.isActive = true;
               scope.$apply();
             } else {

--- a/src/components/query/partials/query.html
+++ b/src/components/query/partials/query.html
@@ -1,12 +1,12 @@
-<div ng-if="selectByRectangleLayers.length == 0 && searchableLayers.length == 0">
+<div ng-if="tooltipLayers.length == 0 && queryableLayers.length == 0">
   <div class="ga-no-result" translate>no_searchable_layer</div>
 </div>
 
-<div ng-if="selectByRectangleLayers.length != 0 && searchableLayers.length == 0">
+<div ng-if="tooltipLayers.length != 0 && queryableLayers.length == 0">
   <div class="ga-bbox-info" translate>inform_draw_rectangl_ctrl</div>
 </div>
 
-<div ng-show="searchableLayers.length != 0">
+<div ng-show="queryableLayers.length != 0">
   <div class="form-group ga-queries-predefined" ng-show="queriesPredef.length > 0">
     <label translate>query_choose</label> 
     <select ng-model="queryPredef" 
@@ -41,7 +41,7 @@
         </div>
         <div class="ga-inputs">
           <select ng-model="f.layer"
-                  ng-options="l.label for l in searchableLayers" 
+                  ng-options="l.label for l in queryableLayers" 
                   ng-change="onChange();onChangeLayer($index, f)">
             <option value="" selected disabled translate>query_layer</option>
           </select>

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -180,7 +180,7 @@ goog.require('ga_styles_service');
                   olLayer.getSource() instanceof ol.source.ImageVector));
             }
 
-            // Test if the layer is a queryable bod layer
+            // Test if the layer has a tooltip
             function isQueryableBodLayer(olLayer) {
               var bodId = olLayer.bodId;
               if (bodId) {
@@ -188,7 +188,7 @@ goog.require('ga_styles_service');
                     bodId;
               }
               return (bodId &&
-                  gaLayers.getLayerProperty(bodId, 'queryable'));
+                  gaLayers.getLayerProperty(bodId, 'tooltip'));
             };
 
             // Get all the queryable layers


### PR DESCRIPTION
No functional changes in this PR.

We want to cleanup the back-end and bod and remove unnecessary attributes as well as consolidate existing ones. See discussion https://github.com/geoadmin/mf-chsdi3/pull/1620

`searchable` layer attribute is used now strictly for searching. `queryable` and `searchbyrectangle` attributes are now merged into `tooltip` attribute.

if a layer can be used in the query tool to query specific attributes is now determined by the `queryableAttributes` property of the layer.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_tooltip)

**This needs merge of https://github.com/geoadmin/mf-chsdi3/pull/1620 first**