### PR TITLE
Hide menu when rubber band effect occurs

### DIFF
--- a/src/components/importwms/style/importwms.less
+++ b/src/components/importwms/style/importwms.less
@@ -55,6 +55,7 @@
   }
 
   .modal-backdrop {
+    position: absolute;
     height: 100%;
 
     .progress {

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -225,6 +225,10 @@ button.ga-btn, .ol-control button {
       opacity: 1;
     }
   }
+
+  &.webkit {
+    position: absolute; // iOS: Hide the menu so we can't see it when the rubberband effect happens
+  }
 }
 
 .ga-truncate-text {


### PR DESCRIPTION
To test with iOS Safari, try to scroll the header. You shouldn't see the closed menu anymore.
 
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_rubber)