### PR TITLE
Determine the max level to display for each layer if resolutions is d…

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1146,17 +1146,21 @@ goog.require('ga_urlutils_service');
           var extent = gaMapUtils.intersectWithDefaultExtent(config3d.extent ||
               ol.proj.get('EPSG:21781').getExtent());
           if (params) {
-            var minLod = gaMapUtils.getLodFromRes(config3d.maxResolution) ||
+            var minRetLod = gaMapUtils.getLodFromRes(config3d.maxResolution) ||
                 window.minimumRetrievingLevel;
-            var maxLod = gaMapUtils.getLodFromRes(config3d.minResolution);
+            var maxRetLod = gaMapUtils.getLodFromRes(config3d.minResolution);
+            var maxLod = 17;// 17 is the last terrain level
+            if (config3d.resolutions) {
+              maxLod = gaMapUtils.getLodFromRes(
+                  config3d.resolutions[config3d.resolutions.length - 1]);
+            }
             provider = new Cesium.UrlTemplateImageryProvider({
               url: params.url,
               subdomains: params.subdomains,
-              minimumRetrievingLevel: minLod,
-              maximumRetrievingLevel: maxLod,
-              // Terrain has only 17 levels. This property active client zoom
-              // for next levels.
-              maximumLevel: 17,
+              minimumRetrievingLevel: minRetLod,
+              maximumRetrievingLevel: maxRetLod,
+              // This property active client zoom for next levels.
+              maximumLevel: maxLod,
               rectangle: gaMapUtils.extentToRectangle(extent, 'EPSG:21781'),
               tilingScheme: new Cesium.GeographicTilingScheme(),
               tileWidth: params.tileSize,


### PR DESCRIPTION
…efined in layer's config

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_dynlod/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.swissimage-product&layers_visibility=false,false,false,true,true&layers_timestamp=18641231,,,,&lon=6.93142&lat=46.81711&elevation=657&heading=4.776&pitch=-89.250)
Fix #2839


Quality is bad at level 18 we should avoid the 50% compression for the level 18. And maybe 16 and 17. But maybe it's also due to reprojection.