### PR TITLE
New appcache, never cache it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ help:
 	@echo "- testprod         Run the JavaScript tests in prod mode"
 	@echo "- teste2e          Run browserstack tests"
 	@echo "- apache           Configure Apache (restart required)"
-	@echo "- appcache         Update appcache file"
 	@echo "- fixrights        Fix rights in common folder"
 	@echo "- all              All of the above (target to run prior to creating a PR)"
 	@echo "- clean            Remove generated files"
@@ -131,9 +130,6 @@ teste2e: guard-BROWSERSTACK_TARGETURL guard-BROWSERSTACK_USER guard-BROWSERSTACK
 
 .PHONY: apache
 apache: apache/app.conf
-
-.PHONY: appcache
-appcache: cleanappcache prd/geoadmin.appcache prd/index.html prd/mobile.html prd/embed.html
 
 .PHONY: deploydev
 deploydev:
@@ -304,6 +300,7 @@ prd/style/app.css: $(SRC_LESS_FILES)
 prd/geoadmin.appcache: src/geoadmin.mako.appcache \
 			${MAKO_CMD} \
 			.build-artefacts/last-version
+	rm -f prd/*.appcache
 	mkdir -p $(dir $@);
 	${PYTHON_CMD} ${MAKO_CMD} \
 	    --var "version=$(VERSION)" \
@@ -312,6 +309,7 @@ prd/geoadmin.appcache: src/geoadmin.mako.appcache \
 	    --var "languages=$(LANGUAGES)" \
 	    --var "api_url=$(API_URL)" \
 	    --var "public_url=$(PUBLIC_URL)" $< > $@
+	mv $@ prd/geoadmin.$(VERSION).appcache
 
 prd/cache/: .build-artefacts/last-version \
 			.build-artefacts/last-api-url
@@ -610,14 +608,6 @@ scripts/00-$(GIT_BRANCH).conf: scripts/00-branch.mako-dot-conf \
 cleanall: clean
 	rm -rf node_modules
 	rm -rf .build-artefacts
-
-
-.PHONY: cleanappcache
-cleanappcache:
-	rm -f prd/geoadmin.appcache
-	rm -f prd/index.html
-	rm -f prd/mobile.html
-	rm -f prd/embed.html
 
 
 .PHONY: clean

--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -7,7 +7,6 @@ AddType application/json .json
 AddType application/font-woff .woff
 AddType text/cache-manifest .appcache
 
-ExpiresByType text/cache-manifest "access plus 0 seconds"
 ExpiresByType text/html "access plus 0 seconds"
 
 AddOutputFilterByType DEFLATE text/css
@@ -81,7 +80,7 @@ RewriteRule ^${apache_base_path}/sitemap_(.*)\.xml http:${api_url}/${version}/si
 # Assure main pages are not cached with headers set according to
 # http://stackoverflow.com/questions/49547/making-sure-a-web-page-is-not-cached-across-all-browser
 # and http://tools.ietf.org/html/rfc2616
-<LocationMatch ^${apache_base_path}/(index.html|mobile.html|embed.html)$>
+<LocationMatch ^${apache_base_path}/(index.html|mobile.html|embed.html|geoadmin.${version}.appcache)$>
     Header unset Age
     Header unset Last-Modified
     Header unset Vary

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -3,7 +3,7 @@
 <html ng-app="geoadmin" ng-controller="GaMainController"
 itemscope itemtype="http://schema.org/WebApplication"
 % if device == 'mobile' and mode=='prod' :
- manifest="geoadmin.appcache"
+ manifest="geoadmin.${version}.appcache"
 % endif
 >
   <head>

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -392,9 +392,9 @@ goog.require('ga_topic_service');
 
     }
 
-    // An appcache update is available.
+    // An new appcache file is available.
     if ($window.applicationCache) { // IE9
-      $window.applicationCache.addEventListener('updateready', function(e) {
+      $window.applicationCache.addEventListener('obsolete', function(e) {
         $window.location.reload();
       });
     }


### PR DESCRIPTION
This PR does 2 things to address various potential problems with appcache.

1) It created a new appcache file name. The idea is that old existing appcaches which still tangle in various browsers (desktop and mobile pages) is invalidated by triggering a 404 response code. Becaus the old `geoadmin.appcache` does not exist anymore, this should happen.

2) Assures that appcache file is never cached. Despite having https://github.com/geoadmin/mf-geoadmin3/blob/master/apache/app.mako-dot-conf#L10, I've detected that browsers still cache this file. By putting it in the same block as index.html, we assure that it's never cached and always requested.

@oterral Some issues we have are still potentially caused by bad working appcache updates. I hope this will get rid of them.