### PR TITLE
Fix standalone WMS and KML examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ This can be fixed by running:
     sudo ln -s /usr/bin/nodejs /usr/bin/node 
     #see https://github.com/joyent/node/issues/3911
 
-### Update to the last OpenLayers Version
+### Update to the last OpenLayers/Cesium/OL3-Cesium Version
 
-Use `make ol` to update the `ol.js` and `ol-debug.js` files.
+Use `make ol3cesium` to update the `ol3cesium.js` and `ol3cesium-debug.js` files.
 
 Add the correct version tag
 
@@ -73,7 +73,9 @@ https://github.com/geoadmin/mf-geoadmin3/blob/master/Makefile#20
 
 You can also use an argument to test a new version of ol3, for instance you can do:
 
-    make OL3_VERSION="632205d902f8dcc1f03eb1dd1736d26a1b3ac2a3" ol
+    make OL3_VERSION=627abaf1a71d48627163eb00ea6a0b6fb8dede14 \
+    OL3_CESIUM_VERSION=10c5fcf1565ffdb484c4ef4e42835142f8f45e67 \
+    CESIUM_VERSION=3e3cf938786ee48b4b376ed932904541d798671d ol3cesium
 
 Remember to update the API and API doc at the same time to keep coherency.
 

--- a/src/components/catalogtree/example/index.html
+++ b/src/components/catalogtree/example/index.html
@@ -83,7 +83,7 @@
     <script>
       window.CLOSURE_NO_DEPS = true;
     </script>
-    <script src="lib/ol-debug.js"></script>
+    <script src="lib/ol3cesium-debug.js"></script>
     <script src="deps.js"></script>
     <script>
       goog.require('ga_catalogtree');

--- a/src/components/featuretree/example/index.html
+++ b/src/components/featuretree/example/index.html
@@ -103,7 +103,7 @@
     <script>
       window.CLOSURE_NO_DEPS = true;
     </script>
-    <script src="lib/ol-debug.js"></script>
+    <script src="lib/ol3cesium-debug.js"></script>
     <script src="deps.js"></script>
     <script>
       goog.require('ga_popup');

--- a/src/components/importkml/example/index.html
+++ b/src/components/importkml/example/index.html
@@ -39,7 +39,8 @@
       #map {
         width: 600px;
         height: 400px;
-        top: 150px; 
+        top: 0px;
+        margin: 10px
       }
 
       #import-kml {
@@ -68,19 +69,29 @@
     <script>
       window.CLOSURE_NO_DEPS = true;
     </script>
-    <script src="lib/ol-debug.js"></script>
+    <script src="lib/ol3cesium-debug.js"></script>
     <script src="deps.js"></script>
     <script>
       goog.require('ga_importkml');
       goog.require('ga_map');
+      goog.require('ga_translation_service');
 
       (function() {
         var module = angular.module('ga_importkml_example', [
           'ga_importkml',
-          'ga_map'
+          'ga_map',
+          'ga_translation_service'
         ]);
 
         module.constant('gaGlobalOptions', {
+          adminUrlRegexp: /^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)/,
+          publicUrlRegexp: /^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*/,
+          defaultEpsg: 'EPSG:21781',
+          defaultExtent: [420000, 30000, 900000, 350000],
+          resourceUrl: 'https://mf-chsdi3.dev.bgdi.ch',
+          languages: ["de", "en", "fr", "it", "rm"],
+          resolutions: [650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0,
+              2.5, 2.0, 1.0, 0.5, 0.25, 0.1],
           serviceUrl : 'https://mf-chsdi3.dev.bgdi.ch'
         });
 
@@ -94,23 +105,25 @@
               '?lang={Lang}';
         }]);
 
