### PR TITLE
Fix #2689: Put translateId in the translate attribute

### DIFF
--- a/src/components/search/partials/searchtypes.html
+++ b/src/components/search/partials/searchtypes.html
@@ -1,5 +1,5 @@
 <div class="ga-search-results-container ng-hide" ng-hide="!results.length">
-  <div class="ga-search-results-header" translate>{{type + '_results_header' + fuzzy}}</div>
+  <div class="ga-search-results-header" translate="{{type + '_results_header' + fuzzy}}"></div>
   <div class="ga-search-results">
     <div class="ga-search-result" tabindex="{{tabstart + i}}"
          ng-repeat="(i, res) in results"

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -260,7 +260,7 @@ itemscope itemtype="http://schema.org/WebApplication"
       </div>
   % if device == 'desktop':
       <div class="pull-right">
-        <a target="_blank" translate translate-attr-href="{{topicId + '_service_link_href'}}">{{topicId + '_service_link_label'}}</a>
+        <a target="_blank" translate="{{topicId + '_service_link_label'}}" translate-attr-href="{{topicId + '_service_link_href'}}"></a>
       </div>
   % endif
     </div><!-- #footer -->


### PR DESCRIPTION
Fix #2689 

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_2689/src/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,)