### PR TITLE
Deactivate client zoom

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1109,8 +1109,9 @@ goog.require('ga_urlutils_service');
             var minRetLod = gaMapUtils.getLodFromRes(config3d.maxResolution) ||
                 window.minimumRetrievingLevel;
             var maxRetLod = gaMapUtils.getLodFromRes(config3d.minResolution);
-            var maxLod = 17;// 17 is the last terrain level
-            if (config3d.resolutions) {
+            // Set maxLod as undefined deactivate client zoom.
+            var maxLod = (maxRetLod) ? undefined : 17;
+            if (maxLod && config3d.resolutions) {
               maxLod = gaMapUtils.getLodFromRes(
                   config3d.resolutions[config3d.resolutions.length - 1]);
             }


### PR DESCRIPTION
Fix #3012 

Based on #3111

[Test](https://mf-geoadmin3.dev.bgdi.ch/fix_3012/?lang=fr&topic=ech&bgLayer=voidLayer&X=219816.58&Y=669020.74&zoom=11&dev3d=true&debug&layers=ch.bfs.gebaeude_wohnungs_register)
