### PR TITLE
Triple ol3 cacheSize to mitigate White Tiles effect

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -688,6 +688,9 @@ goog.require('ga_urlutils_service');
                 dimensions: {
                   'Time': timestamp
                 },
+                // Temporary until https://github.com/openlayers/ol3/pull/4964
+                // is merged upstream
+                cacheSize: 2048 * 3,
                 projection: gaGlobalOptions.defaultEpsg,
                 requestEncoding: 'REST',
                 tileGrid: gaTileGrid.get(layer.resolutions,
@@ -736,6 +739,9 @@ goog.require('ga_urlutils_service');
                 var subdomains = dfltWmsSubdomains;
                 olSource = layer.olSource = new ol.source.TileWMS({
                   urls: getImageryUrls(getWmsTpl(layer.wmsUrl), subdomains),
+                  // Temporary until https://github.com/openlayers/ol3/pull/4964
+                  // is merged upstream
+                  cacheSize: 2048 * 3,
                   params: wmsParams,
                   gutter: layer.gutter || 0,
                   crossOrigin: crossOrigin,


### PR DESCRIPTION
This is a temporary fix for https://github.com/geoadmin/mf-geoadmin3/issues/3206 until https://github.com/openlayers/ol3/pull/4964 is merged upstream in ol3.

It reduces the likelyhood of running into our famous white tiles problem.

Thanks alot @ahocevar for finding it in ol3 and making it reproducable, @fredj for fixing it and @loicgasser for the hint.