### PR TITLE
Fix #3150: Add margin-left to arrow-right

### DIFF
--- a/src/components/swipe/style/swipe.less
+++ b/src/components/swipe/style/swipe.less
@@ -42,6 +42,7 @@
     }
 
     .ga-arrow-right{
+      margin-left: 4px;
       border-left: 10px solid white;
     }
 


### PR DESCRIPTION
Fix #3150 

Tested on all Windows 7  browsers,  Windows phone and ios Safari 8

Doesn't work on dev mode but it's better that it works only in prod mode than only in dev mode 