### PR TITLE
Optimize default values

### DIFF
--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -71,8 +71,8 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions,
     var fogEnabled = boolParam('fogEnabled', true);
     var fogDensity = floatParam('fogDensity', '0.0001');
     var fogSseFactor = floatParam('fogSseFactor', '25');
-    var terrainLevels = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17];
-    window.minimumRetrievingLevel = intParam('minimumRetrievingLevel', '5');
+    var terrainLevels = [8, 11, 14, 16, 17];
+    window.minimumRetrievingLevel = intParam('minimumRetrievingLevel', '8');
     window.terrainAvailableLevels = arrayParam('terrainLevels', terrainLevels);
     window.imageryAvailableLevels = arrayParam('imageryLevels', undefined);
 

--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -248,7 +248,8 @@ var SSECorrector = function(gaPermalink) {
 SSECorrector.prototype.newFrameState = function(frameState) {
     this.cameraHeight = frameState.camera.positionCartographic.height;
 
-    if (this.pickglobe && !this.noheight && this.maxheight) {
+    if (this.pickglobe && !this.noheight &&
+        (!this.maxHeight || this.cameraHeight < this.maxheight)) {
       var scene = frameState.camera._scene;
       var canvas = scene.canvas;
       var pixelHeight = this.pickposition * canvas.clientHeight;


### PR DESCRIPTION
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_optim/?dev3d=true&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swissimage-product&lon=7.90019&lat=46.52498&elevation=1837&heading=7.147&pitch=-16.178)
Based on #https://github.com/geoadmin/mf-geoadmin3/pull/2873

Fog default value        
terrainLevels = 8,11,14,16,17
metadata 3d activated 
minimumRetrievingLevel=8(no effect)

Activation of custom SSE doesn't make a difference with the fog and I think we loose too much quality when we change parameters (dist, pickglobe).