### PR TITLE
Use multi-urls for tiled WMS and defines default template and subdoma…

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -737,25 +737,21 @@ itemscope itemtype="http://schema.org/WebApplication"
             suffix: '.json'
           });
           $translateProvider.cloakClassName('ng-cloak');
-          // TODO: Use $snaitize instead in the future
+          // TODO: Use $sanitize instead in the future
           // see http://angular-translate.github.io/docs/#/guide/19_security
           $translateProvider.useSanitizeValueStrategy(null);
 
         });
 
         module.config(function(gaLayersProvider, gaGlobalOptions) {
+          gaLayersProvider.dfltWmsSubdomains = ['', '0', '1', '2', '3', '4'];
+          gaLayersProvider.dfltWmtsMapProxySubdomains = ['10', '11', '12', '13', '14'];
+          gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
           gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
-          
-          gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =
-          '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
-          
+          gaLayersProvider.wmtsMapProxyGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
           gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
-
-          gaLayersProvider.layersConfigUrlTemplate =
-              gaGlobalOptions.resourceUrl + 'layersConfig?lang={Lang}';
-
-          gaLayersProvider.legendUrlTemplate =
-              gaGlobalOptions.apiUrl + '/rest/services/all/MapServer/{Layer}/legend?lang={Lang}';
+          gaLayersProvider.layersConfigUrlTemplate = gaGlobalOptions.resourceUrl + 'layersConfig?lang={Lang}';
+          gaLayersProvider.legendUrlTemplate = gaGlobalOptions.apiUrl + '/rest/services/all/MapServer/{Layer}/legend?lang={Lang}';
         });
         module.config(function(gaTopicProvider, gaGlobalOptions) {
           gaTopicProvider.topicsUrl = gaGlobalOptions.resourceUrl + 'services';


### PR DESCRIPTION
…ins in one place

Fix #2717

This PR affects WMTS and WMS. For these layers the url and subdomains used are those defined in the `layersConfig `  if those properties are not defined in the layersConfig that uses the default values defined in the `index.mako.html` 

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_tpls/?lang=fr&topic=luftbilder&bgLayer=ch.swisstopo.pixelkarte-grau&dev3d=true&layers=ch.swisstopo.swissimage-product,ch.swisstopo.swisstlm3d-wanderwege,ch.bazl.laermbelastungskataster-zivilflugplaetze_zweite-nachtstunde,ch.swisstopo.lubis-luftbilder_schraegaufnahmen&layers_opacity=1,1,0.75,1&catalogNodes=1179&layers_timestamp=,,,&lon=8.58313&lat=46.40191&elevation=106925&heading=0.357&pitch=-39.552)