### PR TITLE
Pseudo-hide layers behind opaque layers to avoid loading

### DIFF
--- a/src/components/attribution/AttributionDirective.js
+++ b/src/components/attribution/AttributionDirective.js
@@ -15,8 +15,7 @@ goog.require('ga_map_service');
   ]);
 
   module.directive('gaAttribution', function($translate, $window,
-      gaBrowserSniffer, gaLayerFilters, gaAttribution, $rootScope,
-      gaDebounce) {
+      gaBrowserSniffer, gaAttribution, $rootScope, gaDebounce) {
     return {
       restrict: 'A',
       scope: {

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -25,7 +25,8 @@ goog.require('ga_topic_service');
       $translate, $window, $document, $q, gaBrowserSniffer, gaHistory,
       gaFeaturesPermalinkManager, gaLayersPermalinkManager, gaMapUtils,
       gaRealtimeLayersManager, gaNetworkStatus, gaPermalink, gaStorage,
-      gaGlobalOptions, gaBackground, gaTime, gaLayers, gaTopic) {
+      gaGlobalOptions, gaBackground, gaTime, gaLayers, gaTopic,
+      gaLayerHideManager) {
 
     var createMap = function() {
       var toolbar = $('#zoomButtons')[0];
@@ -154,6 +155,9 @@ goog.require('ga_topic_service');
     gaFeaturesPermalinkManager($scope.map);
 
     gaRealtimeLayersManager($scope.map);
+
+    // Optimize performance by hiding non-visible layers
+    gaLayerHideManager($scope.map);
 
     var initWithPrint = /print/g.test(gaPermalink.getParams().widgets);
     var initWithFeedback = /feedback/g.test(gaPermalink.getParams().widgets);

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -139,7 +139,18 @@ describe('ga_map_service', function() {
           timestamps: ['t3', 't4']
         },
         "ch.bfe.sachplan-geologie-tiefenlager": {},
-        "ch.vbs.patrouilledesglaciers-z_rennen": {}
+        "ch.vbs.patrouilledesglaciers-z_rennen": {},
+        "ch.swisstopo.swissimage-product": {},
+        "ch.swisstopo.pixelkarte-farbe-pk25.noscale": {},
+        "ch.swisstopo.pixelkarte-farbe-pk50.noscale": {},
+        "ch.swisstopo.pixelkarte-farbe-pk100.noscale": {},
+        "ch.swisstopo.pixelkarte-farbe-pk200.noscale": {},
+        "ch.swisstopo.pixelkarte-farbe-pk500.noscale": {},
+        "ch.swisstopo.pixelkarte-farbe-pk1000.noscale": {},
+        "ch.swisstopo.swisstlm3d-karte-farbe": {},
+        "ch.swisstopo.swisstlm3d-karte-grau": {},
+        "ch.swisstopo.pixelkarte-farbe": {},
+        "ch.swisstopo.pixelkarte-grau": {}
       });
       $httpBackend.expectGET(expectedUrl);
       $rootScope.$digest();


### PR DESCRIPTION
The idea is to not load tiles from layers which are hidden behind a layer which is fully opaque.

Depending on the benchmark, we  20-34% less tiles are loaded (12-31% less MB). See entry in the benchmark document.

**This is for 2D and 3D: increases map rendering performance, decreases number of requests**

We would need to define which layer would hide the others and apply such a parameters to the layersConfig.

Currently, the following layers are hiding fully all layers behind them:
```
'ch.swisstopo.swissimage-product',
'ch.swisstopo.pixelkarte-farbe',
'ch.swisstopo.pixelkarte-grau',
'ch.swisstopo.swisstlm3d-karte-farbe',
'ch.swisstopo.swisstlm3d-karte-grau',
'ch.swisstopo.pixelkarte-farbe-pk25.noscale',
'ch.swisstopo.pixelkarte-farbe-pk50.noscale',
'ch.swisstopo.pixelkarte-farbe-pk100.noscale',
'ch.swisstopo.pixelkarte-farbe-pk200.noscale',
'ch.swisstopo.pixelkarte-farbe-pk500.noscale',
'ch.swisstopo.pixelkarte-farbe-pk500.noscale',
'ch.swisstopo.pixelkarte-farbe-pk1000.noscale'
```

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_hide/?dev3d=true&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.swissimage-product&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,)

Toughts?