### PR TITLE
Cache lazy loaded scripts

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -695,6 +695,11 @@ itemscope itemtype="http://schema.org/WebApplication"
 
     <script>
       (function() {
+        // Make sure ajax is using cached requests
+        $.ajaxSetup({
+          cache: true
+        });
+
         var module = angular.module('ga');
         var cacheAdd = '${version}' != '' ? '/' + '${version}' : '';
         var pathname = location.pathname.replace(/(index|mobile|embed)\.html$/g, '');


### PR DESCRIPTION
This fixes https://github.com/geoadmin/mf-geoadmin3/issues/2731

Note: also the d3.js library was never cached (also lazy loaded). So this improves the caching for this file as well.