### PR TITLE
Fix mako cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -570,7 +570,7 @@ $(addprefix .build-artefacts/annotated/, $(SRC_JS_FILES) src/TemplateCacheModule
 ${MAKO_CMD}: ${PYTHON_VENV}
 	${PIP_CMD} install "Mako==1.0.0"
 	touch $@
-	@ if [[ ! -e ${PYTHON_VENV}/local ]]; then \
+	@if [ ! -e ${PYTHON_VENV}/local ]; then \
 	    ln -s . ${PYTHON_VENV}/local; \
 	fi
 	cp scripts/cmd.py ${PYTHON_VENV}/local/lib/python2.7/site-packages/mako/cmd.py


### PR DESCRIPTION
before

```sh
rm .build-artefacts/python-venv/bin/mako-render
make .build-artefacts/python-venv/bin/mako-render


.build-artefacts/python-venv/bin/pip install "Mako==1.0.0"
Requirement already satisfied (use --upgrade to upgrade): Mako==1.0.0 in ./.build-artefacts/python-venv/lib/python2.7/site-packages
Requirement already satisfied (use --upgrade to upgrade): MarkupSafe>=0.9.2 in ./.build-artefacts/python-venv/lib/python2.7/site-packages (from Mako==1.0.0)
Cleaning up...
touch .build-artefacts/python-venv/bin/mako-render
/bin/sh: 1: [[: not found
cp scripts/cmd.py .build-artefacts/python-venv/local/lib/python2.7/site-packages/mako/cmd.py

```

now

```sh
rm .build-artefacts/python-venv/bin/mako-render
make .build-artefacts/python-venv/bin/mako-render


.build-artefacts/python-venv/bin/pip install "Mako==1.0.0"
Requirement already satisfied (use --upgrade to upgrade): Mako==1.0.0 in ./.build-artefacts/python-venv/lib/python2.7/site-packages
Requirement already satisfied (use --upgrade to upgrade): MarkupSafe>=0.9.2 in ./.build-artefacts/python-venv/lib/python2.7/site-packages (from Mako==1.0.0)
Cleaning up...
touch .build-artefacts/python-venv/bin/mako-render
cp scripts/cmd.py .build-artefacts/python-venv/local/lib/python2.7/site-packages/mako/cmd.py
```