### PR TITLE
Allow to change mapproxy tiles url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,8 +314,7 @@ prd/geoadmin.appcache: src/geoadmin.mako.appcache \
 	    --var "public_url=$(PUBLIC_URL)" $< > $@
 
 prd/cache/: .build-artefacts/last-version \
-			.build-artefacts/last-api-url \
-			.build-artefacts/last-mapproxy-url
+			.build-artefacts/last-api-url
 	mkdir -p $@
 	curl -q -o prd/cache/services http:$(API_URL)/rest/services
 	$(foreach lang, $(LANGS), curl -s --retry 3 -o prd/cache/layersConfig.$(lang) http:$(API_URL)/rest/services/all/MapServer/layersConfig?lang=$(lang);)
@@ -436,7 +435,6 @@ src/TemplateCacheModule.js: src/TemplateCacheModule.mako.js \
 apache/app.conf: apache/app.mako-dot-conf \
 	    ${MAKO_CMD} \
 	    .build-artefacts/last-api-url \
-	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-apache-base-directory \
 	    .build-artefacts/last-version

--- a/rc_dev
+++ b/rc_dev
@@ -1,6 +1,7 @@
 export KEEP_VERSION=false
 export DEPLOY_TARGET=dev
 export API_URL=//mf-chsdi3.dev.bgdi.ch
+export MAPPROXY_URL=//wmts{s}.dev.bgdi.ch
 export PUBLIC_URL=//public.dev.bgdi.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch

--- a/rc_int
+++ b/rc_int
@@ -1,6 +1,7 @@
 export KEEP_VERSION=true
 export DEPLOY_TARGET=int
 export API_URL=//mf-chsdi3.int.bgdi.ch
+export MAPPROXY_URL=//wmts{s}.int.bgdi.ch
 export PUBLIC_URL=//public.int.bgdi.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=https://mf-geoadmin3.int.bgdi.ch

--- a/rc_prod
+++ b/rc_prod
@@ -1,7 +1,7 @@
 export KEEP_VERSION=true
 export DEPLOY_TARGET=prod
 export API_URL=//api3.geo.admin.ch
-export API_URL=//wmts{s}.geo.admin.ch
+export MAPPROXY_URL=//wmts{s}.geo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=https://map.geo.admin.ch

--- a/rc_prod
+++ b/rc_prod
@@ -1,6 +1,7 @@
 export KEEP_VERSION=true
 export DEPLOY_TARGET=prod
 export API_URL=//api3.geo.admin.ch
+export API_URL=//wmts{s}.geo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export APACHE_BASE_PATH=
 export BROWSERSTACK_TARGETURL=https://map.geo.admin.ch

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -729,6 +729,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           pegman: !!window.location.search.match(/(pegman=true)/),
           mapUrl : location.origin + '${apache_base_path}',
           apiUrl : location.protocol + '${api_url}',
+          mapproxyUrl : location.protocol + '${mapproxy_url}',
           publicUrl : location.protocol + '${public_url}',
           publicUrlRegexp: new RegExp('${public_url_regexp}'),
           adminUrlRegexp: new RegExp('${admin_url_regexp}'),
@@ -770,7 +771,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           gaLayersProvider.dfltWmtsMapProxySubdomains = ['20', '21', '22', '23', '24'];
           gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
           gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
-          gaLayersProvider.wmtsMapProxyGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+          gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =  gaGlobalOptions.mapproxyUrl + '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
           gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
           gaLayersProvider.layersConfigUrlTemplate = gaGlobalOptions.resourceUrl + 'layersConfig?lang={Lang}';
           gaLayersProvider.legendUrlTemplate = gaGlobalOptions.apiUrl + '/rest/services/all/MapServer/{Layer}/legend?lang={Lang}';


### PR DESCRIPTION

This [Demo](https://mf-geoadmin3.dev.bgdi.ch/mom_mapproxy_sources/?topic=schneesport&lang=fr&bgLayer=voidLayer&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.pixelkarte-farbe-pk50.noscale,ch.swisstopo.hangneigung-ueber_30,ch.swisstopo-karto.hangneigung,ch.bafu.wrz-jagdbanngebiete_select,ch.bazl.heliports-gebirgslandeplaetze,ch.swisstopo-karto.schneeschuhrouten,ch.swisstopo-karto.skitouren,ch.swisstopo.skitourenkarte-50.metadata,ch.bav.haltestellen-oev&layers_visibility=false,false,false,false,true,false,true,true,true,true,true,false,true&layers_timestamp=18641231,,,,,,,,,,,,&layers_opacity=1,1,1,1,0.85,0.5,0.2,0.6,1,0.8,0.8,1,1&catalogNodes=2352&lon=7.70568&lat=46.32534&elevation=6733&heading=359.700&pitch=-39.862) is using `mapproxy`tiles from https://wmts{s}.dev.bgdi.ch ([example](https://wmts20.dev.bgdi.ch)), where both layers `ch.swisstopo-karto.schneeschuhrouten`and `` ch.swisstopo-karto.skitouren`are configured.

Choose the right mapproxy source with:

`$ export MAPPROXY_URL=//wmts{s}.dev.bgdi.ch`