### PR TITLE
Remove lazy loading after idle time

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -113,18 +113,8 @@ goog.require('ga_topic_service');
       $scope.map.on('change:target', function(event) {
         if (!!$scope.map.getTargetElement()) {
 
-          // Lazy load on idle (Desktop only)
-          if (!startWith3D &&
-              !gaBrowserSniffer.mobile && !gaBrowserSniffer.embed) {
-            var unregIdle = $scope.$on('gaIdle', function() {
-              cesium.enable(false);
-              unregIdle();
-            });
-          }
-
           $scope.$watch('globals.is3dActive', function(active) {
             if (active || $scope.ol3d) {
-              unregIdle && unregIdle() && (unregIdle = undefined);
               cesium.enable(active);
             }
           });


### PR DESCRIPTION
As discussed in yesterday's meeting, this PR removes the lazy loading of the cesium library after a given idle time. It saves data transfered (to all clients not using 3D) in exchange for longer 3D loading times.

On a 2G connection, initial 3D view is 15s slow (50s insead of 35s). On my home connection, I loose < 1s. I think that's reasonable.

Furthermore, lazy loading was disabled anyway for mobile devices :)