### PR TITLE
[3D]: Make sure the layer config is loaded before creating the terrain provider

### DIFF
--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -110,9 +110,12 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions, $q) {
     }
   }();
 
-  cesiumLoaded.promise.then(function(activate) {
-    ol3d = initCesiumViewer(map, activate);
-    cesiumClients.resolve(ol3d);
+  // We need the Cesium lib and the Layers config to create
+  // the 3D viewer
+  $q.all([cesiumLoaded.promise, gaLayers.loadConfig()])
+      .then(function(resolutions) {
+        ol3d = initCesiumViewer(map, resolutions[0]);
+        cesiumClients.resolve(ol3d);
   });
 
   this.enable = function(activate) {


### PR DESCRIPTION
Since https://github.com/geoadmin/mf-geoadmin3/pull/2729 (I think) 3D permalink was broken because we tried to access the layers before the layer configuration was actually loaded. This fixes this issue.