### PR TITLE
Rename appcache file to get rid of old trailing appcache files

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -4,6 +4,8 @@
 itemscope itemtype="http://schema.org/WebApplication"
 % if device == 'mobile' and mode=='prod' :
  manifest="geoadmin.appcache"
+% else:
+ manifest="we.do.not.cache.this"
 % endif
 >
   <head>


### PR DESCRIPTION
I think alot of our problems that are similar to https://github.com/geoadmin/mf-geoadmin3/issues/3084 is related to old trailing appcache files, especially on desktop version, where they were active initially but then were removed.

According [this article](http://stackoverflow.com/questions/8815280/removing-html5-appcache-manifest-permanently), simply pointing the appcache to something non-existant should be good. So that's what I'll do here for desktop/embed with this PR.

@oterral Maybe we can try to mergency deploy this.