### PR TITLE
Use Cesium.UrlTemplateImageryProvider

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -75,6 +75,8 @@ goog.provide('ga_urlutils_service');
               replace(/%3A/gi, ':').
               replace(/%24/g, '$').
               replace(/%2C/gi, ',').
+              replace(/%7B/gi, '{').
+              replace(/%7D/gi, '}').
               replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
         };
 
@@ -104,6 +106,7 @@ goog.provide('ga_urlutils_service');
                 (value === true ? '' : '=' +
                     this_.encodeUriQuery(value, true)));
           });
+
           return parts.length ? parts.join('&') : '';
         };
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -726,13 +726,14 @@ itemscope itemtype="http://schema.org/WebApplication"
         });
 
         module.config(function(gaLayersProvider, gaGlobalOptions) {
-          gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
+          gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
           
-          gaLayersProvider.wmtsMapProxyGetTileUrlTemplate = '//mf-chsdi3.dev.bgdi.ch/mom_fix_1594/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.{Format}';
+          gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =
+          '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
           
           gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
 
-          gaLayersProvider.wmsMapProxyUrl = '//api3.geo.admin.ch/mapproxy/service?';
+          gaLayersProvider.wmsMapProxyUrl = '//wmts{s}.geo.admin.ch/mapproxy/service';
           
           gaLayersProvider.layersConfigUrlTemplate =
               gaGlobalOptions.resourceUrl + 'layersConfig?lang={Lang}';


### PR DESCRIPTION
This PR changes the Cesium providers used and add prod url for mapproxy

[Test with all kind of layers](https://mf-geoadmin3.dev.bgdi.ch/teo_multi/?lang=en&topic=funksender&bgLayer=ch.swisstopo.pixelkarte-grau&dev3d=true&layers=ch.swisstopo.swissimage-product,ch.swisstopo.vec25-einzelobjekte,ch.bakom.radio-fernsehsender,ch.bazl.luftfahrthindernis,WMS%7C%7CMountainbike-Routen%7C%7Chttps:%2F%2Fwms.zh.ch%2FVelonetzZHWMS%7C%7Cmountainbike-routen,WMS%7C%7CAGNES%7C%7Chttps:%2F%2Fwms.geo.admin.ch%2F%7C%7Cch.swisstopo.fixpunkte-agnes&layers_opacity=1,1,1,0.7,1,1&X=203750.00&Y=663000.00&zoom=2&catalogNodes=408)



