### PR TITLE
Remove pixel detection for tooltip on iOS

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -66,8 +66,8 @@ goog.require('ga_topic_service');
         var getLayersToQueryAtPixel = function(map, pixel, is3dActive) {
           var bodIds = [];
           var layersToQuery = [];
-          if (!is3dActive && (!gaBrowserSniffer.msie ||
-              gaBrowserSniffer.msie > 10)) {
+          if (!is3dActive && !gaBrowserSniffer.ios &&
+              (!gaBrowserSniffer.msie || gaBrowserSniffer.msie > 10)) {
             // Works only on sublayers
             map.forEachLayerAtPixel(pixel,
               function(l) {


### PR DESCRIPTION
Fix tooltip on iOS both mobile and desktop version

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_tool/)