### PR TITLE
Define default properties for feature overlay layer

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1436,7 +1436,8 @@ goog.require('ga_urlutils_service');
    * Service provides map util functions.
    */
   module.provider('gaMapUtils', function() {
-    this.$get = function($window, gaGlobalOptions, gaUrlUtils, $q) {
+    this.$get = function($window, gaGlobalOptions, gaUrlUtils, $q,
+        gaDefinePropertiesForLayer) {
       var resolutions = gaGlobalOptions.resolutions;
       var isExtentEmpty = function(extent) {
         return extent[0] >= extent[2] || extent[1] >= extent[3];
@@ -1765,6 +1766,7 @@ goog.require('ga_urlutils_service');
             zIndex: this.Z_FEATURE_OVERLAY
           });
           layer.set('altitudeMode', 'clampToGround');
+          gaDefinePropertiesForLayer(layer);
           return layer;
         },
 


### PR DESCRIPTION
Fix #2919

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fix_print/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=200420.00&Y=597620.00&dev3d=true&zoom=5&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,)