### PR TITLE
Deactivate some tools when 3d is active

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -252,6 +252,16 @@ goog.require('ga_topic_service');
         $scope.globals.isSwipeActive = false;
       }
     });
+    // Deactivate all tools when 3d is opening
+    $scope.$watch('globals.is3dActive', function(active) {
+      if (active) {
+        $scope.globals.feedbackPopupShown = false;
+        $scope.globals.isFeatureTreeActive = false;
+        $scope.globals.isSwipeActive = false;
+        $scope.globals.isDrawActive = false;
+        $scope.globals.isShareActive = false;
+      }
+    });
     $rootScope.$on('gaNetworkStatusChange', function(evt, offline) {
       $scope.globals.offline = offline;
     });


### PR DESCRIPTION
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_2674/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,true,false,false&layers_timestamp=18641231,,,&mobile=false&X=163030.49&Y=645942.61&zoom=2)

Fix #2674 