### PR TITLE
gaMaputils.intersectWithDefaultExtent must not return an invalid extent

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1372,6 +1372,10 @@ goog.require('ga_urlutils_service');
   module.provider('gaMapUtils', function() {
     this.$get = function($window, gaGlobalOptions, gaUrlUtils, $q) {
       var resolutions = gaGlobalOptions.resolutions;
+      var isExtentEmpty = function(extent) {
+        return extent[0] >= extent[2] || extent[1] >= extent[3];
+      };
+
       return {
         Z_PREVIEW_LAYER: 1000,
         Z_PREVIEW_FEATURE: 1100,
@@ -1667,12 +1671,17 @@ goog.require('ga_urlutils_service');
           if (!extent || extent.length !== 4) {
             return gaGlobalOptions.defaultExtent;
           }
-          return [
+          var extent = [
             Math.max(extent[0], gaGlobalOptions.defaultExtent[0]),
             Math.max(extent[1], gaGlobalOptions.defaultExtent[1]),
             Math.min(extent[2], gaGlobalOptions.defaultExtent[2]),
             Math.min(extent[3], gaGlobalOptions.defaultExtent[3])
           ];
+          if (!isExtentEmpty(extent)) {
+            return extent;
+          } else {
+            return undefined;
+          }
         },
 
         getFeatureOverlay: function(features, style) {


### PR DESCRIPTION
Return undefined if extent is empty. This prevents OpenLayers to try to
zoom on an empty extent.

See
https://github.com/geoadmin/mf-geoadmin3/issues/2733#issuecomment-148775457
and below for details