### PR TITLE
Use a space to avoid having default label in zoom buttons

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -39,10 +39,10 @@ goog.require('ga_topic_service');
           rotate: false,
           zoomOptions: {
             target: toolbar,
-            zoomInLabel: '',
-            zoomOutLabel: '',
-            zoomInTipLabel: '',
-            zoomOutTipLabel: ''
+            zoomInLabel: ' ',
+            zoomOutLabel: ' ',
+            zoomInTipLabel: ' ',
+            zoomOutTipLabel: ' '
           }
         }),
         interactions: ol.interaction.defaults({


### PR DESCRIPTION
Regression since the update of ol.