### PR TITLE
Disable layer.json for image layers in 3D

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1170,10 +1170,12 @@ goog.require('ga_urlutils_service');
               tileWidth: params.tileSize,
               tileHeight: params.tileSize,
               hasAlphaChannel: (format == 'png'),
-              availableLevels: window.imageryAvailableLevels,
+              availableLevels: window.imageryAvailableLevels
               // Experimental
-              metadataUrl: '//terrain3.geo.admin.ch/1.0.0/' + bodId +
-                  '/default/20150101/4326/'
+              // Because of troubles in layer.json definitions, we remove this
+              // feature for now. We will re-activate after demo
+              //metadataUrl: '//terrain3.geo.admin.ch/1.0.0/' + bodId +
+              //    '/default/20150101/4326/'
             });
           }
           if (provider) {


### PR DESCRIPTION
This PR de-activates the usage of the layer.json definitions for the tile loading in 3D. We detected some troubles with the current defintions (see https://github.com/geoadmin/mf-geoadmin3/issues/2874) that lead to data not being visible.

Ping @loicgasser @oterral We'll re-activate it once code-freeze/branch for demo is done.