### PR TITLE
Allow execution of all saucelab tests in one browser/platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ help:
 	@echo "- teste2e          Run browserstack and saucelabs tests"
 	@echo "- browserstack     Run browserstack tests"
 	@echo "- saucelabs        Run saucelabs tests"
+	@echo "- saucelabssingle  Run saucelabs tests but only with single platform/browser"
 	@echo "- apache           Configure Apache (restart required)"
 	@echo "- fixrights        Fix rights in common folder"
 	@echo "- all              All of the above (target to run prior to creating a PR)"
@@ -153,6 +154,10 @@ browserstack: guard-BROWSERSTACK_USER guard-BROWSERSTACK_KEY
 .PHONY: saucelabs
 saucelabs: guard-SAUCELABS_USER guard-SAUCELABS_KEY .build-artefacts/requirements.timestamp lintpy
 	${PYTHON_CMD} test/saucelabs/test.py ${E2E_TARGETURL} ${SAUCELABS_TESTS}
+
+.PHONY: saucelabssingle
+saucelabssingle: guard-SAUCELABS_USER guard-SAUCELABS_KEY .build-artefacts/requirements.timestamp lintpy
+	${PYTHON_CMD} test/saucelabs/test.py ${E2E_TARGETURL} all true
 
 .PHONY: apache
 apache: apache/app.conf

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ In order to lauch only some of the tests, you can use the following command:
 
 Per default all tests are launched.
 
+If you only want to launch sauclab tests on a single platform/browser, you can use
+the following command
+
+    make saucelabssingle
+
 ## Cross-browser end-to-end tests with browserstack.com
 
 To run the e2e browserstack tests, a few things need to be set up in your 

--- a/test/saucelabs/test.py
+++ b/test/saucelabs/test.py
@@ -18,23 +18,26 @@ DEFAULT_WAIT_FOUND = 5
 
 def parse_args(args):
     tests = []
+    singlebrowser = False
     if len(args) < 2:
         print 'ERROR: No URL provided. You need to set SAUCELABS_TARGETURL in your environment! Exit!'
         sys.exit(1)
-    elif len(args) > 3:
+    elif len(args) > 4:
         print 'ERROR: too many arguments! Exit!'
         sys.exit(1)
     else:
         url = args[1]
-        if len(args) == 3:
+        if len(args) >= 3:
             tests = args[2].split(',')
+        if len(args) >= 4:
+            singlebrowser = True if args[3] == 'true' else False
 
-    return url, tests
+    return url, tests, singlebrowser
 
 
 if __name__ == '__main__':
 
-    url, tests = parse_args(sys.argv)
+    url, tests, singlebrowser = parse_args(sys.argv)
 
     # Get value to connect to SauceLabs
     try:
@@ -48,6 +51,11 @@ if __name__ == '__main__':
     # The command_executor tells the test to run on Sauce, while the desired_capabilties
     # parameter tells us which browsers and OS to spin up.
     # browser list : https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/
+
+    # Top browser and platform according to stats. Update from time to time
+    top_browser = {'platform': "Windows 7", 'browserName': "firefox",
+                   'version': "44.0", 'screenResolution': "1280x1024"}
+
     desired_cap_list = [
         {'platform': "Windows 7", 'browserName': "chrome",
             'version': "48.0", 'screenResolution': "1280x1024"},
@@ -57,8 +65,6 @@ if __name__ == '__main__':
             'version': "48.0", 'screenResolution': "1280x1024"},
         {'platform': "Windows 10", 'browserName': "chrome",
             'version': "48.0", 'screenResolution': "1280x1024"},
-        {'platform': "Windows 7", 'browserName': "firefox",
-            'version': "44.0", 'screenResolution': "1280x1024"},
         {'platform': "Windows 7", 'browserName': "firefox",
             'version': "43.0", 'screenResolution': "1280x1024"},
         {'platform': "Windows 8.1", 'browserName': "firefox",
@@ -72,6 +78,8 @@ if __name__ == '__main__':
         # {'platform': "Windows 7", 'browserName': "internet explorer",
         #     'version': "11.0", 'screenResolution': "1280x1024" }
     ]
+
+    desired_cap_list.append(top_browser)
 
     # okay we will start the script!
     print "Starting SauceLabs script!"
@@ -90,6 +98,9 @@ if __name__ == '__main__':
         'checker': runCheckerTest
     }
 
+    if len(tests) > 0 and tests[0] == 'all':
+        tests = []
+
     if len(tests) > 0:
         tests = [t for t in tests if t in doTests.keys()]
         if len(tests) == 0:
@@ -97,7 +108,9 @@ if __name__ == '__main__':
             print 'Please try again...'
             sys.exit(1)
 
-    for current_desired_cap in desired_cap_list:
+    caps_used = [top_browser] if singlebrowser else desired_cap_list
+
+    for current_desired_cap in caps_used:
         print "+--> Start test with " + current_desired_cap['platform'] + \
             " " + current_desired_cap['browserName'] + " (" + current_desired_cap['version'] + ")"
 


### PR DESCRIPTION
Running all Saucelabs tests on all browsers takes 25 minutes. For Pull Request builds, this is probably
too long.

This PR adds the possibility to execute all saucelabs tests on a single environment (browser and platform). It's meant to be used on the Pull Request builder on Jenkins only, but might be handy for manually exectued checks as well.

Jenkins is already adapted to use this. So quick review/merge would be great.