### PR TITLE
[3D] Update the tilt and rotate indicator

### DIFF
--- a/src/components/controls3d/Controls3dDirective.js
+++ b/src/components/controls3d/Controls3dDirective.js
@@ -29,10 +29,21 @@ goog.provide('ga_controls3d_directive');
         var tiltIndicator = element.find('.ga-tilt .ga-indicator');
         var rotateIndicator = element.find('.ga-rotate .ga-indicator');
 
+        var moving = false;
+
+        camera.moveStart.addEventListener(function() {
+          moving = true;
+        });
         camera.moveEnd.addEventListener(function() {
-          var tiltOnGlobe = olcs.core.computeSignedTiltAngleOnGlobe(scene);
-          cssRotate(tiltIndicator, -tiltOnGlobe);
-          cssRotate(rotateIndicator, -camera.heading);
+          moving = false;
+        });
+
+        scene.postRender.addEventListener(function() {
+          if (moving) {
+            var tiltOnGlobe = olcs.core.computeSignedTiltAngleOnGlobe(scene);
+            cssRotate(tiltIndicator, -tiltOnGlobe);
+            cssRotate(rotateIndicator, -camera.heading);
+          }
         });
 
         scope.tilt = function(angle) {


### PR DESCRIPTION
Update the indicators as soon as the view changes.

Note: scope.watch can't be used because angular doesn't start a new digest cycle every time the camera is updated.

