### PR TITLE
Remove context popup in 3d

### DIFF
--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -19,7 +19,8 @@ goog.require('ga_permalink');
           templateUrl: 'components/contextpopup/partials/contextpopup.html',
           scope: {
             map: '=gaContextPopupMap',
-            options: '=gaContextPopupOptions'
+            options: '=gaContextPopupOptions',
+            is3dActive: '=gaContextPopupIs3d'
           },
           link: function(scope, element, attrs) {
             var heightUrl = scope.options.heightUrl;
@@ -62,6 +63,9 @@ goog.require('ga_permalink');
             };
 
             var handler = function(event) {
+              if (scope.is3dActive) {
+                return;
+              }
               event.stopPropagation();
               event.preventDefault();
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -266,7 +266,7 @@ itemscope itemtype="http://schema.org/WebApplication"
     </div><!-- #footer -->
 
     <div ng-controller="GaContextPopupController">
-      <div ga-context-popup ga-context-popup-map="map" ga-context-popup-options="options"></div>
+      <div ga-context-popup ga-context-popup-map="map" ga-context-popup-options="options" ga-context-popup-is3d="globals.is3dActive"></div>
     </div>
 % endif
 


### PR DESCRIPTION
This removes the right-click popup menu in 3d. right click (and hold) is used for zooming in 3d, so the context popup does not make sense here.