### PR TITLE
Use new downgraded servers on prod

### DIFF
--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -24,8 +24,8 @@ int = ip-10-220-6-222.eu-west-1.compute.internal,
       ip-10-220-5-202.eu-west-1.compute.internal
 
 # mf0p
-prod = ip-10-220-4-152.eu-west-1.compute.internal,
-       ip-10-220-5-219.eu-west-1.compute.internal   
+prod = ip-10-220-5-117.eu-west-1.compute.internal,
+       ip-10-220-6-44.eu-west-1.compute.internal
 
 # mf0demo vectortiling feb 2015
 demo = ip-10-220-5-174.eu-west-1.compute.internal


### PR DESCRIPTION
We've downgraded the prod instances from c3.xlarge to m1.medium.

This PR uses the new instances for the deployment.