### PR TITLE
Replace corrupted integration instance

### DIFF
--- a/deploy/deploy-branch.mako.cfg
+++ b/deploy/deploy-branch.mako.cfg
@@ -19,7 +19,8 @@ dest = /var/www/vhosts/mf-geoadmin3/conf/00-${git_branch}.conf
 content = Include /var/www/vhosts/mf-geoadmin3/private/branch/${git_branch}/apache/*.conf
 
 [remote_hosts]
-int = ip-10-220-6-119.eu-west-1.compute.internal
+int = ip-10-220-6-221.eu-west-1.compute.internal,
+      ip-10-220-6-41.eu-west-1.compute.internal
 
 demo = ip-10-220-5-174.eu-west-1.compute.internal
 

--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -20,7 +20,7 @@ content = Include /var/www/vhosts/mf-geoadmin3/private/geoadmin/apache/*.conf
 
 [remote_hosts]
 # mf0i
-int = ip-10-220-6-119.eu-west-1.compute.internal,
+int = ip-10-220-6-221.eu-west-1.compute.internal,
       ip-10-220-6-41.eu-west-1.compute.internal
 
 # mf0p


### PR DESCRIPTION
An integration instance was corrupted yesterday evening during EBS updates.

This PR replaces it in the deploy configuration.

@cedricmoullet Quick merge, if possible.