### PR TITLE
Prevent users to augment the size of the texteara for feedback

### DIFF
--- a/src/components/feedback/style/feedback.less
+++ b/src/components/feedback/style/feedback.less
@@ -15,6 +15,10 @@
   .progress {
     margin-top: 8px;
   }
+  textarea {
+    max-width: 320px;
+    max-height: 75px;
+  }
   [ga-draw] {
     width: 100%;
 


### PR DESCRIPTION
Users shouldn't be able to make a textarea so big, the 'Send' button is
not accessible any more.