### PR TITLE
Adding fuzzy search indicator

### DIFF
--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -195,6 +195,7 @@ goog.require('ga_urlutils_service');
 
       var cancel = function() {
         $scope.results = [];
+        $scope.fuzzy = '';
         if (canceler !== undefined) {
           canceler.resolve();
           canceler = undefined;
@@ -218,6 +219,9 @@ goog.require('ga_urlutils_service');
           timeout: canceler.promise
         }).success(function(data) {
           $scope.results = data.results;
+          if (data.fuzzy) {
+            $scope.fuzzy = '_fuzzy';
+          }
           $scope.options.announceResults($scope.type, data.results.length);
         }).error(function(data, statuscode) {
           // If request is canceled, statuscode is 0 and we don't announce it
@@ -288,6 +292,8 @@ goog.require('ga_urlutils_service');
       $scope.cleanLabel = function(attrs) {
         return gaSearchLabels.cleanLabel(attrs.label);
       };
+
+      $scope.fuzzy = '';
 
       $scope.$watch('options.query', function(newval) {
         //cancel old requests

--- a/src/components/search/partials/searchtypes.html
+++ b/src/components/search/partials/searchtypes.html
@@ -1,5 +1,5 @@
 <div class="ga-search-results-container ng-hide" ng-hide="!results.length">
-  <div class="ga-search-results-header" translate>{{type + '_results_header'}}</div>
+  <div class="ga-search-results-header" translate>{{type + '_results_header' + fuzzy}}</div>
   <div class="ga-search-results">
     <div class="ga-search-result" tabindex="{{tabstart + i}}"
          ng-repeat="(i, res) in results"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -190,6 +190,7 @@
 	"link_validate_kml": "Link zur Validierung des KML",
 	"load_kml": "KML laden",
 	"locations_results_header": "Gehe nach ...",
+	"locations_results_header_fuzzy": "Meinten Sie ...",
 	"luftbilder": "Luftbilder",
 	"luftbilder_service_link_href": "http://www.swisstopo.admin.ch/internet/swisstopo/de/home/products/images.html",
 	"luftbilder_service_link_label": "Bundesamt für Landestopografie swisstopo",

--- a/src/locales/empty.json
+++ b/src/locales/empty.json
@@ -83,6 +83,7 @@
   "follow_us": "",
   "email_us": "",
   "locations_results_header": "",
+  "locations_results_header_fuzzy": "",
   "layers_results_header": "",
   "search_placeholder": "",
   "search_title": "",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -190,6 +190,7 @@
 	"link_validate_kml": "Link to KML validation",
 	"load_kml": "Load KML",
 	"locations_results_header": "Go to ...",
+	"locations_results_header_fuzzy": "Did you mean...",
 	"luftbilder": "Aerial images",
 	"luftbilder_service_link_href": "http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/images.html",
 	"luftbilder_service_link_label": "Federal Office of Topography swisstopo",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -190,6 +190,7 @@
 	"link_validate_kml": "Lien vers validation KML",
 	"load_kml": "Charger KML",
 	"locations_results_header": "Aller à ...",
+	"locations_results_header_fuzzy": "Pensiez-vous à...",
 	"luftbilder": "Photos aériennes",
 	"luftbilder_service_link_href": "http://www.swisstopo.admin.ch/internet/swisstopo/de/home/products/images.html",
 	"luftbilder_service_link_label": "Office fédéral de topographie swisstopo",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -190,6 +190,7 @@
 	"link_validate_kml": "Link alla validazione KML",
 	"load_kml": "Caricare KML",
 	"locations_results_header": "Vai a ...",
+	"locations_results_header_fuzzy": "Intendevi forse...",
 	"luftbilder": "Immagini aeree ",
 	"luftbilder_service_link_href": "http://www.swisstopo.admin.ch/internet/swisstopo/it/home/products/images.html",
 	"luftbilder_service_link_label": "Ufficio federale di topografia swisstopo",

--- a/src/locales/rm.json
+++ b/src/locales/rm.json
@@ -190,6 +190,7 @@
 	"link_validate_kml": "Link to KML validation",
 	"load_kml": "Chargiar KML",
 	"locations_results_header": "Ir a ...",
+	"locations_results_header_fuzzy": "Meinten Sie eventuell...",
 	"luftbilder": "Fotografia ord l'aria",
 	"luftbilder_service_link_href": "http://www.swisstopo.admin.ch/internet/swisstopo/de/home/products/images.html",
 	"luftbilder_service_link_label": "Uffizi federal da topografia swisstopo",


### PR DESCRIPTION
This is a fix for https://github.com/geoadmin/mf-geoadmin3/issues/2552

It needs https://github.com/geoadmin/mf-geoadmin3/issues/2552 to be merged first, therefore en WIP.

It needs translations for `locations_results_header_fuzzy`
@AFoletti Could you do italian
@cedricmoullet Could you do french

@davidoesch Please also read comments in referenced PR https://github.com/geoadmin/mf-chsdi3/pull/1615
@ltclm This might be of interest to you. Especially the ordering of the results. See explanations in https://github.com/geoadmin/mf-chsdi3/pull/1615. I think it's probably not optimal now.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_fuzzy)