### PR TITLE
Don't change id of external WMS layer on page loading

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -405,14 +405,23 @@ goog.require('ga_urlutils_service');
 
         // Test WMS 1.1.1 with  https://wms.geo.bs.ch/wmsBS
         var createWmsLayer = function(params, options, index) {
-          params.VERSION = params.VERSION || '1.3.0';
           options = options || {};
           options.id = 'WMS||' + options.label + '||' + options.url + '||' +
-              params.LAYERS + '||' + params.VERSION;
+              params.LAYERS;
+
+          // If the WMS has a version specified, we add it in
+          // the id. It's important that the layer keeps the same id as the
+          // one in the url otherwise it breaks the asynchronous reordering of
+          // layers.
+          if (params.VERSION) {
+            options.id += '||' + params.VERSION;
+          }
+
           if (options.useReprojection) {
             options.projection = 'EPSG:4326';
             options.id += '||true';
           }
+
           var source = new ol.source.ImageWMS({
             params: params,
             url: options.url,
@@ -2193,7 +2202,7 @@ goog.require('ga_urlutils_service');
                     opacity: opacity || 1,
                     visible: visible,
                     extent: gaGlobalOptions.defaultExtent,
-                    useReprojection: infos[5]
+                    useReprojection: (infos[5] === 'true')
                   },
                   index + 1);
               } catch (e) {


### PR DESCRIPTION
freeeze fixed

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_wmskml/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&catalogNodes=457,532&layers_opacity=0.75,1,0.75,1,1,1,1,0.75,0.75,0.75,0.75,0.75,0.75,0.75,0.75,1,0.75,0.75,1,1,0.75,1,1&layers=ch.bafu.naqua-grundwasser_psm,ch.bafu.bundesinventare-amphibien_anhang4,ch.bafu.bundesinventare-amphibien,ch.bafu.bundesinventare-amphibien_wanderobjekte,ch.bafu.fischerei-aeschen_kernzonen,ch.bafu.fischerei-aeschen_laichplaetze,ch.bafu.fischerei-aeschen_larvenhabitate,ch.blw.klimaeignung-futterbau,ch.blw.klimaeignung-getreidebau,ch.blw.klimaeignung-kartoffeln,ch.blw.klimaeignung-koernermais,ch.blw.klimaeignung-kulturland,ch.blw.klimaeignung-spezialkulturen,ch.blw.klimaeignung-typ,ch.blw.klimaeignung-zwischenfruchtbau,ch.bafu.nabelstationen,ch.blw.niederschlagshaushalt,ch.bafu.laerm-bahnlaerm_tag,ch.bav.kataster-belasteter-standorte-oev,ch.bafu.schutzgebiete-biosphaerenreservate,ch.bafu.laerm-bahnlaerm_nacht,WMS%7C%7CKreisgrenzen%7C%7Chttp:%2F%2Fmapserver1.gr.ch%2Fwms%2Fadmineinteilung%3F%7C%7CKreisgrenzen,KML%7C%7Chttp:%2F%2Fopendata.utou.ch%2Furbanproto%2Fgeneva%2Fgeo%2Fkml%2FRoutes.kml)