### PR TITLE
Fix #2549: Focus in search input on page load (only desktop)

### DIFF
--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -167,6 +167,11 @@ goog.require('ga_translation_service');
       // We begin to watch the query only when topics are loaded
       gaTopic.loadConfig().then(function() {
         $scope.topicLoaded = true;
+        if ($scope.searchFocused) {
+          $timeout(function() {
+            $scope.input.focus();
+          }, 0, false);
+        }
         if ($scope.query) {
           startQuery($scope.query);
         }

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -239,7 +239,7 @@ goog.require('ga_storage_service');
 
     $scope.globals = {
       dev3d: gaGlobalOptions.dev3d,
-      searchFocused: false,
+      searchFocused: !gaBrowserSniffer.mobile,
       homescreen: false,
       tablet: gaBrowserSniffer.mobile && !gaBrowserSniffer.phone,
       touch: gaBrowserSniffer.touchDevice,


### PR DESCRIPTION
[Test](https://mf-geoadmin3.dev.bgdi.ch/autofocus/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&mobile=false)