### PR TITLE
No-Info box shown only when cursor was pointer

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -320,6 +320,7 @@ goog.require('ga_topic_service');
                  coordinate)) {
                 return;
               }
+              var pointerShown = (map.getTarget().style.cursor == 'pointer');
               var size = map.getSize();
               var mapExtent = map.getView().calculateExtent(size);
               var identifyUrl = scope.options.identifyUrlTemplate
@@ -380,14 +381,16 @@ goog.require('ga_topic_service');
               }
 
               // When all the requests are finished we test how many features
-              // are displayed. If there is none we close the popup after 3
-              // seconds.
+              // are displayed. If there is none and the cursor was a pointer
+              // in the moment of the click, we show a no-info box for
+              // 3 seconds. As we show pointer only on desktop, this also
+              // means that no-info box is never shown on mobile
               if (all.length > 0) {
                 $q.all(all).then(function(nbResults) {
                   var sum = nbResults.reduce(function(a, b) {
                     return a + b;
                   });
-                  if (sum == 0) {
+                  if (sum == 0 && pointerShown) {
                     showNoInfo();
                   }
                 });


### PR DESCRIPTION
This is a fix for https://github.com/geoadmin/mf-geoadmin3/issues/3120 and as discussed.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_ni/?topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,ch.are.gueteklassen_oev,ch.bav.haltestellen-oev&layers_visibility=false,false,false,false,true,true&layers_timestamp=18641231,,,,,&X=129038.02&Y=609270.67&zoom=6&layers_opacity=1,1,1,1,0.75,1)
