### PR TITLE
Include version in feedback as parameter

### DIFF
--- a/src/components/feedback/FeedbackDirective.js
+++ b/src/components/feedback/FeedbackDirective.js
@@ -56,27 +56,25 @@ goog.require('ga_permalink');
                                            scope.map.getView().getProjection());
                 }
                 // Not supported by IE9
-                var feedbackMessage = scope.feedback;
-                feedbackMessage += '\n\n\n---------------------------------\n';
-                feedbackMessage += 'Message created with version: ';
-                feedbackMessage += gaGlobalOptions.version;
                 if (!scope.isIE || gaBrowserSniffer.msie > 9) {
                     formData = new FormData();
                     formData.append('email', scope.email);
-                    formData.append('feedback', feedbackMessage);
+                    formData.append('feedback', scope.feedback);
                     formData.append('ua', navigator.userAgent);
                     formData.append('permalink', scope.permalinkValue);
                     formData.append('attachement', scope.file || '');
                     formData.append('kml', kml);
+                    formData.append('version', gaGlobalOptions.version + '');
                     return formData;
                 } else {
                     formData = {
                       email: scope.email,
-                      feedback: feedbackMessage,
+                      feedback: scope.feedback,
                       ua: navigator.userAgent,
                       permalink: scope.permalinkValue,
                       attachement: '',
-                      kml: kml
+                      kml: kml,
+                      version: gaGlobalOptions.version + ''
                     };
                     return $.param(formData);
                 }


### PR DESCRIPTION
This is the front-end solution for https://github.com/geoadmin/mf-chsdi3/pull/1948. The PR in chsdi3 should be merged first.

It's the correct handling of what we did in https://github.com/geoadmin/mf-geoadmin3/pull/3090/files by putting the version not in the feedback message, but as a paremeter to the request.