### PR TITLE
Place 3D ribbon to right

### DIFF
--- a/src/components/controls3d/style/controls3d.less
+++ b/src/components/controls3d/style/controls3d.less
@@ -8,6 +8,7 @@
   margin-left: auto;
   margin-right: auto;
   width: 200px;
+  z-index: 600;
   @media (max-width: @screen-tablet) {
     bottom: 26px;
   }

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -140,10 +140,17 @@ itemscope itemtype="http://schema.org/WebApplication"
         IE9Fix.call(this);
       </script>
     <![endif]-->
-    <div ng-cloak
-         class="corner-ribbon top-left sticky red shadow" ng-show="globals.is3dActive">
+
+    <div ng-cloak class="corner-ribbon 
+% if device == 'mobile':
+    top-left    
+% else:
+    bottom-left
+% endif
+    sticky red shadow" ng-show="globals.is3dActive">
       3D - ALPHA
     </div>
+
     <div ng-controller="GaSeoController">
       <div ga-seo ga-seo-options="options" ga-seo-map="map"></div>
     </div>

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -1613,7 +1613,7 @@ body:not(.embed) {
   color: #f0f0f0;
   transform: rotate(-45deg);
   -webkit-transform: rotate(-45deg);
-  z-index: 10000;
+  z-index: 400;
 }
 
 /* Custom styles */
@@ -1629,10 +1629,15 @@ body:not(.embed) {
 /* Different positions */
 
 .corner-ribbon.top-left{
-  top: 25px;
+  top: 130px;
   left: -50px;
   transform: rotate(-45deg);
   -webkit-transform: rotate(-45deg);
+  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    top: 70px;
+  }
+
+
 }
 
 .corner-ribbon.top-right{
@@ -1645,8 +1650,9 @@ body:not(.embed) {
 
 .corner-ribbon.bottom-left{
   top: auto;
-  bottom: 25px;
-  left: -50px;
+  bottom: 50px;
+  left: -100px;
+  width: 300px;
   transform: rotate(45deg);
   -webkit-transform: rotate(45deg);
 }


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/2834

Places ribbon in upper right corner (hides language selection). On smaller screens, ribbon is horizontal so it doesn't fully hide important elements.

[Demo](https://mf-geoadmin3.dev.bgdi.ch/gjn_ribbon/index.html?dev3d=true&topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&lon=8.20649&lat=46.59585&elevation=59908&heading=7.144&pitch=-65.249&mobile=false)