### PR TITLE
Update terrain tiles for levels 12 to 14

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1045,7 +1045,7 @@ goog.require('ga_urlutils_service');
               response.data['ch.swisstopo.terrain.3d'] = {
                 type: 'terrain',
                 serverLayerName: 'ch.swisstopo.terrain.3d',
-                timestamps: ['20160101'],
+                timestamps: ['20151231'],
                 attribution: 'swisstopo 3D',
                 attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
                     'swisstopo/en/home/products/height/swissALTI3D.html'


### PR DESCRIPTION
[Test Link](https://mf-geoadmin3.dev.bgdi.ch/gal_20151231/?dev3d=true&topic=ech&lang=en&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false&lon=7.32146&lat=45.96975&elevation=21755&heading=359.979&pitch=-40.154)

Quality is better but not optimal. Topo is having a hard time...