### PR TITLE
Fix #3159: Adjust print font of measure overlays

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -766,14 +766,14 @@ goog.require('ga_time_service');
                 'externalGraphic': $scope.options.bubbleUrl,
                 'graphicWidth': 97,
                 'graphicHeight': 27,
-                'graphicXOffset': -46,
+                'graphicXOffset': -48,
                 'graphicYOffset': -27,
                 'label': $(elt).text(),
                 'labelXOffset': 0,
                 'labelYOffset': 18,
                 'fontColor': '#ffffff',
-                'fontSize': 12,
-                'fontWeight': 'bold'
+                'fontSize': 10,
+                'fontWeight': 'normal'
               }
             },
             'styleProperty': '_gx_style',


### PR DESCRIPTION
Fix #3159 

@mariokeusen [test](https://mf-geoadmin3.dev.bgdi.ch/fix_3159/?lang=fr&topic=ech&widgets=print&bgLayer=ch.swisstopo.pixelkarte-farbe&X=133391.30&Y=570500.00&dev3d=true&zoom=1&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttps:%2F%2Fpublic.dev.bgdi.ch%2F5YuaOmZYSDqayMIl-Vnkfg&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,)