### PR TITLE
Fix #2934: Remove preview layers from time management

### DIFF
--- a/src/components/catalogtree/CatalogitemDirective.js
+++ b/src/components/catalogtree/CatalogitemDirective.js
@@ -80,13 +80,9 @@ goog.require('ga_layer_metadata_popup_service');
               // Leaf
               } else if (!gaBrowserSniffer.mobile) {
                 iEl.on('mouseenter', function(evt) {
-                  scope.$applyAsync(function() {
-                    addPreviewLayer(scope.map, scope.item);
-                  });
+                  addPreviewLayer(scope.map, scope.item);
                 }).on('mouseleave', function(evt) {
-                  scope.$applyAsync(function() {
-                    removePreviewLayer(scope.map);
-                  });
+                  removePreviewLayer(scope.map);
                 });
               }
               compiledContent(scope, function(clone, scope) {

--- a/src/components/catalogtree/CatalogitemDirective.js
+++ b/src/components/catalogtree/CatalogitemDirective.js
@@ -80,9 +80,13 @@ goog.require('ga_layer_metadata_popup_service');
               // Leaf
               } else if (!gaBrowserSniffer.mobile) {
                 iEl.on('mouseenter', function(evt) {
-                  addPreviewLayer(scope.map, scope.item);
+                  scope.$applyAsync(function() {
+                    addPreviewLayer(scope.map, scope.item);
+                  });
                 }).on('mouseleave', function(evt) {
-                  removePreviewLayer(scope.map);
+                  scope.$applyAsync(function() {
+                    removePreviewLayer(scope.map);
+                  });
                 });
               }
               compiledContent(scope, function(clone, scope) {

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1388,17 +1388,16 @@ goog.require('ga_urlutils_service');
          * found.
          */
         this.getLayerTimestampFromYear = function(bodId, yearStr) {
+          if (angular.isNumber(yearStr)) {
+            yearStr = '' + yearStr;
+          }
           var layer = this.getLayer(bodId);
           var timestamps = layer.timestamps || [];
 
           if (!layer.timeEnabled) {
-            // a WMTS layer has at least one timestamp
+            // a WMTS/Terrain layer has at least one timestamp
             return (layer.type == 'wmts' || layer.type == 'terrain') ?
                 timestamps[0] : undefined;
-          } else if (layer.type == 'wms') {
-            // A time enabled WMS layer has no timestamps so we return the
-            // yearsStr unchanged
-            return yearStr;
           }
 
           if (!angular.isDefined(yearStr)) {
@@ -1817,7 +1816,8 @@ goog.require('ga_urlutils_service');
         timeEnabledLayersFilter: function(layer) {
           return !layer.background &&
                  layer.timeEnabled &&
-                 layer.visible;
+                 layer.visible &&
+                 !layer.preview;
         },
         /**
          * Keep layers with potential tooltip

--- a/src/components/timeselector/TimeService.js
+++ b/src/components/timeselector/TimeService.js
@@ -55,7 +55,7 @@ goog.require('ga_permalink_service');
       var Time = function() {
 
         // This property active the auto update status. The main goal of this
-        // property is to deactiviate the auto display of the timeslector, when
+        // property is to deactivate the auto display of the timeslector, when
         // layers from permalink are not yet loaded.
         this.allowStatusUpdate = false;
 
@@ -64,7 +64,7 @@ goog.require('ga_permalink_service');
           // Listen on layer's time property change
           map.getLayers().on('add', function(evt) {
             var olLayer = evt.element;
-            if (olLayer.timeEnabled) {
+            if (!olLayer.preview && olLayer.timeEnabled) {
               ol.Observable.unByKey(propDeregKey[olLayer.id]);
               that.updateStatus(evt.target);
               propDeregKey[olLayer.id] = olLayer.on('propertychange',
@@ -80,7 +80,7 @@ goog.require('ga_permalink_service');
           map.getLayers().on('remove', function(evt) {
             var olLayer = evt.element;
             ol.Observable.unByKey(propDeregKey[olLayer.id]);
-            if (olLayer.timeEnabled) {
+            if (!olLayer.preview && olLayer.timeEnabled) {
               that.updateStatus(evt.target);
             }
           });

--- a/src/components/timeselector/partials/timeselector-bt.html
+++ b/src/components/timeselector/partials/timeselector-bt.html
@@ -3,7 +3,5 @@
         ng-class="{
           'ga-time-selector-enabled': !isDisable,
           'ga-time-selector-active': isActive
-        }"
-        ng-mouseenter="onMouseEnter()"
-        ng-mouseleave="onMouseLeave()">
+        }">
 </button>


### PR DESCRIPTION
Fix #2934 
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_2934/?topic=luftbilder&lang=fr&bgLayer=ch.swisstopo.pixelkarte-grau&layers=ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.pixelkarte-farbe-pk1000.noscale,ch.swisstopo.zeitreihen,ch.swisstopo.lubis-luftbilder-dritte-firmen,ch.swisstopo.lubis-luftbilder_infrarot&layers_visibility=false,false,false,false,false,true,true&X=204700.00&Y=745050.00&zoom=0&layers_timestamp=,,,,18641231,20011231,20081231&catalogNodes=1179,1180,1186)