### PR TITLE
Avoid using git once snapshot is created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LESS_PARAMETERS ?= -ru
 KEEP_VERSION ?= 'false'
 LAST_VERSION := $(shell if [ -f .build-artefacts/last-version ]; then cat .build-artefacts/last-version 2> /dev/null; else echo '-none-'; fi)
 VERSION := $(shell if [ '$(KEEP_VERSION)' = 'true' ] && [ '$(LAST_VERSION)' != '-none-' ]; then echo $(LAST_VERSION); else date '+%s'; fi)
-GIT_BRANCH := $(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+GIT_BRANCH := $(shell if [ -f .build-artefacts/deployed-git-branch ]; then cat .build-artefacts/deployed-git-branch 2> /dev/null; else git rev-parse --symbolic-full-name --abbrev-ref HEAD; fi)
 GIT_LAST_BRANCH := $(shell if [ -f .build-artefacts/last-git-branch ]; then cat .build-artefacts/last-git-branch 2> /dev/null; else echo 'dummy'; fi)
 BRANCH_TO_DELETE ?=
 DEPLOY_ROOT_DIR := /var/www/vhosts/mf-geoadmin3/private/branch

--- a/README.md
+++ b/README.md
@@ -170,10 +170,6 @@ The code for deployment, however, does not come from your working directory,
 but does get cloned (first time) or pulled (if done once) *directly from github*.
 So you'll likely use this command *after* you push your branch to github.
 
-Use `make deploybranch GIT_BRANCH=dev_other_branch` to deploy a different 
-branch than the one you are currently working on. Make sure that the branch 
-specified exists on github.
-
 The first time you use the command will take some time to execute.
 
 The code of the deployed branch is in a specific directory 

--- a/scripts/deploydev.sh
+++ b/scripts/deploydev.sh
@@ -48,8 +48,9 @@ if [ $CREATE_SNAPSHOT == 'true' ]; then
   sudo -u deploy deploy -c deploy/deploy.cfg $SNAPSHOTDIR
   echo "Snapshot of branch $GITBRANCH created at $SNAPSHOTDIR"
   cd $SNAPSHOTDIR/geoadmin/code/geoadmin/
-  git describe --tags --abbrev=0 > .last-release
-  git log -1 --pretty=format:"%h - %an, %ar : %s" > .last-commit-ref
+  git describe --tags --abbrev=0 > .build-artefacts/last-release
+  git log -1 --pretty=format:"%h - %an, %ar : %s" > .build-artefacts/last-commit-ref
+  git rev-parse --symbolic-full-name --abbrev-ref HEAD > .build-artefacts/deployed-git-branch
   rm -rf .git*
 else
   echo "NO Snapshot created. Specify '-s' parameter got create snapshot."


### PR DESCRIPTION
Using the same approach as in https://github.com/geoadmin/mf-chsdi3/pull/1920/files
When creating a snapshot while deploying to dev we currently remove `.git` folder which is around 100Mb (800 Mb for chsdi).

The problem is that in https://github.com/geoadmin/mf-geoadmin3/blob/master/deploy/hooks/post-restore-code#L21
we use `make all` and the related git branch is false. This fixes this issue. I don't know how to test that other than merging it.
PR coming for chsdi.