### PR TITLE
Migrate Search overlays to regular layer

### DIFF
--- a/src/components/StylesService.js
+++ b/src/components/StylesService.js
@@ -151,9 +151,9 @@ goog.require('ga_measure_service');
       var imgPath = gaGlobalOptions.resourceUrl + 'img/';
       styles['marker'] = new ol.style.Style({
         image: new ol.style.Icon({
-          anchor: [0.5, 46],
+          anchor: [0.5, 1],
           anchorXUnits: 'fraction',
-          anchorYUnits: 'pixels',
+          anchorYUnits: 'fraction',
           src: imgPath + 'marker.png'
         })
       });

--- a/src/components/StylesService.js
+++ b/src/components/StylesService.js
@@ -149,6 +149,14 @@ goog.require('ga_measure_service');
     this.$get = function(gaGlobalOptions, gaMeasure) {
 
       var imgPath = gaGlobalOptions.resourceUrl + 'img/';
+      styles['marker'] = new ol.style.Style({
+        image: new ol.style.Icon({
+          anchor: [0.5, 46],
+          anchorXUnits: 'fraction',
+          anchorYUnits: 'pixels',
+          src: imgPath + 'marker.png'
+        })
+      });
       var headingStyle = new ol.style.Style({
         image: new ol.style.Icon({
           rotateWithView: true,

--- a/src/components/controls3d/Controls3dDirective.js
+++ b/src/components/controls3d/Controls3dDirective.js
@@ -1,5 +1,6 @@
 goog.provide('ga_controls3d_directive');
 
+goog.require('ga_map_service');
 (function() {
 
   var cssRotate = function(element, angle) {
@@ -11,9 +12,11 @@ goog.provide('ga_controls3d_directive');
     });
   };
 
-  var module = angular.module('ga_controls3d_directive', []);
+  var module = angular.module('ga_controls3d_directive', [
+    'ga_map_service'
+  ]);
 
-  module.directive('gaControls3d', function() {
+  module.directive('gaControls3d', function(gaMapUtils) {
     return {
       restrict: 'A',
       templateUrl: 'components/controls3d/partials/controls3d.html',
@@ -74,14 +77,7 @@ goog.provide('ga_controls3d_directive');
         };
 
         scope.resetRotation = function() {
-          var angle = -camera.heading;
-          while (angle < -Math.PI) {
-            angle += Cesium.Math.TWO_PI;
-          }
-          while (angle > Math.PI) {
-            angle -= Cesium.Math.TWO_PI;
-          }
-          scope.rotate(Cesium.Math.toDegrees(angle));
+          gaMapUtils.resetMapToNorth(undefined, scope.ol3d);
         };
 
       }

--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -236,7 +236,8 @@ goog.require('ga_map_service');
 
             scope.zoom = function(evt, feature) {
               evt.stopPropagation();
-              gaPreviewFeatures.zoom(map, parser.readFeature(feature.geojson));
+              gaPreviewFeatures.zoom(map, undefined,
+                  parser.readFeature(feature.geojson));
             };
 
             scope.more = function(evt, layer) {

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1304,7 +1304,7 @@ goog.require('ga_urlutils_service');
       return {
         Z_PREVIEW_LAYER: 1000,
         Z_PREVIEW_FEATURE: 1100,
-        Z_LOCATION_MARKER: 2000,
+        Z_FEATURE_OVERLAY: 2000,
         preload: 6, //Number of upper zoom to preload when offline
         defaultExtent: gaGlobalOptions.defaultExtent,
         viewResolutions: resolutions,
@@ -1485,7 +1485,8 @@ goog.require('ga_urlutils_service');
             }),
             style: style,
             updateWhileAnimating: true,
-            updateWhileInteracting: true
+            updateWhileInteracting: true,
+            zIndex: this.Z_FEATURE_OVERLAY
           });
           layer.set('altitudeMode', 'clampToGround');
           return layer;

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -2002,18 +2002,6 @@ goog.require('ga_urlutils_service');
         return $q.all(promises);
       };
 
-      // Get a buffered extent if necessary
-      var getMinimalExtent = function(extent) {
-        if (ol.extent.getHeight(extent) < MINIMAL_EXTENT_SIZE &&
-            ol.extent.getWidth(extent) < MINIMAL_EXTENT_SIZE) {
-          var center = ol.extent.getCenter(extent);
-          return ol.extent.buffer(center.concat(center),
-              MINIMAL_EXTENT_SIZE / 2);
-        } else {
-          return extent;
-        }
-      };
-
       // Remove features associated with a layer.
       var removeFromLayer = function(layer) {
         var features = source.getFeatures();
@@ -2043,6 +2031,17 @@ goog.require('ga_urlutils_service');
       };
 
       var PreviewFeatures = function() {
+        // Get a buffered extent if necessary
+        this.getMinimalExtent = function(extent) {
+          if (ol.extent.getHeight(extent) < MINIMAL_EXTENT_SIZE &&
+              ol.extent.getWidth(extent) < MINIMAL_EXTENT_SIZE) {
+            var center = ol.extent.getCenter(extent);
+            return ol.extent.buffer(center.concat(center),
+                MINIMAL_EXTENT_SIZE / 2);
+          } else {
+            return extent;
+          }
+        };
 
         // Add a feature.
         this.add = function(map, feature) {
@@ -2104,7 +2103,7 @@ goog.require('ga_urlutils_service');
         // Zoom on a feature (if defined) or zoom on the entire source
         // extent.
         this.zoom = function(map, feature) {
-          var extent = getMinimalExtent((feature) ?
+          var extent = this.getMinimalExtent((feature) ?
               feature.getGeometry().getExtent() : source.getExtent());
           map.getView().fit(extent, map.getSize());
         };

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -220,6 +220,7 @@ goog.require('ga_translation_service');
           scope: {
             options: '=gaSearchOptions',
             map: '=gaSearchMap',
+            ol3d: '=gaSearchOl3d',
             searchFocused: '=gaSearchFocused'
           },
           link: function($scope, element, attrs) {

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -145,7 +145,7 @@ goog.require('ga_translation_service');
               $scope.map.getView().getProjection().getExtent(), q);
 
           if (position) {
-            gaMapUtils.moveTo($scope.map, 8, position);
+            gaMapUtils.moveTo($scope.map, $scope.ol3d, 8, position);
             gaMarkerOverlay.add($scope.map, position,
                                 [position, position], true);
           } else {

--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -22,17 +22,6 @@ goog.require('ga_urlutils_service');
     return $.map(extent, parseFloat);
   };
 
-  var extentToRectangle = function(e) {
-    var sw = ol.proj.transform([e[0], e[1]], 'EPSG:21781', 'EPSG:4326');
-    var ne = ol.proj.transform([e[2], e[3]], 'EPSG:21781', 'EPSG:4326');
-
-    var west = sw[0];
-    var south = sw[1];
-    var east = ne[0];
-    var north = ne[1];
-    return Cesium.Rectangle.fromDegrees(west, south, east, north);
-  };
-
   var addOverlay = function(gaOverlay, map, res) {
     var visible = originToZoomLevel.hasOwnProperty(res.attrs.origin);
     var center = [res.attrs.y, res.attrs.x];
@@ -347,26 +336,11 @@ goog.require('ga_urlutils_service');
               var ol3d = $scope.ol3d;
               if (originToZoomLevel.hasOwnProperty(res.attrs.origin) &&
                   !isGazetteerPoly) {
-                if (ol3d && ol3d.getEnabled()) {
-                  ol3d.getCesiumScene().camera.flyTo({
-                    destination: Cesium.Cartesian3.fromDegrees(
-                                   res.attrs.lon,
-                                   res.attrs.lat,
-                                   3000)
-                  });
-                } else {
-                  gaMapUtils.moveTo($scope.map,
-                                    originToZoomLevel[res.attrs.origin],
-                                    [res.attrs.y, res.attrs.x]);
-                }
+                gaMapUtils.moveTo($scope.map, $scope.ol3d,
+                    originToZoomLevel[res.attrs.origin],
+                    [res.attrs.y, res.attrs.x]);
               } else {
-                if (ol3d && ol3d.getEnabled()) {
-                  ol3d.getCesiumScene().camera.flyTo({
-                    destination: extentToRectangle(e)
-                  });
-                } else {
-                  gaMapUtils.zoomToExtent($scope.map, e);
-                }
+                gaMapUtils.zoomToExtent($scope.map, $scope.ol3d, e);
               }
               addOverlay(gaMarkerOverlay, $scope.map, res);
               $scope.options.valueSelected(
@@ -473,16 +447,7 @@ goog.require('ga_urlutils_service');
                   onCloseCB: angular.noop
                 });
                 var feature = geojsonParser.readFeature(f);
-                var ol3d = $scope.ol3d;
-                if (ol3d && ol3d.getEnabled()) {
-                  var extent = feature.getGeometry().getExtent();
-                  extent = gaPreviewFeatures.getMinimalExtent(extent);
-                  ol3d.getCesiumScene().camera.flyTo({
-                    destination: extentToRectangle(extent)
-                  });
-                } else {
-                  gaPreviewFeatures.zoom($scope.map, feature);
-                }
+                gaPreviewFeatures.zoom($scope.map, $scope.ol3d, feature);
               });
               $scope.options.valueSelected(
                   gaSearchLabels.cleanLabel(res.attrs.label));

--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -430,7 +430,8 @@ goog.require('ga_urlutils_service');
           templateUrl: 'components/search/partials/searchtypes.html',
           scope: {
             options: '=gaSearchFeaturesOptions',
-            map: '=gaSearchFeaturesMap'
+            map: '=gaSearchFeaturesMap',
+            ol3d: '=gaSearchFeaturesOl3d'
           },
           controller: 'GaSearchTypesController',
           link: function($scope, element, attrs) {
@@ -471,8 +472,17 @@ goog.require('ga_urlutils_service');
                   features: [f],
                   onCloseCB: angular.noop
                 });
-                gaPreviewFeatures.zoom($scope.map,
-                    geojsonParser.readFeature(f));
+                var feature = geojsonParser.readFeature(f);
+                var ol3d = $scope.ol3d;
+                if (ol3d && ol3d.getEnabled()) {
+                  var extent = feature.getGeometry().getExtent();
+                  extent = gaPreviewFeatures.getMinimalExtent(extent);
+                  ol3d.getCesiumScene().camera.flyTo({
+                    destination: extentToRectangle(extent)
+                  });
+                } else {
+                  gaPreviewFeatures.zoom($scope.map, feature);
+                }
               });
               $scope.options.valueSelected(
                   gaSearchLabels.cleanLabel(res.attrs.label));

--- a/src/components/search/partials/search.html
+++ b/src/components/search/partials/search.html
@@ -16,7 +16,7 @@
           ng-show="restat.sets()"
           ng-class="'ga-search-' + restat.sets()">
       <!-- locations -->
-      <div ga-search-locations ga-search-locations-options="childoptions" ga-search-locations-map="map"></div>
+      <div ga-search-locations ga-search-locations-options="childoptions" ga-search-locations-map="map" ga-search-locations-ol3d="::ol3d"></div>
       <!-- features -->
       <div ga-search-features ga-search-features-options="childoptions" ga-search-features-map="map"></div>
       <!-- layers -->

--- a/src/components/search/partials/search.html
+++ b/src/components/search/partials/search.html
@@ -18,7 +18,7 @@
       <!-- locations -->
       <div ga-search-locations ga-search-locations-options="childoptions" ga-search-locations-map="map" ga-search-locations-ol3d="::ol3d"></div>
       <!-- features -->
-      <div ga-search-features ga-search-features-options="childoptions" ga-search-features-map="map"></div>
+      <div ga-search-features ga-search-features-options="childoptions" ga-search-features-map="map" ga-search-features-ol3d="::ol3d"></div>
       <!-- layers -->
       <div ga-search-layers ga-search-layers-options="childoptions" ga-search-layers-map="map"></div>
     </span> <!-- dropdown -->

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -153,7 +153,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         <div id="logo" class="pull-left ga-logo ga-logo-{{langId}}"></div>
       </a>
       <div id="search-container" ng-controller="GaSearchController">
-        <div ga-search ga-search-map="map" ga-search-options="options" ga-search-focused="globals.searchFocused"></div>
+        <div ga-search ga-search-map="map" ga-search-options="options" ga-search-focused="globals.searchFocused" ga-search-ol3d="::ol3d"></div>
   % if device == 'desktop':
         <span ga-help="24,31,25" ga-help-options="{showOnHover:true}"></span>
   % endif      


### PR DESCRIPTION
Should be rebased and merged after #2590.

[Test](https://mf-geoadmin3.dev.bgdi.ch/gberaudo_search_layer/src/?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&catalogNodes=532&layers=ch.swisstopo.vec200-names-namedlocation&lon=7.01749&lat=46.51861&elevation=76984&heading=359.927&pitch=-89.998)