### PR TITLE
[3D] restrict the camera view

### DIFF
--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -26,6 +26,7 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions, $q) {
 
   // Create the cesium viewer with basic layers
   var initCesiumViewer = function(map, enabled) {
+    var frustumFar = intParam('frustumFar', '500000000');
     var tileCacheSize = intParam('tileCacheSize', '100');
     var maximumScreenSpaceError = intParam('maximumScreenSpaceError', '2');
     window.minimumRetrievingLevel = intParam('minimumRetrievingLevel', '6');
@@ -49,6 +50,7 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions, $q) {
     globe.tileCacheSize = tileCacheSize;
     globe.maximumScreenSpaceError = maximumScreenSpaceError;
     var scene = cesiumViewer.getCesiumScene();
+    scene.camera.frustum.far = frustumFar;
     scene.globe.depthTestAgainstTerrain = true;
     scene.screenSpaceCameraController.minimumZoomDistance = 50;
     scene.terrainProvider =


### PR DESCRIPTION
Added a new `frustumFar` parameter to control the `far` attribute of the frustum (see https://cesiumjs.org/Cesium/Build/Documentation/PerspectiveFrustum.html)

Everything that is beyond this value is ignored. 