### PR TITLE
Fix #3053: Add 3d overlay warning in embed page

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -243,17 +243,16 @@ itemscope itemtype="http://schema.org/WebApplication"
 % endif
 
     <div ga-controls3d ga-controls3d-ol3d="::ol3d" ng-if="ol3d" ng-show="globals.is3dActive" ga-controls3d-pegman="globals.pegman"></div>
-
+    <div ga-attribution-warning
+         ga-attribution-warning-ol3d="::ol3d">
+      <span translate>3d_overlay_warning</span>
+    </div>
 % if device != 'embed':
     <div ng-cloak translate-cloak
          ga-background-selector
          ga-background-selector-map="map"
          ga-background-selector-ol3d="::ol3d"
          ng-hide="globals.offline">
-    </div>
-    <div ga-attribution-warning
-         ga-attribution-warning-ol3d="::ol3d">
-      <span translate>3d_overlay_warning</span>
     </div>
     <div ng-cloak translate-cloak id="footer" class="navbar navbar-fixed-bottom">
       <div  class="pull-left" ga-scale-line ga-scale-line-map="map" ng-show="!globals.is3dActive"></div>


### PR DESCRIPTION
Fix #3053. [Test](https://mf-geoadmin3.dev.bgdi.ch/fix_3053/index.html?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swissimage-product,ch.bafu.permafrost&layers_opacity=1,0.55&lon=7.59658&lat=46.12999&elevation=4110&heading=195.012&pitch=-15.420)