### PR TITLE
Add coverage report and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,10 +498,10 @@ apache/app.conf: apache/app.mako-dot-conf \
 	    --var "version=$(VERSION)" $< > $@
 
 test/karma-conf-debug.js: test/karma-conf.mako.js ${MAKO_CMD}
-	${PYTHON_CMD} ${MAKO_CMD} $< > $@
+	${PYTHON_CMD} ${MAKO_CMD} --var "mode=debug" $< > $@
 
 test/karma-conf-release.js: test/karma-conf.mako.js ${MAKO_CMD}
-	${PYTHON_CMD} ${MAKO_CMD} --var "mode=prod" $< > $@
+	${PYTHON_CMD} ${MAKO_CMD} --var "mode=release" $< > $@
 
 test/lib/angular-mocks.js test/lib/expect.js test/lib/sinon.js externs/angular.js externs/jquery.js: package.json
 	npm install --only=dev;

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,8 @@ autolintpy: ${AUTOPEP8_CMD}
 
 .PHONY: testdebug
 testdebug: .build-artefacts/app-whitespace.js test/karma-conf-debug.js 
-	PHANTOMJS_BIN="node_modules/.bin/phantomjs" ./node_modules/.bin/karma start test/karma-conf-debug.js --single-run
+	PHANTOMJS_BIN="node_modules/.bin/phantomjs" ./node_modules/.bin/karma start test/karma-conf-debug.js --single-run;
+	cat .build-artefacts/coverage.txt; echo;
 
 .PHONY: testrelease
 testrelease: prd/lib/build.js test/karma-conf-release.js devlibs

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "karma": "~0.13.22",
     "karma-mocha": "0.2.2",
     "karma-phantomjs-launcher": "1.0.0",
+    "karma-coverage": "~v0.5.5",
     "sinon": "1.17.3",
     "expect.js": "0.3.1",
     "commander": "2.9.0",

--- a/test/karma-conf.mako.js
+++ b/test/karma-conf.mako.js
@@ -3,38 +3,38 @@
 module.exports = function(config) {
   config.set({
   // base path, that will be used to resolve files and exclude
-  % if mode == 'release':
-     basePath: '../prd',
-  % else:
-     basePath: '../src',
-  % endif
+% if mode == 'release':
+  basePath: '../prd',
+% else:
+  basePath: '../src',
+% endif
 
   // list of files / patterns to load in the browser
   files: [
-    % if mode == 'release':
-       'lib/build.js',
-    % else:
-       'lib/jquery.js',
-       'lib/angular.js',
-       'lib/angular-translate.js',
-       'lib/angular-translate-loader-static-files.js',
-       'lib/bootstrap.js',
-       'lib/typeahead-0.9.3.js',
-       'lib/proj4js-compressed.js',
-       'lib/EPSG21781.js',
-       'lib/EPSG2056.js',
-       'lib/EPSG32631.js',
-       'lib/EPSG32632.js',
-       'lib/Cesium/Cesium.js',
-       '../test/closure-loader-globals.js',
-       'lib/ol3cesium-debug.js',
-       '../.build-artefacts/app-whitespace.js',
-    % endif
-       '../test/lib/angular-mocks.js',
-       '../test/lib/expect.js',
-       '../test/lib/sinon.js',
-       '../test/specs/Loader.spec.js',
-       '../test/specs/**/*.js'
+  % if mode == 'release':
+    'lib/build.js',
+  % else:
+    'lib/jquery.js',
+    'lib/angular.js',
+    'lib/angular-translate.js',
+    'lib/angular-translate-loader-static-files.js',
+    'lib/bootstrap.js',
+    'lib/typeahead-0.9.3.js',
+    'lib/proj4js-compressed.js',
+    'lib/EPSG21781.js',
+    'lib/EPSG2056.js',
+    'lib/EPSG32631.js',
+    'lib/EPSG32632.js',
+    'lib/Cesium/Cesium.js',
+    '../test/closure-loader-globals.js',
+    'lib/ol3cesium-debug.js',
+    '../.build-artefacts/app-whitespace.js',
+  % endif
+    '../test/lib/angular-mocks.js',
+    '../test/lib/expect.js',
+    '../test/lib/sinon.js',
+    '../test/specs/Loader.spec.js',
+    '../test/specs/**/*.js'
   ],
 
 
@@ -49,6 +49,9 @@ module.exports = function(config) {
     // need to use Karma's html2js preprocessor, and cache partials in
     // tests using ngMock's "module" function.
     //'components/**/*.html': 'html2js'
+  % if mode == 'debug':
+    '../.build-artefacts/app-whitespace.js': ['coverage']
+  % endif
   },
 
 
@@ -57,9 +60,25 @@ module.exports = function(config) {
   ],
 
 
-  // test results reporter to use
-  // possible values: 'dots', 'progress', 'junit'
+% if mode == 'debug':
+  coverageReporter: {
+    dir: '../.build-artefacts',
+    includeAllSources: true,
+    reporters: [
+      { type: 'cobertura', subdir: '.', file: 'coverage.xml' },
+      { type: 'text-summary', subdir: '.', file: 'coverage.txt' }
+    ]
+  },
+% endif
+
+
+// test results reporter to use
+// possible values: 'dots', 'progress', 'junit'
+% if mode == 'release':
   reporters: ['progress'],
+% else:
+  reporters: ['coverage', 'progress'],
+% endif
 
 
   // web server port

--- a/test/specs/DebounceService.spec.js
+++ b/test/specs/DebounceService.spec.js
@@ -1,0 +1,31 @@
+describe('ga_debounce_service', function() {
+  var gaDebounce, $timeout;
+
+  beforeEach(function() {
+    inject(function($injector) {
+      gaDebounce = $injector.get('gaDebounce');
+      $timeout = $injector.get('$timeout');
+    });
+  });
+  
+  it('it invoked callback after specified delay', function() {
+    var spy = sinon.spy(function () {});
+    var debounced = gaDebounce.debounce(spy, 100, false, false);
+    debounced()
+    expect(spy.called).to.be(false);
+    $timeout.flush(100);
+    expect(spy.called).to.be(true);
+  });
+
+  it('it wait again if another call arrives during wait', function() {
+    var spy = sinon.spy(function () {});
+    var debounced = gaDebounce.debounce(spy, 100, false, false);
+    debounced();
+    $timeout.flush(99);
+    debounced();
+    $timeout.flush(99);
+    expect(spy.called).to.be(false);
+    $timeout.flush(1);
+    expect(spy.called).to.be(true);
+  });
+});


### PR DESCRIPTION
I was looking into ways to have some kind of metrics about the coverage of our unit tests and found:
https://github.com/karma-runner/karma-coverage

I currently output two coverage reports:

- A text summary file in `.build-artefacts/coverage.txt`
- An xml file in `.build-artefacts/coverage.xml` that we could feed to Jenkins @gjn 

Values before this PR:

Statements   : 32.37% ( 3012/9304 )
Branches     : 18.07% ( 732/4052 )
Functions    : 32.28% ( 593/1837 )
Lines        : 32.37% ( 3012/9304 )

With the addition of some tests on the debounce service we get:

Statements   : 32.5% ( 3024/9304 )
Branches     : 18.19% ( 737/4052 )
Functions    : 32.39% ( 595/1837 )
Lines        : 32.5% ( 3024/9304 )

So we can see a small improvement.
I am still wondering if the coverage report is correct as 9'034 lines seems a bit smaller that what we have in `.build-artefacts/app-whitespace.js` (more like 12'947)