### PR TITLE
Adapt build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@
 /prd
 /.build-artefacts
 /apache/app.conf
-/test/karma-conf-dev.js
-/test/karma-conf-prod.js
+/test/karma-conf-*.js
 /deploy/deploy-branch.cfg
 /src/locales/*.csv
 /scripts/00-*.conf

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ GIT_BRANCH := $(shell if [ -f .build-artefacts/deployed-git-branch ]; then cat .
 GIT_LAST_BRANCH := $(shell if [ -f .build-artefacts/last-git-branch ]; then cat .build-artefacts/last-git-branch 2> /dev/null; else echo 'dummy'; fi)
 BRANCH_TO_DELETE ?=
 DEPLOY_ROOT_DIR := /var/www/vhosts/mf-geoadmin3/private/branch
+DEPLOYCONFIG ?=
 DEPLOY_TARGET ?= 'dev'
 LAST_DEPLOY_TARGET := $(shell if [ -f .build-artefacts/last-deploy-target ]; then cat .build-artefacts/last-deploy-target 2> /dev/null; else echo '-none-'; fi)
 OL3_VERSION ?= 34d8d77344ee0b653770f065c593d4ab7b5d102b # master, 2 mars 2016
@@ -182,11 +183,11 @@ deploydemo: guard-SNAPSHOT
 
 .PHONY: deployint
 deployint: guard-SNAPSHOT
-	./scripts/deploysnapshot.sh $(SNAPSHOT) int
+	./scripts/deploysnapshot.sh $(SNAPSHOT) int $(DEPLOYCONFIG)
 
 .PHONY: deployprod
 deployprod: guard-SNAPSHOT
-	./scripts/deploysnapshot.sh $(SNAPSHOT) prod
+	./scripts/deploysnapshot.sh $(SNAPSHOT) prod $(DEPLOYCONFIG)
 
 .PHONY: deploybranch
 deploybranch: deploy/deploy-branch.cfg $(DEPLOY_ROOT_DIR)/$(GIT_BRANCH)/.git/config

--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,13 @@ help:
 	@echo
 	@echo "Possible targets:"
 	@echo
-	@echo "- prod               Build app for prod (/prd)"
-	@echo "- dev                Build app for dev (/src)"
+	@echo "- release            Build app for release (/prd)"
+	@echo "- debug              Build app for debug (/src)"
 	@echo "- lint               Run the linter"
 	@echo "- lintpy             Run the linter for the python files"
 	@echo "- autolintpy         Run the auto-corrector for python files"
-	@echo "- testdev            Run the JavaScript tests in dev mode"
-	@echo "- testprod           Run the JavaScript tests in prod mode"
+	@echo "- testdebug          Run the JavaScript tests in debug mode"
+	@echo "- testrelease        Run the JavaScript tests in release mode"
 	@echo "- teste2e            Run browserstack and saucelabs tests"
 	@echo "- browserstack       Run browserstack tests"
 	@echo "- saucelabs          Run saucelabs tests"
@@ -111,10 +111,10 @@ help:
 	@echo
 
 .PHONY: all
-all: lint dev prod apache testdev testprod deploy/deploy-branch.cfg fixrights
+all: lint debug release apache testdebug testrelease deploy/deploy-branch.cfg fixrights
 
-.PHONY: prod
-prod: devlibs \
+.PHONY: release
+release: devlibs \
 	prd/lib/ \
 	prd/lib/build.js \
 	prd/style/app.css \
@@ -129,8 +129,8 @@ prod: devlibs \
 	prd/cache/ \
 	prd/robots.txt
 
-.PHONY: dev
-dev: devlibs src/deps.js src/style/app.css src/index.html src/mobile.html src/embed.html
+.PHONY: debug
+debug: devlibs src/deps.js src/style/app.css src/index.html src/mobile.html src/embed.html
 
 .PHONY: lint
 lint: devlibs .build-artefacts/lint.timestamp
@@ -143,13 +143,13 @@ lintpy: ${FLAKE8_CMD}
 autolintpy: ${AUTOPEP8_CMD}
 	${AUTOPEP8_CMD} --in-place --aggressive --aggressive --verbose --max-line-lengt=110 $(PYTHON_FILES)
 
-.PHONY: testdev
-testdev: .build-artefacts/app-whitespace.js test/karma-conf-dev.js 
-	PHANTOMJS_BIN="node_modules/.bin/phantomjs" ./node_modules/.bin/karma start test/karma-conf-dev.js --single-run
+.PHONY: testdebug
+testdebug: .build-artefacts/app-whitespace.js test/karma-conf-debug.js 
+	PHANTOMJS_BIN="node_modules/.bin/phantomjs" ./node_modules/.bin/karma start test/karma-conf-debug.js --single-run
 
-.PHONY: testprod
-testprod: prd/lib/build.js test/karma-conf-prod.js devlibs
-	PHANTOMJS_BIN="node_modules/.bin/phantomjs" ./node_modules/.bin/karma start test/karma-conf-prod.js --single-run
+.PHONY: testrelease
+testrelease: prd/lib/build.js test/karma-conf-release.js devlibs
+	PHANTOMJS_BIN="node_modules/.bin/phantomjs" ./node_modules/.bin/karma start test/karma-conf-release.js --single-run
 
 .PHONY: teste2e
 teste2e: saucelabs 
@@ -496,10 +496,10 @@ apache/app.conf: apache/app.mako-dot-conf \
 	    --var "apache_base_directory=$(APACHE_BASE_DIRECTORY)" \
 	    --var "version=$(VERSION)" $< > $@
 
-test/karma-conf-dev.js: test/karma-conf.mako.js ${MAKO_CMD}
+test/karma-conf-debug.js: test/karma-conf.mako.js ${MAKO_CMD}
 	${PYTHON_CMD} ${MAKO_CMD} $< > $@
 
-test/karma-conf-prod.js: test/karma-conf.mako.js ${MAKO_CMD}
+test/karma-conf-release.js: test/karma-conf.mako.js ${MAKO_CMD}
 	${PYTHON_CMD} ${MAKO_CMD} --var "mode=prod" $< > $@
 
 test/lib/angular-mocks.js test/lib/expect.js test/lib/sinon.js externs/angular.js externs/jquery.js: package.json

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 SRC_JS_FILES := $(shell find src/components src/js -type f -name '*.js')
 SRC_JS_FILES_FOR_COMPILER = $(shell sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/ --js /g' .build-artefacts/js-files | sed 's/^.*base\.js //')
 SRC_LESS_FILES := $(shell find src -type f -name '*.less')
@@ -49,6 +50,7 @@ DEFAULT_EPSG_EXTEND ?= '[420000, 30000, 900000, 350000]'
 DEFAULT_ELEVATION_MODEL ?= COMB
 DEFAULT_TERRAIN ?= ch.swisstopo.terrain.3d
 SAUCELABS_TESTS ?=
+USER_SOURCE ?= rc_user
 
 ## Python interpreter can't have space in path name
 ## So prepend all python scripts with python cmd
@@ -70,6 +72,8 @@ help:
 	@echo
 	@echo "Possible targets:"
 	@echo
+	@echo "- user               Build the app with user specific configuration"
+	@echo "- all                Build the app with current environment"
 	@echo "- release            Build app for release (/prd)"
 	@echo "- debug              Build app for debug (/src)"
 	@echo "- lint               Run the linter"
@@ -83,7 +87,6 @@ help:
 	@echo "- saucelabssingle    Run saucelabs tests but only with single platform/browser"
 	@echo "- apache             Configure Apache (restart required)"
 	@echo "- fixrights          Fix rights in common folder"
-	@echo "- all                All of the above (target to run prior to creating a PR)"
 	@echo "- clean              Remove generated files"
 	@echo "- cleanall           Remove all the build artefacts"
 	@echo "- deploydev          Deploys current github master to dev. Specify SNAPSHOT=true to create snapshot as well."
@@ -109,6 +112,10 @@ help:
 	@echo "- APACHE_BASE_DIRECTORY       (build with: $(LAST_APACHE_BASE_DIRECTORY), current value: $(APACHE_BASE_DIRECTORY))"
 
 	@echo
+
+.PHONY: user
+user:
+	source $(USER_SOURCE) && make all
 
 .PHONY: all
 all: lint debug release apache testdebug testrelease deploy/deploy-branch.cfg fixrights

--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ or when you're using ssh key (see https://help.github.com/articles/generating-ss
 
     $ git clone git@github.com:geoadmin/mf-geoadmin3.git
 
-Build:
+There's no need to create a user specific source file. Simply use the following
+build command:
 
-    $ make all
+    $ make user
+
+Variables have sensible default values for development. Anyhow, they can be set as make macros or envvars in a customized source file. E.G. you can copy the rc_user file and adapt it to your needs. They you can lauch:
+
+    $ source rc_customized && make all
 
 Use `make help` to know about the possible `make` targets and the currently set variables:
 
@@ -27,21 +32,6 @@ Use `make translate` to import directly translations from the Google spreadsheet
     
     export DRIVE_USER=your_login
     export DRIVE_PWD=your_password
-
-Variables have sensible default values for development. Anyhow, they can be set as make macros or envvars. For example:
-
-    $ make APACHE_BASE_PATH=/elemoine apache 
-    $ APACHE_BASE_PATH=/elemoine make 
-
-You can customize the build by creating an `rc` file that you source once. Ex:  
-
-    $ cat rc_elemoine 
-    export APACHE_BASE_PATH=/mypath
-    export APACHE_BASE_DIRECTORY=/home/elemoine/mf-geoadmin3
-    export API_URL=//mf-chsdi.3dev.bgdi.ch
-    export DEPLOY_TARGET=dev
-    $ source rc_elemoine 
-    $ make  
 
 For builds on test (rc_dev), integration (rc_int) and production (rc_prod), you
 should source the corresponding `rc` file.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ This will do the corresponding thing for prod:
 
 `make deployprod SNAPSHOT=201407031411`
 
+Per default the deploy command uses the deploy configuration of the snapshot directory.
+If you want to use the deploy configuration of directory from which you are executing this command, you can use:
+
+`make deployint SNAPSHOT=201512011411 DEPLOYCONFIG=from_current_directory`
 
 Note: we should NOT manually adapt code in /var/www/vhosts/mf-geoadmin3 directory
 

--- a/rc_fredj
+++ b/rc_fredj
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/fredj
-export APACHE_BASE_PATH=/fredj
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/fredj

--- a/rc_ltalp
+++ b/rc_ltalp
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltalp
-export APACHE_BASE_PATH=/ltalp
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltalp

--- a/rc_ltclm
+++ b/rc_ltclm
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltclm
-export APACHE_BASE_PATH=/ltclm
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltclm

--- a/rc_ltfap
+++ b/rc_ltfap
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltfap
-export APACHE_BASE_PATH=/ltfap
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltfap

--- a/rc_ltfoa
+++ b/rc_ltfoa
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltfoa
-export APACHE_BASE_PATH=/ltfoa
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltfoa

--- a/rc_ltfrr
+++ b/rc_ltfrr
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltfrr
-export APACHE_BASE_PATH=/ltfrr
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltfrr

--- a/rc_ltgal
+++ b/rc_ltgal
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltgal
-export APACHE_BASE_PATH=/ltgal
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltgal

--- a/rc_ltgud
+++ b/rc_ltgud
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltgud
-export APACHE_BASE_PATH=/ltgud
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltgud

--- a/rc_ltjeg
+++ b/rc_ltjeg
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltjeg
-export APACHE_BASE_PATH=/ltjeg
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltjeg

--- a/rc_ltkan
+++ b/rc_ltkan
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltkan
-export APACHE_BASE_PATH=/ltkan
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltkan

--- a/rc_ltmoc
+++ b/rc_ltmoc
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltmoc
-export APACHE_BASE_PATH=/ltmoc
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltmoc

--- a/rc_ltmom
+++ b/rc_ltmom
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltmom
-export APACHE_BASE_PATH=/ltmom
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltmom

--- a/rc_ltpoa
+++ b/rc_ltpoa
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltpoa
-export APACHE_BASE_PATH=/ltpoa
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltpoa

--- a/rc_ltteo
+++ b/rc_ltteo
@@ -1,3 +1,0 @@
-export API_URL=//mf-chsdi3.dev.bgdi.ch/ltteo
-export APACHE_BASE_PATH=/ltteo
-export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/ltteo

--- a/rc_user
+++ b/rc_user
@@ -1,0 +1,4 @@
+export USERNAME='$(shell whoami)'
+export API_URL=//mf-chsdi3.dev.bgdi.ch/$USERNAME
+export APACHE_BASE_PATH=/$USERNAME
+export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch/$USERNAME

--- a/scripts/deploysnapshot.sh
+++ b/scripts/deploysnapshot.sh
@@ -36,11 +36,19 @@ if [ ! "${answer}" == "y" ]; then
   exit 1
 fi
 
+# Deterimine which deploy configuration to use
+if [ -z $3 ] || [ $3 != "from_current_directory" ]
+then
+  echo "Using snapshot deploy configuration"
+  DEPLOYCONFIG=$SNAPSHOTDIR_CODE/deploy/deploy.cfg
+else
+  echo "Using local deploy configuration"
+  DEPLOYCONFIG=deploy/deploy.cfg
+fi
+
 cd $cwd
 
-
-
-sudo -u deploy deploy -r deploy/deploy.cfg $2 $SNAPSHOTDIR
+sudo -u deploy deploy -r $DEPLOYCONFIG $2 $SNAPSHOTDIR
 
 VARNISH_FLUSH_FILE=rc_int
 

--- a/test/karma-conf.mako.js
+++ b/test/karma-conf.mako.js
@@ -3,7 +3,7 @@
 module.exports = function(config) {
   config.set({
   // base path, that will be used to resolve files and exclude
-  % if mode == 'prod':
+  % if mode == 'release':
      basePath: '../prd',
   % else:
      basePath: '../src',
@@ -11,7 +11,7 @@ module.exports = function(config) {
 
   // list of files / patterns to load in the browser
   files: [
-    % if mode == 'prod':
+    % if mode == 'release':
        'lib/build.js',
     % else:
        'lib/jquery.js',
@@ -44,7 +44,7 @@ module.exports = function(config) {
 
 
   preprocessors: {
-    // In both prod mode (build.js) and dev mode (app-whitespace.js) the
+    // In both release mode (build.js) and debug mode (app-whitespace.js) the
     // partials are pre-cached in Angular's $templateCache. So we don't
     // need to use Karma's html2js preprocessor, and cache partials in
     // tests using ngMock's "module" function.


### PR DESCRIPTION
This PR adapts the current build to better refelct the build in mf-chsdi3. It does

1) Deploy targets are taken per default from snapshot directory now (as in chsdi3)
2) Renaming of make targets to not confuse build targets and staging targets `debug` and `testdebug` instead of `dev` and `testdev`. `release` and `testrelease` instead of `prod` and `testprod`
3) Add a `make user` target as the main target to be used by the developers (as in chsdi3)

[Testlinkg](ttps://mf-geoadmin3.dev.bgdi.ch/gjn_build/) shows that a fresh checkout build does work find.

We specifcy the bash shell as the default shell in the `Makefile` now (to support `source` command), which is the only thing with _potential_ side effects. But I didn't find any.

@oterral @loicgasser Feedback and review welcome.

@davidoesch @cedricmoullet Internal changes - but needed to streamline our main build tool among projects.