### PR TITLE
Manage 'null' value in the query tool

### DIFF
--- a/src/components/query/QueryDirective.js
+++ b/src/components/query/QueryDirective.js
@@ -59,10 +59,23 @@ goog.require('ga_storage_service');
         }
         var params = paramsByLayer[filter.layer.bodId].params;
         var operator = $scope.selectedQueryOperator.value;
+
         // Where condition
         var where = (params.where) ? params.where + ' ' + operator + ' ' : '';
-        where += filter.attribute.name + ' ' + filter.operator + ' ' +
-            filter.attribute.transformToLiteral(filter.value);
+        where += filter.attribute.name + ' ';
+
+        // Manage 'null' value
+        if (/^null$/i.test(filter.value)) {
+          where += 'is ';
+          if (/^(!=|<|>|not ilike)$/i.test(filter.operator)) {
+            where += 'not ';
+          }
+          where += 'null';
+        } else {
+          where += filter.operator + ' ' +
+              filter.attribute.transformToLiteral(filter.value);
+        }
+
         params.where = where;
       });
       return list;

--- a/src/components/query/QueryService.js
+++ b/src/components/query/QueryService.js
@@ -121,6 +121,11 @@ goog.provide('ga_query_service');
               // Set STRING as default field type.
               var type = attrInfos[field.type] || attrInfos.STRING;
 
+              // Transform null value to 'null' string
+              if (field.values && field.values[0] === null) {
+                field.values[0] = 'null';
+              }
+
               attr.push({
                 name: field.name,
                 label: label,
@@ -178,6 +183,12 @@ goog.provide('ga_query_service');
           $http.get(msUrl + bodId + '/attributes/' + attrName, {
             cache: true
           }).success(function(data) {
+
+            // Transform null value to 'null' string
+            if (data.values && data.values[0] === null) {
+              data.values[0] = 'null';
+            }
+
             deferred.resolve(data.values);
           }).error(function(data, status, headers, config) {
             $log.error('Request failed');


### PR DESCRIPTION
Fix #2013 

Needs  https://github.com/geoadmin/mf-chsdi3/pull/1921

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_null_valtest/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&lang=fr&layers_opacity=1,1,1,1,0.75&X=170625.00&Y=600250.00&zoom=2)