### PR TITLE
Increase left-click pixel tolerance (tooltip request)

### DIFF
--- a/src/js/TooltipController.js
+++ b/src/js/TooltipController.js
@@ -6,7 +6,7 @@ goog.provide('ga_tooltip_controller');
   module.controller('GaTooltipController', function($scope, gaGlobalOptions,
       gaBrowserSniffer) {
     $scope.options = {
-      tolerance: gaBrowserSniffer.touchDevice ? 15 : 5,
+      tolerance: gaBrowserSniffer.touchDevice ? 20 : 10,
       identifyUrlTemplate: gaGlobalOptions.apiUrl +
           '/rest/services/{Topic}/MapServer/identify',
       htmlUrlTemplate: gaGlobalOptions.cachedApiUrl +


### PR DESCRIPTION
Based on the discussions and tests in https://github.com/geoadmin/mf-geoadmin3/issues/2942, we do this quick adaption.

We increase the click tolerance from 5px to 10px (15 to 20 on mobile) to increase likelyhood of positive result. This is not the final solution.

@davidoesch Ok?

Vector tiles to the rescue!