### PR TITLE
Catalog checkbox represents layer visibility

### DIFF
--- a/src/components/catalogtree/CatalogitemDirective.js
+++ b/src/components/catalogtree/CatalogitemDirective.js
@@ -28,6 +28,13 @@ goog.require('ga_layer_metadata_popup_service');
           gaPreviewLayers.removeAll(map);
         };
 
+        var getOlLayer = function(map, item) {
+          if (!item) {
+            return undefined;
+          }
+          return gaMapUtils.getMapOverlayForBodId(map, item.layerBodId);
+        };
+
         return {
           restrict: 'A',
           replace: true,
@@ -40,14 +47,23 @@ goog.require('ga_layer_metadata_popup_service');
           },
           controller: function($scope) {
 
-            $scope.toggleLayer = function() {
-              removePreviewLayer($scope.map);
-              if ($scope.item.selectedOpen) {
-                gaCatalogtreeMapUtils.addLayer($scope.map, $scope.item);
-              } else {
-                var layer = gaMapUtils.getMapOverlayForBodId(
-                    $scope.map, $scope.item.layerBodId);
-                $scope.map.removeLayer(layer);
+            $scope.item.active = function(activate) {
+              var layer = getOlLayer($scope.map, $scope.item);
+              //setter called
+              if (arguments.length) {
+                if (layer) {
+                  layer.visible = activate;
+                }
+                if (activate) {
+                  $scope.item.selectedOpen = true;
+                  // Add it if it's not already on the map
+                  if (!layer) {
+                    removePreviewLayer($scope.map);
+                    gaCatalogtreeMapUtils.addLayer($scope.map, $scope.item);
+                  }
+                }
+              } else { //getter called
+                return $scope.item.selectedOpen && layer && layer.visible;
               }
             };
 

--- a/src/components/catalogtree/partials/catalogitem.html
+++ b/src/components/catalogtree/partials/catalogitem.html
@@ -3,7 +3,7 @@
   <div ng-switch-when="undefined" class="ga-catalogitem-leaf ga-catalogitem-entry"
        ng-class="{'ga-catalogitem-selected': item.selectedOpen}">
     <label title="{{item.label}}" class="ga-truncate-text ga-checkbox">
-      <input type="checkbox" ng-model="item.selectedOpen" ng-change="toggleLayer()"/>
+      <input type="checkbox" ng-model="item.active" ng-model-options="{getterSetter: true}"/>
       <span></span>
       {{item.label}}
     </label>


### PR DESCRIPTION
@davidoesch As discussed this morning on the phone, the catalog handling has been adapted. If a layer is currently not added to the layer selection, the behaviour is as before: a click on the catalog entry will add the layer to the map.

Once the layer is in the layer selection, the behaviour in the catalog changes. The checkbox represents the layer's visibility. Clicking on the catalog item will toggle the layer visibility.
To remove a layer from the layer selection, it has to be removed in the layer manager.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_cat/)

