### PR TITLE
Add multi-domain support for wms layers in 3D

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -778,7 +778,7 @@ goog.require('ga_urlutils_service');
 
       var Layers = function(wmtsGetTileUrlTemplate,
           wmtsMapProxyGetTileUrlTemplate, terrainTileUrlTemplate,
-          layersConfigUrlTemplate, legendUrlTemplate, wmsMapProxyUrl) {
+          layersConfigUrlTemplate, legendUrlTemplate) {
         var layers;
 
         var getWmtsUrlFromTemplate = function(tpl, layer, time,
@@ -1048,8 +1048,11 @@ goog.require('ga_urlutils_service');
             if (timestamp) {
               wmsParams.time = timestamp;
             }
-            var url = config3d.wmsUrl ? gaUrlUtils.remove(config3d.wmsUrl,
-                ['request', 'service', 'version'], true) : wmsMapProxyUrl;
+            var url = gaUrlUtils.remove(config3d.wmsUrl,
+                                      ['request', 'service', 'version'], true);
+            url = url.replace('wms.geo.admin.ch', 'wms{s}.geo.admin.ch');
+            config3d.subdomains = config3d.subdomains ||
+                                  ['', '0', '1', '2', '3', '4'];
             params = {
               url: gaUrlUtils.append(url, gaUrlUtils.toKeyValue(wmsParams)),
               tileSize: tileSize
@@ -1316,8 +1319,7 @@ goog.require('ga_urlutils_service');
 
       return new Layers(this.wmtsGetTileUrlTemplate,
           this.wmtsMapProxyGetTileUrlTemplate, this.terrainTileUrlTemplate,
-          this.layersConfigUrlTemplate, this.legendUrlTemplate,
-          this.wmsMapProxyUrl);
+          this.layersConfigUrlTemplate, this.legendUrlTemplate);
     };
 
   });

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -751,8 +751,6 @@ itemscope itemtype="http://schema.org/WebApplication"
           
           gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
 
-          gaLayersProvider.wmsMapProxyUrl = '//wmts{s}.geo.admin.ch/mapproxy/service';
-          
           gaLayersProvider.layersConfigUrlTemplate =
               gaGlobalOptions.resourceUrl + 'layersConfig?lang={Lang}';
 


### PR DESCRIPTION
Multi-domain support for wms requests in 3D.

Fix for https://github.com/geoadmin/mf-geoadmin3/issues/2717

Also, removes unneeded variable.

@cedricmoullet Shouldn't we have wms dynamically scaled before going public with this?