### PR TITLE
Fix #2700: Doesn't add attribution when already available in third pa…

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -678,9 +678,10 @@ goog.require('ga_time_service');
           // Get all attributions to diaplay
           var attribution = gaAttribution.getTextFromLayer(layer);
           if (attribution !== undefined) {
-            if (layer.useThirdPartyData &&
-                thirdPartyAttributions.indexOf(attribution) == -1) {
-              thirdPartyAttributions.push(attribution);
+            if (layer.useThirdPartyData) {
+              if (thirdPartyAttributions.indexOf(attribution) == -1) {
+                thirdPartyAttributions.push(attribution);
+              }
             } else if (attributions.indexOf(attribution) == -1) {
               attributions.push(attribution);
             }


### PR DESCRIPTION
…rt attributions list

Fix #2700 

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_2700/?topic=ech&lang=de&bgLayer=ch.swisstopo.swissimage&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443032201-13835%2Fgeocaching.kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443032703-15373%2Fgeocaching(1).kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443032810-15768%2Fgeocaching(2).kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443033012-16556%2Fgeocaching(3).kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443033111-16820%2Fgeocaching(4).kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443033222-17202%2Fgeocaching(5).kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443033296-17404%2Fgeocaching(6).kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443033411-17687%2Fgeocaching(7).kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443033495-17889%2Fgeocaching(8).kml,KML%7C%7Chttp:%2F%2Fwww.gpsvisualizer.com%2Fdownload%2Fgpsbabel%2F1443033581-18108%2Fgeocaching(9).kml&layers_visibility=false,false,false,false,true,true,true,true,true,true,true,true,true,true&layers_timestamp=18641231,,,,,,,,,,,,,&X=142770.00&Y=614790.00&zoom=6)