### PR TITLE
Remove version parameter to get fa in appcache

### DIFF
--- a/src/geoadmin.mako.appcache
+++ b/src/geoadmin.mako.appcache
@@ -10,7 +10,7 @@
 CACHE:
 ${version}/lib/build.js	
 ${version}/style/app.css
-${version}/style/font-awesome-4.5.0/font/fontawesome-webfont.woff?v=4.5.0
+${version}/style/font-awesome-4.5.0/font/fontawesome-webfont.woff
 ${version}/services
 % for lang in languages:
 ${version}/layersConfig?lang=${lang}


### PR DESCRIPTION
Fix the loading of font from appcache on Safari.