### PR TITLE
Fix #2580: Update permalink only when all layers are loaded

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1561,12 +1561,9 @@ goog.require('ga_urlutils_service');
         }
       }
 
-      return function(map) {
-        var scope = $rootScope.$new();
+      // Update permalink on layer's modification
+      var registerLayersPermalink = function(scope, map) {
         var deregFns = [];
-        var dupId = 0; // Use for duplicate layer
-        // We must reorder layer when async layer are added
-        var mustReorder = false;
         scope.layers = map.getLayers().getArray();
         scope.layerFilter = gaLayerFilters.permalinked;
         scope.$watchCollection('layers | filter:layerFilter',
@@ -1605,6 +1602,12 @@ goog.require('ga_urlutils_service');
 
           });
         });
+      };
+      return function(map) {
+        var scope = $rootScope.$new();
+        var dupId = 0; // Use for duplicate layer
+        // We must reorder layer when async layer are added
+        var mustReorder = false;
 
         var addTopicSelectedLayers = function() {
           addLayers(gaTopic.get().selectedLayers.slice(0).reverse());
@@ -1753,7 +1756,7 @@ goog.require('ga_urlutils_service');
           }
 
           gaTime.allowStatusUpdate = true;
-
+          registerLayersPermalink(scope, map);
           // Listen for next topic change events
           $rootScope.$on('gaTopicChange', addTopicSelectedLayers);
         });
@@ -1926,6 +1929,9 @@ goog.require('ga_urlutils_service');
     this.$get = function($rootScope, gaPermalink, gaLayers,
         gaPreviewFeatures, gaMapUtils) {
       var queryParams = gaPermalink.getParams();
+      var layersParamValue = queryParams.layers;
+      var layerSpecs = layersParamValue ? layersParamValue.split(',') : [];
+
       return function(map) {
         gaLayers.loadConfig().then(function() {
           var featureIdsCount = 0;
@@ -1943,7 +1949,8 @@ goog.require('ga_urlutils_service');
                 featureIdsCount += featureIds.length;
                 Array.prototype.push.apply(featureIdsByBodId[bodId],
                     featureIds);
-                if (!gaMapUtils.getMapOverlayForBodId(map, bodId)) {
+                if (!gaMapUtils.getMapOverlayForBodId(map, bodId) &&
+                    layerSpecs.indexOf(bodId) == -1) {
                   map.addLayer(gaLayers.getOlLayerById(bodId));
                 }
               }


### PR DESCRIPTION
Fix #2580 

[test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_2580?X=249500.00&Y=645090.00&zoom=7&lang=de&topic=ech&bgLayer=ch.swisstopo.swissimage&layers=ch.swisstopo.swissboundaries3d-land-flaeche.fill,ch.swisstopo.vec25-gewaessernetz,ch.bfe.stauanlagen-bundesaufsicht,ch.bfe.statistik-wasserkraftanlagen&ch.bfe.statistik-wasserkraftanlagen=208400)