### PR TITLE
Defined lods for each resolutions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ DEFAULT_EXTENT ?= '[420000, 30000, 900000, 350000]'
 DEFAULT_RESOLUTION ?= 500.0
 DEFAULT_LEVEL_OF_DETAIL ?= 7 #level of detail for the default resolution
 RESOLUTIONS ?= '[650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0, 2.5, 2.0, 1.0, 0.5, 0.25, 0.1]'
+LEVEL_OF_DETAILS ?= '[6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 16, 17, 18, 18]' #lods corresponding to resolutions
 DEFAULT_EPSG ?= EPSG:21781
 DEFAULT_EPSG_EXTEND ?= '[420000, 30000, 900000, 350000]'
 DEFAULT_ELEVATION_MODEL ?= COMB
@@ -323,6 +324,7 @@ define buildpage
 		--var "default_resolution"="$(DEFAULT_RESOLUTION)" \
 		--var "default_level_of_detail"="$(DEFAULT_LEVEL_OF_DETAIL)" \
 		--var "resolutions"="$(RESOLUTIONS)" \
+		--var "level_of_details"="$(LEVEL_OF_DETAILS)" \
 		--var "public_url=$(PUBLIC_URL)" \
 		--var "default_elevation_model=${DEFAULT_ELEVATION_MODEL}" \
 		--var "default_terrain=$(DEFAULT_TERRAIN)" \

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1440,6 +1440,7 @@ goog.require('ga_urlutils_service');
     this.$get = function($window, gaGlobalOptions, gaUrlUtils, $q,
         gaDefinePropertiesForLayer) {
       var resolutions = gaGlobalOptions.resolutions;
+      var lodsForRes = gaGlobalOptions.lods;
       var isExtentEmpty = function(extent) {
         return extent[0] >= extent[2] || extent[1] >= extent[3];
       };
@@ -1778,7 +1779,7 @@ goog.require('ga_urlutils_service');
           }
           var idx = resolutions.indexOf(res);
           if (idx != -1) {
-            return lodForDfltRes + (idx - dfltResIdx);
+            return lodsForRes[idx];
           }
           // TODO: Implement the calculation of the closest level of detail
           // available if res is not in the resolutions array

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -738,6 +738,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           defaultResolution: ${default_resolution},
           defaultLod: ${default_level_of_detail},
           resolutions: JSON.parse(${resolutions}),
+          lods: JSON.parse(${level_of_details}),
           defaultEpsg: '${default_epsg}',
           defaultEpsgExtent: JSON.parse(${default_epsg_extend}),
           defaultElevationModel: '${default_elevation_model}',


### PR DESCRIPTION
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_lods/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.swisstopo.geologie-geocover&layers_opacity=1,0.6&time=1978&layers_timestamp=19781231,&lon=8.02596&lat=47.01674&elevation=1534&heading=0.001&pitch=-40.007)

Fix #2937