### PR TITLE
Add metadata for external WMS layers

### DIFF
--- a/src/components/catalogtree/CatalogitemDirective.js
+++ b/src/components/catalogtree/CatalogitemDirective.js
@@ -57,8 +57,8 @@ goog.require('ga_layer_metadata_popup_service');
               evt.stopPropagation();
             };
 
-            $scope.getLegend = function(evt, bodid) {
-              gaLayerMetadataPopup.toggle(bodid);
+            $scope.getLegend = function(evt, bodId) {
+              gaLayerMetadataPopup.toggle(bodId);
               evt.stopPropagation();
             };
           },

--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -58,7 +58,8 @@ goog.require('ga_urlutils_service');
 
   module.directive('gaLayermanager', function($compile, $document, $timeout,
       $rootScope, $translate, $window, gaBrowserSniffer, gaLayerFilters,
-      gaLayerMetadataPopup, gaLayers, gaAttribution, gaUrlUtils) {
+      gaLayerMetadataPopup, gaLayers, gaAttribution, gaUrlUtils,
+      gaMapUtils) {
 
     // Timestamps list template
     var tpl =
@@ -200,6 +201,11 @@ goog.require('ga_urlutils_service');
           return !!gaLayers.getLayer(layer.bodId);
         };
 
+        scope.hasMetadata = function(layer) {
+          return scope.isBodLayer(layer) ||
+              gaMapUtils.isExternalWmsLayer(layer);
+        };
+
         scope.showWarning = function(layer) {
           var url = gaUrlUtils.isValid(layer.url) ?
               gaUrlUtils.getHostname(layer.url) : layer.url;
@@ -208,10 +214,7 @@ goog.require('ga_urlutils_service');
         };
 
         scope.displayLayerMetadata = function(evt, layer) {
-          var bodId = layer.bodId;
-          if (gaLayers.getLayer(bodId)) {
-            gaLayerMetadataPopup.toggle(bodId);
-          }
+          gaLayerMetadataPopup.toggle(layer);
           evt.preventDefault();
         };
 

--- a/src/components/layermanager/partials/layermanager.html
+++ b/src/components/layermanager/partials/layermanager.html
@@ -44,7 +44,7 @@
         <button class="ga-icon ga-btn icon-arrow-down"
                 ng-disabled="$last"
                 ng-click="moveLayer($event, layer, -1)"></button>
-        <button ng-if="isBodLayer(layer)" class="ga-icon ga-btn icon-info-sign"
+        <button ng-if="hasMetadata(layer)" class="ga-icon ga-btn icon-info-sign"
                 ng-click="displayLayerMetadata($event, layer)"></button>
       </div>
     </div>

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -332,7 +332,7 @@ goog.require('ga_urlutils_service');
    */
   module.provider('gaWms', function() {
     this.$get = function(gaDefinePropertiesForLayer, gaMapUtils, gaUrlUtils,
-        gaGlobalOptions) {
+        gaGlobalOptions, $q) {
       var getCesiumImageryProvider = function(layer) {
         var params = layer.getSource().getParams();
         var proxy;
@@ -423,6 +423,24 @@ goog.require('ga_urlutils_service');
             map.addLayer(olLayer);
           }
           return olLayer;
+        };
+
+        // Make a GetLegendGraphic request
+        this.getLegend = function(layer) {
+          var defer = $q.defer();
+          var params = layer.getSource().getParams();
+          var html = '<img src="' + gaUrlUtils.append(layer.url,
+              gaUrlUtils.toKeyValue({
+            request: 'GetLegendGraphic',
+            layer: params.LAYERS,
+            style: params.style || 'default',
+            service: 'WMS',
+            version: params.version || '1.3.0',
+            format: 'image/png',
+            sld_version: '1.1.0'
+          })) + '"></img>';
+          defer.resolve({data: html});
+          return defer.promise;
         };
       };
       return new Wms();

--- a/test/specs/LayerMetadataPopupService.spec.js
+++ b/test/specs/LayerMetadataPopupService.spec.js
@@ -1,12 +1,42 @@
 describe('ga_layer_metadata_popup_service', function() {
   var gaLayerMetadataPopup,
-      $httpBackend,
+      gaLang, gaLayers, $http,
+      $httpBackend, $q,
       $rootScope,
       $translate;
 
+  var getBodLayer = function(bodId) {
+    var layer = new ol.layer.Tile();
+    layer.id = bodId;
+    layer.bodId = bodId;
+    layer.displayInLayerManager = true;
+    return layer;
+  };
+
+  var getExternalWmsLayer = function(name) {
+    var layer = new ol.layer.Image({
+      source: new ol.source.ImageWMS({
+        params: {LAYERS: name}
+      })
+    });
+    layer.id = 'WMS||The wms layer||http://foo.ch/wms||' + name;
+    layer.displayInLayerManager = true;
+    layer.type = 'WMS';
+    layer.url = 'http://foo.ch/wms';
+    return layer;
+  };
+
+  var getMetaDataUrl = function(bodId) {
+     return 'http://legendservice.com/all/' + bodId + '?lang=' + gaLang.get();
+  }
+
+  var getWmsHtmlLegend = function(olLayer) {
+    return '<img src="' + olLayer.url + '/' +
+        olLayer.getSource().getParams()['LAYERS'] + '">';
+  }
+
   beforeEach(function() {
     module(function($provide) {
-      $provide.value('gaTopic', {});
       $provide.value('gaLang', new (function() {
         var lang = 'somelang';
         this.get = function() {
@@ -17,18 +47,33 @@ describe('ga_layer_metadata_popup_service', function() {
           $translate.use(newLang);
         };
       })());
+      $provide.value('gaLayers', new (function() {
+        this.getMetaDataOfLayer = function(bodId) {
+          return $http.get(getMetaDataUrl(bodId));
+        };
+        this.getOlLayerById = function(bodId) {
+          return getBodLayer(bodId);
+        };
+      })());
+      $provide.value('gaWms', new (function() {
+        this.getLegend = function(olLayer) {
+          var defer = $q.defer();
+          defer.resolve({data: getWmsHtmlLegend(olLayer)});
+          return defer.promise;
+        };
+      })());
     });
 
     inject(function($injector) {
       gaLayerMetadataPopup = $injector.get('gaLayerMetadataPopup');
+      gaLayers = $injector.get('gaLayers');
+      gaLang = $injector.get('gaLang');
+      $http = $injector.get('$http');
       $httpBackend = $injector.get('$httpBackend');
       $rootScope = $injector.get('$rootScope');
       $translate = $injector.get('$translate');
+      $q = $injector.get('$q');
     });
-
-    $translate.use('somelang');
-    $httpBackend.whenGET('http://example.com/all?lang=somelang').respond({});
-    $httpBackend.flush();
   });
 
   afterEach(function () {
@@ -36,58 +81,109 @@ describe('ga_layer_metadata_popup_service', function() {
     $httpBackend.verifyNoOutstandingRequest();
   });
 
-  it('creates a legend popup with the right content', function() {
-    var expectedUrlLegend = 'http://legendservice.com/all/somelayer?lang=somelang';
-    $httpBackend.whenGET(expectedUrlLegend).respond('<div>Some raw html</div>');
+  it('creates a legend popup for a bod layer with the right content', function() {
+
+    // Show the legend of the first bod layer (using bodId)
+    $httpBackend.whenGET(getMetaDataUrl('somelayer')).respond('<div>Some raw html</div>');
     gaLayerMetadataPopup.toggle('somelayer');
     $rootScope.$digest();
     $httpBackend.flush();
 
+    // Verify the html
     var popupLegend = $('.ga-tooltip-metadata');
+    var popupContent = '<div>Some raw html</div>';
     expect(popupLegend.length).to.be(1);
     expect(popupLegend.parents().length).to.be(2);
     expect(popupLegend.css('display')).to.be('block');
-    var popupContent = '<div>Some raw html</div>';
     expect(popupLegend.find('.ga-popup-content').html().indexOf(popupContent) > -1).to.be(true);
 
+    // Hide the legend of the first bod layer
     gaLayerMetadataPopup.toggle('somelayer');
     $rootScope.$digest();
 
-    // We don't create a new one because we have the same id
+    // Verify the html
     popupLegend = $('.ga-tooltip-metadata');
     expect(popupLegend.length).to.be(1);
     expect(popupLegend.css('display')).to.be('none');
 
-    //With a new url -> request and a new popup
+    // Show the legend of the first bod layer
     gaLayerMetadataPopup.toggle('somelayer');
     $rootScope.$digest();
 
+    // Verify the html
     popupLegend = $('.ga-tooltip-metadata');
     expect(popupLegend.length).to.be(1);
     expect(popupLegend.css('display')).to.be('block');
 
-    expectedUrlLegend = 'http://legendservice.com/all/somenewlayer?lang=somelang';
-    $httpBackend.whenGET(expectedUrlLegend).respond('<div>Some new raw html</div>');
-    gaLayerMetadataPopup.toggle('somenewlayer');
+    // Show the legend of the second bod layer (using an olLayer)
+    var someNewLayer = getBodLayer('somenewlayer');
+    $httpBackend.whenGET(getMetaDataUrl('somenewlayer')).respond('<div>Some new raw html</div>');
+    gaLayerMetadataPopup.toggle(someNewLayer);
     $rootScope.$digest();
     $httpBackend.flush();
 
+    // Verify the html
     popupLegend = $('.ga-tooltip-metadata');
     expect(popupLegend.length).to.be(2);
 
-    // 2 popups so far, on translation end -> 2 new requests
-    var expectedUrlLayersConfig = 'http://example.com/all?lang=someotherlang';
-    $httpBackend.whenGET(expectedUrlLayersConfig).respond({});
-    $translate.use('someotherlang');
-
-    expectedUrlLegend = 'http://legendservice.com/all/somelayer?lang=someotherlang';
-    $httpBackend.whenGET(expectedUrlLegend).respond('<div>Some translated raw html</div>');
-    expectedUrlLegend = 'http://legendservice.com/all/somenewlayer?lang=someotherlang';
-    $httpBackend.whenGET(expectedUrlLegend).respond('<div>Some translated new raw html</div>');
+    // Change the language
+    gaLang.set('someotherlang');
+    $httpBackend.whenGET(getMetaDataUrl('somelayer')).respond('<div>Some translated raw html</div>');
+    $httpBackend.whenGET(getMetaDataUrl('somenewlayer')).respond('<div>Some translated new raw html</div>');
     $rootScope.$digest();
     $httpBackend.flush();
 
+    // Verify the html
     popupLegend = $('.ga-tooltip-metadata');
     expect(popupLegend.length).to.be(2);
+
+    // Hide legend of the 2 bod layers for next test
+    gaLayerMetadataPopup.toggle('somelayer');
+    gaLayerMetadataPopup.toggle(someNewLayer);
+  });
+
+  it('creates a legend popup for a external wms layer with the right content', function() {
+    var wmsLayer = getExternalWmsLayer('somewmslayer');
+    var newWmsLayer = getExternalWmsLayer('somenewwmslayer');
+
+    // Show the legend of the first wms layer
+    gaLayerMetadataPopup.toggle(wmsLayer);
+    $rootScope.$digest();
+
+    // Verify the html
+    var popupLegend = $('.ga-tooltip-metadata');
+    var popupContent = getWmsHtmlLegend(wmsLayer);
+    expect(popupLegend.length).to.be(3); // 2 from the first test
+    expect(popupLegend.parents().length).to.be(2);
+    expect($(popupLegend[2]).css('display')).to.be('block');
+    expect($(popupLegend[2]).find('.ga-popup-content').html().indexOf(popupContent) > -1).to.be(true);
+
+    // Hide the legend of the first wms layer
+    gaLayerMetadataPopup.toggle(wmsLayer);
+    $rootScope.$digest();
+
+    // Verify the html
+    popupLegend = $('.ga-tooltip-metadata');
+    expect(popupLegend.length).to.be(3);
+    expect($(popupLegend[2]).css('display')).to.be('none');
+
+    // Show the legend of the first wms layer
+    gaLayerMetadataPopup.toggle(wmsLayer);
+    $rootScope.$digest();
+
+    // Verify the html
+    popupLegend = $('.ga-tooltip-metadata');
+    expect(popupLegend.length).to.be(3);
+    expect($(popupLegend[2]).css('display')).to.be('block');
+
+    // Show the legend of the 2nd wms layer
+    gaLayerMetadataPopup.toggle(newWmsLayer);
+    $rootScope.$digest();
+
+    // Verify the html
+    popupLegend = $('.ga-tooltip-metadata');
+    popupContent = getWmsHtmlLegend(newWmsLayer);
+    expect(popupLegend.length).to.be(4);
+    expect($(popupLegend[3]).find('.ga-popup-content').html().indexOf(popupContent) > -1).to.be(true);
   });
 });


### PR DESCRIPTION
Attempt to fix the long time bug #1041

Display the GetLegend for external WMS layers  

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_wms/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=242363.45&Y=696017.65&dev3d=true&zoom=6&layers=WMS%7C%7CAGNES%7C%7Chttps:%2F%2Fwms.geo.admin.ch%2F%7C%7Cch.swisstopo.fixpunkte-agnes,WMS%7C%7COrthophoto%20Avenches%20Haras%7C%7Chttp:%2F%2Fogc.heig-vd.ch%2Fmapserver%2Fwms%3F%7C%7Cr-pod_avenches_haras,WMS%7C%7CRadwege%7C%7Chttps:%2F%2Fwms.zh.ch%2FVeloinfrastrukturZHWMS%7C%7Cradwege,WMS%7C%7CGrundwasserschutzzonen%7C%7Chttps:%2F%2Fwms.geo.gr.ch%2Fgewaesserschutz%7C%7CGrundwasserschutzzonen)