### PR TITLE
Fix KML loading

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -752,7 +752,10 @@ goog.require('ga_urlutils_service');
               }
 
               if (options.zoomToExtent) {
-                olMap.getView().fit(olLayer.getExtent(), olMap.getSize());
+                var extent = olLayer.getExtent();
+                if (extent) {
+                  olMap.getView().fit(extent, olMap.getSize());
+                }
               }
             }
           });


### PR DESCRIPTION
Test link: https://mf-geoadmin3.dev.bgdi.ch/gberaudo_fix_examples/

AssertionError: Assertion failed: invalid extent or geometry
    at new goog.asserts.AssertionError (https://map.geo.admin.ch/src/lib/ol3cesium-debug.js:6582:20)
    at Object.goog.asserts.doAssertFailure_ (https://map.geo.admin.ch/src/lib/ol3cesium-debug.js:6639:11)
    at Object.goog.asserts.assert [as assert] (https://map.geo.admin.ch/src/lib/ol3cesium-debug.js:6669:18)
    at ol.View.fit (https://map.geo.admin.ch/src/lib/ol3cesium-debug.js:24859:18)
    at https://map.geo.admin.ch/src/components/map/MapService.js:755:33
    at processQueue (https://map.geo.admin.ch/src/lib/angular.js:14569:28)
    at https://map.geo.admin.ch/src/lib/angular.js:14585:27
    at Scope.$eval (https://map.geo.admin.ch/src/lib/angular.js:15848:28)
    at Scope.$digest (https://map.geo.admin.ch/src/lib/angular.js:15659:31)
    at Scope.$apply (https://map.geo.admin.ch/src/lib/angular.js:15953:24)