### PR TITLE
Use new PL topic configuration parameter

### DIFF
--- a/rc_branch.mako
+++ b/rc_branch.mako
@@ -1,3 +1,3 @@
 export APACHE_BASE_PATH=/${apache_base_path}
-export API_URL=//mf-chsdi3.${deploy_target}.bgdi.ch
+export API_URL=//mf-chsdi3.${deploy_target}.bgdi.ch/gjn_topicspl
 export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/${apache_base_path}

--- a/src/components/backgroundselector/BackgroundService.js
+++ b/src/components/backgroundselector/BackgroundService.js
@@ -14,7 +14,8 @@ goog.require('ga_permalink');
    * Backgrounds manager
    */
   module.provider('gaBackground', function() {
-    this.$get = function($rootScope, $q, gaTopic, gaLayers, gaPermalink) {
+    this.$get = function($rootScope, $q, gaTopic, gaLayers, gaPermalink,
+        gaUrlUtils) {
       var isOfflineToOnline = false;
       var bg; // The current background
       var bgs = []; // The list of backgrounds available
@@ -45,7 +46,12 @@ goog.require('ga_permalink');
       };
 
       var getBgByTopic = function(topic) {
-        var topicBg = getBgById(topic.defaultBackground) || bgs[0];
+        var topicBg = null;
+        if (topic.plConfig) {
+          var p = gaUrlUtils.parseKeyValue(topic.plConfig);
+          topicBg = getBgById(p.bgLayer);
+        }
+        topicBg = topicBg || getBgById(topic.defaultBackground) || bgs[0];
         if (topicBg && !isOfflineToOnline) {
            return topicBg;
         }

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -2073,10 +2073,25 @@ goog.require('ga_urlutils_service');
         var mustReorder = false;
 
         var addTopicSelectedLayers = function() {
-          addLayers(gaTopic.get().selectedLayers.slice(0).reverse());
-          var activatedLayers = gaTopic.get().activatedLayers;
-          if (activatedLayers.length) {
-            addLayers(activatedLayers.slice(0).reverse(), null, false);
+          // if plConf is active, we get layers from there. This
+          // might include opacity and visibility
+          var topic = gaTopic.get();
+          if (topic.plConfig) {
+            var p = gaUrlUtils.parseKeyValue(topic.plConfig);
+            addLayers(p.layers ? p.layers.split(',') : [],
+                      p.layers_opacity ?
+                          p.layers_opacity.split(',') : undefined,
+                      p.layers_visibility ?
+                          p.layers_visibility.split(',') : false,
+                      p.layers_timestamp ?
+                          p.layers_timestamp.split(',') : undefined
+            );
+          } else {
+            addLayers(topic.selectedLayers.slice(0).reverse());
+            var activatedLayers = topic.activatedLayers;
+            if (activatedLayers.length) {
+              addLayers(activatedLayers.slice(0).reverse(), null, false);
+            }
           }
         };
 

--- a/src/components/topic/TopicService.js
+++ b/src/components/topic/TopicService.js
@@ -26,6 +26,9 @@ goog.require('ga_permalink');
             if (!value.activatedLayers) {
               value.activatedLayers = [];
             }
+            if (!value.plConfig || !value.plConfig.length) {
+              value.plConfig = false;
+            }
           });
           topic = getTopicById(gaPermalink.getParams().topic, true);
           if (topic) {


### PR DESCRIPTION
This is to fix https://github.com/geoadmin/mf-geoadmin3/issues/3031

Topic initical configuration can now be specified with a permalink parameter that contains 'bgLayer', 'layers', 'layers_opacity', 'layers_visibility' and 'layers_timestamps' from the bod.

Note that all other plConfig values that might exist are simply ignored. If we want to extent it, we have to adapt front-end code.

[Testlink for Schneesport](https://mf-geoadmin3.dev.bgdi.ch/gjn_topicpl/?topic=schneesport)