### PR TITLE
Set text overflow for share embed button

### DIFF
--- a/src/components/share/ShareDirective.js
+++ b/src/components/share/ShareDirective.js
@@ -16,7 +16,7 @@ goog.require('ga_permalink');
       link: function(scope, element, attrs) {
         if (!gaBrowserSniffer.mobile) {
           element.attr('readonly', 'readonly').tooltip({
-            placement: attrs.placement || 'bottom',
+            placement: attrs.gaTooltipPlacement || 'bottom',
             trigger: 'focus',
             title: function() {
               return $translate.instant('share_link_tooltip');

--- a/src/components/share/style/share.less
+++ b/src/components/share/style/share.less
@@ -52,6 +52,11 @@
   .ga-share-embed {
     margin-top: 8px;
 
+    button {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     @media (max-width: @screen-tablet) {
       .input-group {
         width: 100%;

--- a/src/components/share/style/share.less
+++ b/src/components/share/style/share.less
@@ -1,5 +1,13 @@
 [ga-share] {
 
+  .tooltip.bottom {
+    margin-top: -3px;
+  }
+
+  .tooltip-inner {
+    max-width: 240px;
+  }
+
   .input-group {
     width: 100%;
 

--- a/src/components/swipe/partials/swipe.html
+++ b/src/components/swipe/partials/swipe.html
@@ -5,7 +5,7 @@
     {{layer.label}}
   </div>
   <div class="ga-swipe-arrows">
-    <i class="fa fa-caret-right"></i>
-    <i class="fa fa-caret-right"></i>
+    <div class="ga-arrow-left"></div>
+    <div class="ga-arrow-right"></div>
   </div>
 </div>

--- a/src/components/swipe/style/swipe.less
+++ b/src/components/swipe/style/swipe.less
@@ -30,15 +30,23 @@
     left: 0px;
     top: 50%;
     margin-top: -16px;
+    padding: 5px 4px;
     background-color: red;
-    padding: 5px 2px;
-    color: white;
 
-    i {
-      float: left;
-      line-height: 22px;
-      margin: 0px 0px;
-      padding-top: 2px;
+    div {
+      display: inline-block;
+      width: 0; 
+      height: 0; 
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent;
+    }
+
+    .ga-arrow-right{
+      border-left: 10px solid white;
+    }
+
+    .ga-arrow-left {
+      border-right: 10px solid white;
     }
   }
 


### PR DESCRIPTION
Fix #3025, #3066, #3024 

[Test](https://mf-geoadmin3.dev.bgdi.ch/fix_3025/?lang=it&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&dev3d=true&zoom=1&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=true,false,false,false&layers_timestamp=20131231,,,&time=2013)