### PR TITLE
Fix #2901: Slider is shown correctly after 3d switch

### DIFF
--- a/src/components/tilt3d/partials/tilt3d.html
+++ b/src/components/tilt3d/partials/tilt3d.html
@@ -1,1 +1,1 @@
-<button type="button" class="ga-tilt3d" ng-click="tilt()" ng-class="{'ga-disabled': disabled, 'ga-unsupported': !supported}"></button>
+<button type="button" class="ga-btn ga-tilt3d" ng-click="tilt()" ng-class="{'ga-disabled': disabled, 'ga-unsupported': !supported}"></button>

--- a/src/components/timeselector/TimeSelectorDirective.js
+++ b/src/components/timeselector/TimeSelectorDirective.js
@@ -130,6 +130,7 @@ goog.require('ga_time_service');
         templateUrl: 'components/timeselector/partials/timeselector.html',
         scope: {
           map: '=gaTimeSelectorMap',
+          ol3d: '=gaTimeSelectorOl3d',
           options: '=gaTimeSelectorOptions'
         },
         controller: 'GaTimeSelectorDirectiveController',
@@ -164,11 +165,19 @@ goog.require('ga_time_service');
             }
           });
 
+          // Watch if 3d is active
+          scope.$watch(function() {
+            return scope.ol3d && scope.ol3d.getEnabled();
+          }, function(active) {
+            scope.is3dActive = active;
+            elt.toggle(scope.isActive && !scope.is3dActive);
+          });
+
           // Activate/deactivate the component
           scope.$watch('isActive', function(active) {
             scope.years = active ? scope.options.years : [];
             applyNewYear((active ? scope.currentYear : undefined));
-            elt.toggle(active);
+            elt.toggle(active && !scope.is3dActive);
           });
 
           // currentYear is always an integer

--- a/src/components/timeselector/partials/timeselector.html
+++ b/src/components/timeselector/partials/timeselector.html
@@ -3,8 +3,8 @@
    ceiling="{{options.maxYear}}"
    ng-model="currentYear"
    ga-data="years"
-   ga-redraw="isActive"
-   ga-keyboard-events="isActive"
+   ga-redraw="isActive && !is3dActive"
+   ga-keyboard-events="isActive && !is3dActive"
    ga-magnetize="true"
    ga-input-text="true"
    ga-unfit-to-bar="true">

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -282,9 +282,10 @@ itemscope itemtype="http://schema.org/WebApplication"
 
 % if device != 'embed':
     <div ng-controller="GaTimeSelectorController">
-      <div ga-time-selector ga-time-selector-map="map"
-           ga-time-selector-options="options"
-           ng-show="!globals.is3dActive">
+      <div ga-time-selector
+           ga-time-selector-map="::map"
+           ga-time-selector-ol3d="::ol3d"
+           ga-time-selector-options="options">
       </div>
     </div>
 % endif


### PR DESCRIPTION
Fix #2901 

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fixslider/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=19451231,,,&lon=8.61888&lat=44.17042&elevation=206923&heading=360.000&pitch=-41.452)