### PR TITLE
Assure make call before deploying snapshot creates new version

### DIFF
--- a/scripts/deploysnapshot.sh
+++ b/scripts/deploysnapshot.sh
@@ -17,8 +17,8 @@ SNAPSHOTDIR=/var/www/vhosts/mf-geoadmin3/private/snapshots/$1
 # we assure that snapshot is re-build with new version
 cwd=$(pwd)
 cd $SNAPSHOTDIR/geoadmin/code/geoadmin
-KEEP_VERSION=false
 source rc_$2
+KEEP_VERSION=false
 make all
 
 echo -n "Checking service and layersConfig files"


### PR DESCRIPTION
I detected this during yesterday's deploy. When deploying twice to the same target, the layersconfig and services were not updated with latest API calls.

The reason was that no re-build was triggered because of no changes. But a change should be triggered because we want a new version to be build in the snapshot directory.

The KEEP_VERSION variable was correctly set, but gets instantly overwritten by the next line (in rc_int, KEEP_VERSION is set to true again, which is correct for the on-target build)