### PR TITLE
Fix #2701: Active multiprint only when zeitreihen is visible

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -1030,7 +1030,7 @@ goog.require('ga_time_service');
 
     $scope.layers = $scope.map.getLayers().getArray();
     $scope.layerFilter = function(layer) {
-      return layer.bodId == 'ch.swisstopo.zeitreihen';
+      return layer.bodId == 'ch.swisstopo.zeitreihen' && layer.visible;
     };
     $scope.$watchCollection('layers | filter:layerFilter', function(lrs) {
       $scope.options.multiprint = (lrs.length == 1);


### PR DESCRIPTION
Fix #2701 

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_2701/?topic=ech)