### PR TITLE
Apply patch when slip comes from node modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,6 +526,7 @@ node_modules: package.json
 	cp node_modules/sinon/pkg/sinon.js test/lib/;
 	cp node_modules/google-closure-compiler/contrib/externs/angular-1.4.js externs/angular.js;
 	cp node_modules/google-closure-compiler/contrib/externs/jquery-1.9.js externs/jquery.js;
+	git apply --directory=src/lib scripts/slipjs.patch
 
 .build-artefacts/app.js: .build-artefacts/js-files
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Currently we have a make target `slipjs` which is not required by any other make target.

slipjs is also a package.json dep and when we `npm install` initial debug file gets downloaded as it seems and revert the changes in the debug file.

Related commit:
https://github.com/geoadmin/mf-geoadmin3/commit/9d3e228fae85e2ce3ac04c44834432d705dc4afc#diff-9566e188f62d1912ae8f605cead2ca6c