### PR TITLE
Use outerWidth instead of width in draggable directive

### DIFF
--- a/src/components/DraggableDirective.js
+++ b/src/components/DraggableDirective.js
@@ -68,7 +68,7 @@ goog.require('ga_browsersniffer_service');
           // When we start dragging we fix the width to avoid the popup to be
           // resized on borders
           element.css({
-            width: element.width() + 'px'
+            width: element.outerWidth() + 'px'
           });
         }
 
@@ -107,8 +107,8 @@ goog.require('ga_browsersniffer_service');
       var adjustX = function(x) {
         if (x < 0) {
           x = 0;
-        } else if (x + element.width() > $(document.body).width()) {
-          x = $(document.body).width() - element.width();
+        } else if (x + element.outerWidth() > $(document.body).width()) {
+          x = $(document.body).width() - element.outerWidth();
         }
         return x;
       };


### PR DESCRIPTION
Fix #2770

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_2770/src/?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&X=199290.00&Y=600940.00&zoom=6)