+        module.config(function(gaTopicProvider, gaGlobalOptions) {
+          gaTopicProvider.topicsUrl = gaGlobalOptions.resourceUrl + 'services';
+        });
 
         module.controller('MainController', 
-          ['$scope', 'gaLayers', 
-          function($scope, gaLayers) {
+          ['$scope', 'gaLayers', 'gaGlobalOptions',
+          function($scope, gaLayers, gaGlobalOptions) {
 
             var defaultExtent = [485869.5728, 76443.1884, 837076.5648, 299941.7864];
             var swissProjection = ol.proj.get('EPSG:21781');
             swissProjection.setExtent(defaultExtent);
 
-            var resolutions = [650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0, 2.5,
-              2.0, 1.0, 0.5, 0.25, 0.1];
+            var resolutions = gaGlobalOptions.resolutions;
 
             var map = new ol.Map({
               controls: ol.control.defaults({
                 attribution: false
               }),
-              renderer: ol.RendererHint.CANVAS,
+              renderer: 'canvas',
               view: new ol.View({
                 projection: swissProjection,
                 center: ol.extent.getCenter(defaultExtent),
@@ -120,7 +133,7 @@
             });
 
             $scope.map = map;
-            gaLayers.loadForTopic('inspire', 'en').then(function() {
+            gaLayers.loadConfig().then(function() {
               map.addLayer(gaLayers.getOlLayerById('ch.swisstopo.swissimage'));
             });
         }]);

--- a/src/components/importwms/example/index.html
+++ b/src/components/importwms/example/index.html
@@ -40,7 +40,7 @@
       #map {
         width: 720px;
         height: 400px;
-        top: 360px;
+        top: 0px;
         margin: 10px;
       }
       
@@ -71,19 +71,29 @@
     <script>
       window.CLOSURE_NO_DEPS = true;
     </script>
-    <script src="lib/ol-debug.js"></script>
+    <script src="lib/ol3cesium-debug.js"></script>
     <script src="deps.js"></script>
     <script>
       goog.require('ga_importwms');
       goog.require('ga_map');
+      goog.require('ga_translation_service');
 
       (function() {
         var module = angular.module('ga_importwms_example', [
           'ga_importwms',
-          'ga_map'
+          'ga_map',
+          'ga_translation_service'
         ]);
 
         module.constant('gaGlobalOptions', {
+          adminUrlRegexp: /^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)/,
+          publicUrlRegexp: /^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*/,
+          defaultEpsg: 'EPSG:21781',
+          defaultExtent: [420000, 30000, 900000, 350000],
+          resourceUrl: 'https://mf-chsdi3.dev.bgdi.ch',
+          languages: ["de", "en", "fr", "it", "rm"],
+          resolutions: [650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0,
+              2.5, 2.0, 1.0, 0.5, 0.25, 0.1],
           serviceUrl: 'https://mf-chsdi3.dev.bgdi.ch'
         });
         
@@ -97,21 +107,24 @@
               '?lang={Lang}';
         }]);
 
-        module.controller('MainController', ['$scope',
-            'gaLayers', function($scope, gaLayers) {
+        module.config(function(gaTopicProvider, gaGlobalOptions) {
+          gaTopicProvider.topicsUrl = gaGlobalOptions.resourceUrl + 'services';
+        });
+
+        module.controller('MainController', ['$scope', 'gaLayers',
+            'gaGlobalOptions', function($scope, gaLayers, gaGlobalOptions) {
 
           var defaultExtent = [485869.5728, 76443.1884, 837076.5648, 299941.7864];
           var swissProjection = ol.proj.get('EPSG:21781');
           swissProjection.setExtent(defaultExtent);
 
-          var resolutions = [650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0, 2.5,
-            2.0, 1.0, 0.5, 0.25, 0.1];
+          var resolutions = gaGlobalOptions.resolutions;
 
           var map = new ol.Map({
             controls: ol.control.defaults({
               attribution: false
             }),
-            renderer: ol.RendererHint.CANVAS,
+            renderer: 'canvas',
             view: new ol.View({
               projection: swissProjection,
               center: ol.extent.getCenter(defaultExtent),
@@ -121,7 +134,7 @@
           });
 
           $scope.map = map;
-          gaLayers.loadForTopic('inspire', 'en').then(function() {
+          gaLayers.loadConfig().then(function() {
             map.addLayer(gaLayers.getOlLayerById('ch.swisstopo.swissimage'));
           });
         }]);
@@ -136,7 +149,7 @@
                  'https://wms.geo.admin.ch/',
                  'http://ogc.heig-vd.ch/mapserver/wms?',
                  'http://www.wms.stadt-zuerich.ch/WMS-ZH-STZH-OGD/MapServer/WMSServer?',
-                 'http://wms.geo.gl.ch/?',
+                 'http://wms.geo.gl.ch/',
                  'http://mapserver1.gr.ch/wms/admineinteilung?',
                  'http://mapserver1.gr.ch/wms/belastetestandorte?',
                  'http://mapserver1.gr.ch/wms/beweidbareflaechen?',

--- a/src/components/map/example/index.html
+++ b/src/components/map/example/index.html
@@ -65,7 +65,7 @@
     <script>
       window.CLOSURE_NO_DEPS = true;
     </script>
-    <script src="lib/ol-debug.js"></script>
+    <script src="lib/ol3cesium-debug.js"></script>
     <script src="deps.js"></script>
     <script>
       goog.require('ga_map');

--- a/src/components/profile/example/index.html
+++ b/src/components/profile/example/index.html
@@ -77,7 +77,7 @@
     <script>
       window.CLOSURE_NO_DEPS = true;
     </script>
-    <script src="lib/ol-debug.js"></script>
+    <script src="lib/ol3cesium-debug.js"></script>
     <script src="deps.js"></script>
     <script>
       goog.require('ga_popup');

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -691,7 +691,7 @@ itemscope itemtype="http://schema.org/WebApplication"
       window.CLOSURE_NO_DEPS = true;
     </script>
 
-    <!-- ol-debug.js includes Closure's base.js code, so we don't
+    <!-- ol3cesium-debug.js includes Closure's base.js code, so we don't
          need to load base.js ourselves. We keep Closure's base.js file
          around in case we need to test with ol.js or ol-simple.js. -->
     <!--<script src="lib/closure/base.js"></script>-->


### PR DESCRIPTION
I am trying to run the [importkml](https://mf-geoadmin3.dev.bgdi.ch/gberaudo/src/components/importkml/example/) and [importwmts](https://mf-geoadmin3.dev.bgdi.ch/gberaudo/src/components/importwms/example/) examples but it doesn't work.

Links:
- https://mf-geoadmin3.dev.bgdi.ch/gberaudo_fix_examples/src/components/importwms/example/index.html?lang=en
- https://mf-geoadmin3.dev.bgdi.ch/gberaudo_fix_examples/src/components/importkml/example/index.html?lang=en