### PR TITLE
New timestamp for terrain tiles

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1030,7 +1030,7 @@ goog.require('ga_urlutils_service');
               response.data['ch.swisstopo.terrain.3d'] = {
                 type: 'terrain',
                 serverLayerName: 'ch.swisstopo.terrain.3d',
-                timestamps: ['20151231'],
+                timestamps: ['20160101'],
                 attribution: 'swisstopo 3D',
                 attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
                     'swisstopo/en/home/products/height/swissALTI3D.html'


### PR DESCRIPTION
Zoom level 8 - 11 have been generated with the new data including Switzerland surroundings.

We have no more artifacts (for these zoom levels), tiles are slightly smaller and it seems to fix:
https://github.com/geoadmin/mf-geoadmin3/issues/2872

We'll start the production of the mesh for the other LODs next week.


[Test Link](https://mf-chsdi3.dev.bgdi.ch/shorten/683233e408)


(We're still copying level 17, it should be over in a couple of hours)