### PR TITLE
New terrain timestamp

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -984,7 +984,7 @@ goog.require('ga_urlutils_service');
               response.data['ch.swisstopo.terrain.3d'] = {
                 type: 'terrain',
                 serverLayerName: 'ch.swisstopo.terrain.3d',
-                timestamps: ['20151231'],
+                timestamps: ['20160115'],
                 attribution: 'swisstopo',
                 attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
                     'swisstopo/' + lang + '/home.html'


### PR DESCRIPTION
Terrain without altimetric corrections.

[Test Link](https://mf-geoadmin3.dev.bgdi.ch/gal_new_terrain/)