### PR TITLE
Apply wms template on layer creation only

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -821,7 +821,11 @@ goog.require('ga_urlutils_service');
         var layers;
 
         // Returns a unique WMS template url (e.g. //wms{s}.geo.admin.ch)
-        var getWmsTpl = function(tpl, wmsParams) {
+        var getWmsTpl = function(wmsUrl, wmsParams) {
+          var tpl = wmsUrl;
+          if (/wms.geo/.test(wmsUrl)) {
+            tpl = undefined;
+          }
           if (tpl && /(request|service|version)/i.test(tpl)) {
             tpl = gaUrlUtils.remove(tpl, ['request', 'service', 'version'],
                 true);
@@ -1021,12 +1025,6 @@ goog.require('ga_urlutils_service');
                 attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
                     'swisstopo/en/home/products/height/swissALTI3D.html'
               };
-              // Use WMS multi-domains by default
-              angular.forEach(response.data, function(conf, id) {
-                if (conf.type == 'wms' && /wms.geo/.test(conf.wmsUrl)) {
-                   delete response.data[id].wmsUrl;
-                }
-              });
             }
             if (!layers) { // First load
               layers = response.data;


### PR DESCRIPTION
This is a fix for https://github.com/geoadmin/mf-geoadmin3/issues/2805

Since we introduced multi-domain support for geoadmin WMS backends [1], all print requests which contained geoadmin wms layers did not work. This PR adresses this by still keeping multi-domain support for wms but using single-domain for printing.

[1] https://github.com/geoadmin/mf-geoadmin3/pull/2767