### PR TITLE
Detect when cesium initialization failed

### DIFF
--- a/src/components/tilt3d/Tilt3dDirective.js
+++ b/src/components/tilt3d/Tilt3dDirective.js
@@ -14,8 +14,16 @@ goog.provide('ga_tilt3d_directive');
 
         // true is the selected background layer is not 3d compatible.
         scope.disabled = false;
-        scope.$on('gaBgChange', function(evt, value) {
+        var unregBgChange = scope.$on('gaBgChange', function(evt, value) {
           scope.disabled = !!value.disable3d;
+        });
+
+        // if cesium initialisation failed, is3dActive becomes undefined
+        scope.$watch('globals.is3dActive', function(val) {
+          if (!angular.isDefined(val)) {
+            scope.supported = false;
+            unregBgChange();
+          }
         });
 
         scope.tilt = function() {

--- a/src/components/tilt3d/style/tilt3d.less
+++ b/src/components/tilt3d/style/tilt3d.less
@@ -1,9 +1,8 @@
 .ga-tilt3d {
   background-image: data-uri('icon_3d_off.png');
-  &.ga-unsupported, &.ga-disabled {
-    cursor: default;
-  }
+
   &.ga-unsupported,  &.ga-disabled {
+    cursor: default;
     background-image: data-uri('icon_3d_disabled.png');
   }
 }

--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -29,15 +29,21 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions, $q) {
     var tileCacheSize = intParam('tileCacheSize', '100');
     var maximumScreenSpaceError = intParam('maximumScreenSpaceError', '2');
     window.minimumRetrievingLevel = intParam('minimumRetrievingLevel', '6');
-    var cesiumViewer = new olcs.OLCesium({
-      map: map,
-      createSynchronizers: function(map, scene) {
-         return [
-           new ga.GaRasterSynchronizer(map, scene),
-           new olcs.VectorSynchronizer(map, scene)
-         ];
-      }
-    });
+    var cesiumViewer;
+    try {
+      cesiumViewer = new olcs.OLCesium({
+        map: map,
+        createSynchronizers: function(map, scene) {
+           return [
+             new ga.GaRasterSynchronizer(map, scene),
+             new olcs.VectorSynchronizer(map, scene)
+           ];
+        }
+      });
+    } catch (e) {
+      alert(e.message);
+      return;
+    }
     var globe = cesiumViewer.getCesiumScene().globe;
     globe.baseColor = Cesium.Color.WHITE;
     globe.tileCacheSize = tileCacheSize;

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -98,6 +98,9 @@ goog.require('ga_topic_service');
                                           gaGlobalOptions, $q);
       cesium.loaded().then(function(ol3d) {
         $scope.ol3d = ol3d;
+        if (!$scope.ol3d) {
+          $scope.globals.is3dActive = undefined;
+        }
       });
 
       if (startWith3D) {


### PR DESCRIPTION
Some browsers in particular moibile browser have wevbgl but can't initalize Cesium see this [discussion](https://groups.google.com/forum/#!topic/cesium-dev/x0sfot1WhuQ). This PR catch the failure and deactivate the 3d button.

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_catch/?lang=fr&dev3d=true&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&lon=8.22546&lat=43.12481&elevation=389360&heading=360.000&pitch=-43.723)