### PR TITLE
Order correctly the extent generated from printRectangle coordinates

### DIFF
--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -61,6 +61,7 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions, $q) {
       }
     } catch (e) {
       alert(e.message);
+      window.console.error(e.stack);
       return;
     }
     var globe = cesiumViewer.getCesiumScene().globe;


### PR DESCRIPTION
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_2848?topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttps:%2F%2Fpublic.geo.admin.ch%2F_wE8svJLRfGUV18EynFxMw&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&X=187473.39&Y=539894.70&zoom=7)

Fix #2848 and #2698

Tested on mac pro with a pixel ratio > 1