### PR TITLE
Use correct selector for copy button

### DIFF
--- a/src/components/draw/partials/draw.html
+++ b/src/components/draw/partials/draw.html
@@ -123,7 +123,9 @@
         <input type="text" ng-model="userShortenUrl" class="form-control"
                ga-share-copy-input data-placement="top">
         <span class="input-group-btn">
-          <button class="btn btn-default" ga-share-copy-bt=".ga-share-permalink input"></button>
+          <button class="btn btn-default"
+                  ga-share-copy-bt=".ga-share-permalink input[ng-model=userShortenUrl]">
+          </button>
         </span>
       </div>
     </div>
@@ -133,7 +135,9 @@
         <input type="text" ng-model="adminShortenUrl" class="form-control"
                ga-share-copy-input data-placement="top">
         <span class="input-group-btn">
-          <button class="btn btn-default" ga-share-copy-bt=".ga-share-permalink input"></button>
+          <button class="btn btn-default"
+                  ga-share-copy-bt=".ga-share-permalink input[ng-model=adminShortenUrl]">
+          </button>
         </span>
       </div>
     </div>


### PR DESCRIPTION
This time it's the good fix for #2810 

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_copybt/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&layers_visibility=false,false,false,true,true&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttps:%2F%2Fpublic.dev.bgdi.ch%2FmEki7oEtRk-Uz6o9Ka2xeg&layers_timestamp=18641231,,,,&X=144515.00&Y=721290.00&zoom=7)