### PR TITLE
IFrame API

### DIFF
--- a/src/components/IFrameComService.js
+++ b/src/components/IFrameComService.js
@@ -1,0 +1,49 @@
+goog.provide('ga_iframe_com_service');
+(function() {
+
+  var module = angular.module('ga_iframe_com_service', []);
+
+  module.provider('gaIFrameCom', function() {
+
+    //Feature detection from
+    //https://github.com/Automattic/wpcom-proxy-request/pull/6
+
+    var stringsOnly = (function() {
+      var r = false;
+      try {
+        window.postMessage({toString: function() {r = true;}},'*');
+      } catch (e) {}
+      return r;
+    })();
+
+    this.$get = function() {
+
+      var IFrameCom = function() {
+
+        this.stringsOnly = function() {
+          return stringsOnly;
+        };
+
+        this.send = function(type, payload, targetOrigin) {
+          if (!targetOrigin) {
+            targetOrigin = '*';
+          }
+
+          if (top != window) {
+            var msg = {
+              type: type,
+              payload: payload
+            };
+            if (stringsOnly) {
+              msg = JSON.stringify(msg);
+            }
+            window.parent.postMessage(msg, targetOrigin);
+          }
+        };
+      };
+
+      return new IFrameCom();
+    };
+  });
+
+})();

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -26,7 +26,8 @@ goog.require('ga_topic_service');
   module.directive('gaTooltip',
       function($timeout, $http, $q, $translate, $sce, gaPopup, gaLayers,
           gaBrowserSniffer, gaMapClick, gaDebounce, gaPreviewFeatures,
-          gaMapUtils, gaTime, gaTopic, gaIdentify, gaGlobalOptions) {
+          gaMapUtils, gaTime, gaTopic, gaIdentify, gaGlobalOptions
+          gaPermalink) {
         var mouseEvts = '';
         if (!gaBrowserSniffer.mobile) {
           mouseEvts = 'ng-mouseenter="options.onMouseEnter($event,' +
@@ -532,6 +533,12 @@ goog.require('ga_topic_service');
               var name = feature.get('name');
               var featureId = feature.getId();
               var layerId = feature.get('layerId') || layer.id;
+              if (layer.get('type') == 'KML') {
+                layerId = layer.label;
+                if (name && name.length) {
+                  featureId = name;
+                }
+              }
               var id = layerId + '#' + featureId;
               htmlpopup = htmlpopup.
                   replace('{{id}}', id).
@@ -566,6 +573,11 @@ goog.require('ga_topic_service');
 
             // Show the popup with all features informations
             var showPopup = function(html, value) {
+              // Don't show popup when notooltip paramter is active
+              if (gaPermalink.getParams().notooltip == 'true') {
+                return;
+              }
+
               // Show popup on first result
               if (htmls.length === 0) {
 

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -89,7 +89,7 @@ goog.require('ga_topic_service');
             // onclick
             if (layer) {
               if (!vectorLayer || vectorLayer == layer) {
-                if (!featureFound && isFeatureQueryable(feature)) {
+                if (!featureFound) {
                   featureFound = feature;
                 }
               }
@@ -473,8 +473,9 @@ goog.require('ga_topic_service');
                     feature.setId(value.getId());
                     feature.set('layerId', layerId);
                     gaPreviewFeatures.add(map, feature);
-                    showPopup(value.get('htmlpopup'), value);
-
+                    if (value.get('htmlpopup')) {
+                      showPopup(value.get('htmlpopup'), value);
+                    }
                     // Store the ol feature for highlighting
                     featuresByLayerId[layerId][feature.getId()] = feature;
                   } else {
@@ -545,6 +546,9 @@ goog.require('ga_topic_service');
                   replace('{{descr}}', feature.get('description') || '').
                   replace('{{name}}', (name) ? '(' + name + ')' : '');
               feature.set('htmlpopup', htmlpopup);
+              if (!isFeatureQueryable(feature)) {
+                feature.set('htmlpopup', undefined);
+              }
               feature.set('layerId', layerId);
               showFeatures([feature]);
               // Iframe communication from inside out

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -3,6 +3,7 @@ goog.provide('ga_tooltip_directive');
 goog.require('ga_browsersniffer_service');
 goog.require('ga_debounce_service');
 goog.require('ga_identify_service');
+goog.require('ga_iframe_com_service');
 goog.require('ga_map_service');
 goog.require('ga_popup_service');
 goog.require('ga_previewfeatures_service');
@@ -15,6 +16,7 @@ goog.require('ga_topic_service');
     'ga_browsersniffer_service',
     'ga_debounce_service',
     'ga_identify_service',
+    'ga_iframe_com_service',
     'ga_map_service',
     'ga_popup_service',
     'ga_previewfeatures_service',
@@ -26,8 +28,8 @@ goog.require('ga_topic_service');
   module.directive('gaTooltip',
       function($timeout, $http, $q, $translate, $sce, gaPopup, gaLayers,
           gaBrowserSniffer, gaMapClick, gaDebounce, gaPreviewFeatures,
-          gaMapUtils, gaTime, gaTopic, gaIdentify, gaGlobalOptions
-          gaPermalink) {
+          gaMapUtils, gaTime, gaTopic, gaIdentify, gaGlobalOptions,
+          gaPermalink, gaIFrameCom) {
         var mouseEvts = '';
         if (!gaBrowserSniffer.mobile) {
           mouseEvts = 'ng-mouseenter="options.onMouseEnter($event,' +
@@ -551,7 +553,16 @@ goog.require('ga_topic_service');
               }
               feature.set('layerId', layerId);
               showFeatures([feature]);
+
               // Iframe communication from inside out
+              gaIFrameCom.send('gaFeatureSelection', {
+                layerId: layerId,
+                featureId: featureId
+              });
+
+              // We leave the old code to not break existing clients
+              // Once they have adapted to new implementation, we
+              // can remove the code below
               if (top != window) {
                if (featureId && layerId) {
                   window.parent.postMessage(id, '*');


### PR DESCRIPTION
This is a reduced alternative for https://github.com/geoadmin/mf-geoadmin3/issues/3146 and replaces https://github.com/geoadmin/mf-geoadmin3/pull/3164. It also establishes a first version of an iframe API.

It adds a service to handle iframe messaging to parent pages. Message is an object of the form
```
{
  type: messageType, //the message type
  payload: data //the data for this type
}
```

The PR also adds the notooltip parameter. If true, no tooltip is ever shown. It's application wide setting and applied for all layers. It's also working on mobile, desktop and embeded.

Existing message is adapted to make it structured. It adds the following messages:

- Selection of kml object
- Saving of kml file (as in https://github.com/geoadmin/mf-geoadmin3/pull/3317)
- Application change state (permalink is updated)

For details, see [Testlink (on codepen)](http://codepen.io/gjn19/pen/VajQyo)