### PR TITLE
Remove pixel detection when we get the layers to query

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -62,33 +62,14 @@ goog.require('ga_topic_service');
           return l;
         };
 
-        // Get all the queryable layers at a pixel
-        var getLayersToQueryAtPixel = function(map, pixel, is3dActive) {
-          var bodIds = [];
+        // Get all the queryable layers
+        var getLayersToQuery = function(map) {
           var layersToQuery = [];
-          if (!is3dActive && !gaBrowserSniffer.ios &&
-              (!gaBrowserSniffer.msie || gaBrowserSniffer.msie > 10)) {
-            // Works only on sublayers
-            map.forEachLayerAtPixel(pixel,
-              function(l) {
-                l = getOlParentLayer(l);
-                bodIds.push(l.bodId);
-                layersToQuery.push(l);
-              },
-              undefined,
-              function(l) {
-                l = getOlParentLayer(l);
-                return (bodIds.indexOf(l.bodId) === -1 &&
-                    hasTooltipBodLayer(l)) || isVectorLayer(l);
-              }
-            );
-          } else {
-            map.getLayers().forEach(function(l) {
-              if (hasTooltipBodLayer(l) || isVectorLayer(l)) {
-                layersToQuery.push(l);
-              }
-            });
-          }
+          map.getLayers().forEach(function(l) {
+            if (hasTooltipBodLayer(l) || isVectorLayer(l)) {
+              layersToQuery.push(l);
+            }
+          });
           return layersToQuery;
         };
 
@@ -344,8 +325,7 @@ goog.require('ga_topic_service');
               var identifyUrl = scope.options.identifyUrlTemplate
                   .replace('{Topic}', gaTopic.get().id),
                   pixel = map.getPixelFromCoordinate(coordinate),
-                  layersToQuery = getLayersToQueryAtPixel(map, pixel,
-                      is3dActive());
+                  layersToQuery = getLayersToQuery(map);
 
               // When 3d is Active we use the cesium native function to get the
               // first queryable feature.


### PR DESCRIPTION
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_tooltip/?lang=fr&topic=schneesport&bgLayer=voidLayer&X=146659.97&Y=693981.58&zoom=3&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.pixelkarte-farbe-pk50.noscale,ch.swisstopo.hangneigung-ueber_30,ch.swisstopo-karto.hangneigung,ch.bafu.wrz-jagdbanngebiete_select,ch.bazl.heliports-gebirgslandeplaetze,ch.swisstopo-karto.schneeschuhrouten,ch.swisstopo-karto.skitouren,ch.swisstopo.skitourenkarte-50.metadata,ch.bav.haltestellen-oev&layers_visibility=false,false,false,false,true,false,true,true,false,true,true,false,false&layers_timestamp=18641231,,,,,,,,,,,,&layers_opacity=1,1,1,1,0.85,0.5,0.2,0.6,1,0.8,0.8,1,1&catalogNodes=2352)