### PR TITLE
Hide Layers behind opaque layers only in 3D

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -157,7 +157,7 @@ goog.require('ga_topic_service');
     gaRealtimeLayersManager($scope.map);
 
     // Optimize performance by hiding non-visible layers
-    gaLayerHideManager($scope.map);
+    gaLayerHideManager($scope);
 
     var initWithPrint = /print/g.test(gaPermalink.getParams().widgets);
     var initWithFeedback = /feedback/g.test(gaPermalink.getParams().widgets);


### PR DESCRIPTION
This is a reaction to the discussion in https://github.com/geoadmin/mf-geoadmin3/pull/2769. The hiding behind opaqu layers is limited to the 3D view only.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_3dhide/?dev3d=true)