### PR TITLE
Cleanup all untracked files and folders

### DIFF
--- a/scripts/deploydev.sh
+++ b/scripts/deploydev.sh
@@ -24,7 +24,7 @@ fi
 cd $BASEDIR/geoadmin
 
 # remove all local changes and get latest GITBRANCH from remote
-git fetch --all && git reset --hard && git checkout $GITBRANCH && git reset --hard origin/$GITBRANCH
+git fetch --all && git reset --hard && git checkout $GITBRANCH && git reset --hard origin/$GITBRANCH && git clean -fxd .
 
 # build the project
 source rc_dev 


### PR DESCRIPTION
If a folder name changes in between 2 versions and is not cleaned anymore in the cleanall target, we might end up with unwanted files and folders. (as we are not creating a fresh clone when deploying to dev)

Use: `git clean -n -fxd .` for a dry run