### PR TITLE
Adapt deploy

### DIFF
--- a/deploy/hooks/post-restore
+++ b/deploy/hooks/post-restore
@@ -8,4 +8,25 @@ if [ -x /etc/init.d/apache2 ]; then
     sudo /etc/init.d/apache2 restart
 fi
 
-exit 0
+# We should check if apache is running and return error if it's not
+sleep 5
+sudo /etc/init.d/apache2 status
+
+apache_rc=$?
+
+if [ $apache_rc -ne 0 ]; then
+
+  echo "-----------Deploy Error----------"
+  echo "Apache is not running on the deployed instance. Aborting deployment. Please check  instance"
+  echo "-----------End of Deploy Error----------"
+
+else
+
+  # We wait to assure that varnishes had time to detect running apache again
+  # before we deploy to next instance
+  echo "Waiting 70 seconds before continuing. Give varnish time to rediscover this instance..."
+  sleep 70
+
+fi
+
+exit $apache_rc

--- a/deploy/hooks/post-restore-code
+++ b/deploy/hooks/post-restore-code
@@ -11,13 +11,11 @@ CODE_DIR=$2
 cd $CODE_DIR
 
 # ---------IMPORTANT---------
-# We assume that code deployed does not need re-build on target.
-# It should be rebuild in source machine with correct settings
-
-# On a branch deploy, we rebuild, as we are not coming from
-# a snapshot
+# We rebuild only the minimum on the target machine. We assume
+# that the package was pre-build with the correct environment
 if [ -f rc_$TARGET ]; then
     source rc_$TARGET
+    make apache/app.conf
     if [[ $CODE_DIR == */branch/* ]]; then
         make preparebranch
         if [ -f rc_branch ]; then

--- a/deploy/hooks/post-restore-code
+++ b/deploy/hooks/post-restore-code
@@ -10,6 +10,12 @@ CODE_DIR=$2
 
 cd $CODE_DIR
 
+# ---------IMPORTANT---------
+# We assume that code deployed does not need re-build on target.
+# It should be rebuild in source machine with correct settings
+
+# On a branch deploy, we rebuild, as we are not coming from
+# a snapshot
 if [ -f rc_$TARGET ]; then
     source rc_$TARGET
     if [[ $CODE_DIR == */branch/* ]]; then
@@ -17,8 +23,8 @@ if [ -f rc_$TARGET ]; then
         if [ -f rc_branch ]; then
             source rc_branch
         fi
+        make all
     fi
-    make all
 fi
 
 exit $?


### PR DESCRIPTION
This PR assures 3 things:

1) In worst case, varnish takes 70 seconds before it detects that apache if up again after we deployed to an instance. We therefore wait in the post-restore hook 70 seconds before we continue our deploy to other instances
2) If we detect that Apache is down after 70 seconds, we issue an error and interrupt further deploy onto other machines
3) We don't rebuild the project on all target instances. The idea is the build _for_ the target instances in the snapshot directory and simply rscyn the code to the target instances. This will heavily reduce the downtime of apache on the target machine (from 3+ minutes to <15s)

1) and 2) should be done for mf-chsdi3 deploy as well.

@loicgasser as discussed, please have a look and we can test on integration.
@danduk82 @procrastinatio Your thougths (I know it's sub-optimal process, but it's on the safer side)