### PR TITLE
Add new swisstlm3d pre-generated tiles as background

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -875,7 +875,7 @@ goog.require('ga_urlutils_service');
               };
               response.data['ch.swisstopo.pixelkarte-grau_3d'] = {
                 subLayersIds: [
-                  'ch.swisstopo.swisstlm3d-karte-grau'
+                  'ch.swisstopo.swisstlm3d-karte-grau.3d'
                 ],
                 attribution: 'tlm grau 3D',
                 attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
@@ -883,7 +883,7 @@ goog.require('ga_urlutils_service');
               };
               response.data['ch.swisstopo.pixelkarte-farbe_3d'] = {
                 subLayersIds: [
-                  'ch.swisstopo.swisstlm3d-karte-farbe'
+                  'ch.swisstopo.swisstlm3d-karte-farbe.3d'
                 ],
                 attribution: 'tlm farbe 3D',
                 attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
@@ -901,6 +901,33 @@ goog.require('ga_urlutils_service');
                 attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
                     'swisstopo/en/home/products/height/swissALTI3D.html'
               };
+              response.data['ch.swisstopo.swisstlm3d-karte-farbe.3d'] = {
+                type: 'wmts',
+                format: 'jpeg',
+                serverLayerName: 'ch.swisstopo.swisstlm3d-karte-farbe.3d',
+                url: '//wmts{s}.geo.admin.ch/1.0.0/' +
+                    '{Layer}/default/' +
+                    '20150401/{TileMatrixSet}/{z}/{y}/{x}.{Format}',
+                subdomains: '56789',
+                attribution: 'swisstlm 3D Farbe',
+                attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
+                    'swisstopo/en/home/products/height/swissALTI3D.html'
+              };
+              response.data['ch.swisstopo.swisstlm3d-karte-grau.3d'] = {
+                type: 'wmts',
+                format: 'jpeg',
+                serverLayerName: 'ch.swisstopo.swisstlm3d-karte-grau.3d',
+                url: '//wmts{s}.geo.admin.ch/1.0.0/' +
+                    '{Layer}/default/' +
+                    '20150401/{TileMatrixSet}/{z}/{y}/{x}.{Format}',
+                subdomains: '56789',
+                attribution: 'swisstlm 3D Grau',
+                attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
+                    'swisstopo/en/home/products/height/swissALTI3D.html'
+              };
+
+
+
               // Terain
               response.data['ch.swisstopo.terrain.3d'] = {
                 type: 'terrain',


### PR DESCRIPTION
This PR adds the new tlm3d layers as default background for 3d.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_native_tlm3d/?dev3d=true&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false&layers_timestamp=18641231,,&lon=7.87683&lat=46.20254&elevation=145937&heading=5.183&pitch=-62.069)