### PR TITLE
Feedback with cache version number

### DIFF
--- a/src/components/feedback/FeedbackDirective.js
+++ b/src/components/feedback/FeedbackDirective.js
@@ -20,7 +20,8 @@ goog.require('ga_permalink');
    * "response" scope property to "success" or "error".
    */
   module.directive('gaFeedback',
-      function($http, $translate, gaPermalink, gaBrowserSniffer, gaExportKml) {
+      function($http, $translate, gaPermalink, gaBrowserSniffer, gaExportKml,
+               gaGlobalOptions) {
           return {
             restrict: 'A',
             replace: true,
@@ -55,10 +56,14 @@ goog.require('ga_permalink');
                                            scope.map.getView().getProjection());
                 }
                 // Not supported by IE9
+                var feedbackMessage = scope.feedback;
+                feedbackMessage += '\n\n\n---------------------------------\n';
+                feedbackMessage += 'Message created with version: ';
+                feedbackMessage += gaGlobalOptions.version;
                 if (!scope.isIE || gaBrowserSniffer.msie > 9) {
                     formData = new FormData();
                     formData.append('email', scope.email);
-                    formData.append('feedback', scope.feedback);
+                    formData.append('feedback', feedbackMessage);
                     formData.append('ua', navigator.userAgent);
                     formData.append('permalink', scope.permalinkValue);
                     formData.append('attachement', scope.file || '');
@@ -67,7 +72,7 @@ goog.require('ga_permalink');
                 } else {
                     formData = {
                       email: scope.email,
-                      feedback: scope.feedback,
+                      feedback: feedbackMessage,
                       ua: navigator.userAgent,
                       permalink: scope.permalinkValue,
                       attachement: '',

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -727,6 +727,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           //dev3d to be removed once 3d goes live
           dev3d: true,
           buildMode: '${mode}',
+          version: '${version}',
           pegman: !!window.location.search.match(/(pegman=true)/),
           mapUrl : location.origin + '${apache_base_path}',
           apiUrl : location.protocol + '${api_url}',


### PR DESCRIPTION
This PR addes the cache version number to the feedback message.

With this, we can determine if the feedback is coming from a cached, old page or with the latest one.

@oterral Might be helpful.