### PR TITLE
Don't show time elements when in 3D

### DIFF
--- a/rc_branch.mako
+++ b/rc_branch.mako
@@ -1,3 +1,3 @@
 export APACHE_BASE_PATH=/${apache_base_path}
-export API_URL=//mf-chsdi3.${deploy_target}.bgdi.ch/teo_ls_2
+export API_URL=//mf-chsdi3.${deploy_target}.bgdi.ch
 export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/${apache_base_path}

--- a/src/components/layermanager/style/layermanager.less
+++ b/src/components/layermanager/style/layermanager.less
@@ -211,6 +211,10 @@
   }
 }
 
+.ga-3d-active .ga-layer-time {
+  display: none;
+}
+
 /* HACK for alignment in FF and IE */
 .no-webkit [ga-layermanager] .ga-layer-infos label {
   margin-top: -1px;

--- a/src/components/timeselector/style/timeselector.less
+++ b/src/components/timeselector/style/timeselector.less
@@ -171,3 +171,12 @@
   }
 }
 
+.ga-3d-active [ga-time-selector-bt] {
+  display: none;
+  background: data-uri('time_black.png') center center no-repeat;
+}
+
+.ga-3d-active [ga-time-selector] {
+  display: none;
+}
+

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -208,6 +208,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         <div ga-geolocation ga-geolocation-map="map"></div>
   % endif
         <div id="zoomButtons"></div>
+        <div ga-tilt3d ng-if="globals.dev3d"></div>
   % if device != 'embed':
         <div ga-time-selector-bt ga-time-selector-bt-map="map"></div> 
   % endif
@@ -215,7 +216,6 @@ itemscope itemtype="http://schema.org/WebApplication"
   % if device == 'mobile':
         <div ga-offline-bt></div>
   % endif
-        <div ga-tilt3d ng-if="globals.dev3d"></div>
       </div>
       <div ga-swipe 
            ga-swipe-map="map" 
@@ -273,7 +273,8 @@ itemscope itemtype="http://schema.org/WebApplication"
 % if device != 'embed':
     <div ng-controller="GaTimeSelectorController">
       <div ga-time-selector ga-time-selector-map="map"
-           ga-time-selector-options="options">
+           ga-time-selector-options="options"
+           ng-show="!globals.is3dActive">
       </div>
     </div>
 % endif


### PR DESCRIPTION
This fixes https://github.com/geoadmin/mf-geoadmin3/issues/2649

It assures that time specific controls are not visible when we are in 3D mode.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_3d_notime/?dev3d=true)