### PR TITLE
Topic change refactoring

### DIFF
--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -347,14 +347,6 @@ goog.require('ga_urlutils_service');
           });
         }
 
-        // Remove non topic layer
-        scope.$on('gaTopicChange', function(evt, newTopic) {
-          scope.filteredLayers.forEach(function(l) {
-            scope.removeLayer(l);
-          });
-          $rootScope.$broadcast('gaPostTopicChange', newTopic);
-        });
-
         // Change layers label when topic changes
         scope.$on('gaLayersTranslationChange', function(evt) {
           map.getLayers().forEach(function(olLayer) {

--- a/src/components/map/PermalinkLayersService.js
+++ b/src/components/map/PermalinkLayersService.js
@@ -341,8 +341,19 @@ goog.require('ga_wms_service');
 
           gaTime.allowStatusUpdate = true;
           registerLayersPermalink(scope, map);
-          // Listen for next topic change events
-          $rootScope.$on('gaPostTopicChange', addTopicSelectedLayers);
+          $rootScope.$on('gaTopicChange', function() {
+            // First we remove all layers that are selected
+            var toDelete = [];
+            angular.forEach(map.getLayers().getArray(), function(l) {
+              if (gaLayerFilters.selected(l)) {
+                toDelete.push(l);
+              }
+            });
+            angular.forEach(toDelete, function(l) {
+              map.removeLayer(l);
+            });
+            addTopicSelectedLayers();
+          });
         });
       };
     };

--- a/test/specs/map/PermalinkLayersService.spec.js
+++ b/test/specs/map/PermalinkLayersService.spec.js
@@ -339,12 +339,13 @@ describe('ga_permalinklayers_service', function() {
         expect(map.getLayers().getLength()).to.be(2);
         expect(permalink.getParams().layers).to.be('bar,foo');
 
-        // On next topic change the selected layers are added
+        // On next topic change the selected layers are added and the previous
+        // removed
         topic = topicLoaded3;
-        $rootScope.$broadcast('gaPostTopicChange', {});
-        expect(map.getLayers().getLength()).to.be(4);
+        $rootScope.$broadcast('gaTopicChange', {});
+        expect(map.getLayers().getLength()).to.be(2);
         $rootScope.$digest();
-        expect(permalink.getParams().layers).to.be('bar,foo,bar2,foo2');
+        expect(permalink.getParams().layers).to.be('bar2,foo2');
 
         // For next test 
         permalink.deleteParam('layers');
@@ -359,12 +360,12 @@ describe('ga_permalinklayers_service', function() {
         expect(map.getLayers().getLength()).to.be(1);
         expect(permalink.getParams().layers).to.be('ged');
 
-        // On next topic change the selected layers are added
+        // Even when layers are defined, a topic change does reset the selection
         topic = topicLoaded2;
-        $rootScope.$broadcast('gaPostTopicChange', {});
-        expect(map.getLayers().getLength()).to.be(3);
+        $rootScope.$broadcast('gaTopicChange', {});
+        expect(map.getLayers().getLength()).to.be(2);
         $rootScope.$digest();
-        expect(permalink.getParams().layers).to.be('ged,bar,foo');
+        expect(permalink.getParams().layers).to.be('bar,foo');
 
         // For next test
         topic = undefined;


### PR DESCRIPTION
This is a refactoring of https://github.com/geoadmin/mf-geoadmin3/pull/3154

It moves the `reset layers on topic change` out of the layermanager directive and into the gaPermalinkManager service. I'm not debating that it's the right place (it's probably not) but It's good to have this outside of the layermanager.