### PR TITLE
replaced lv03 and wsg84 with lv95 as grid from print checkbox

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -725,7 +725,7 @@ goog.require('ga_time_service');
           'opacity': 1,
           'singleTile': true,
           'type': 'WMS',
-          'layers': ['org.epsg.grid_21781,org.epsg.grid_4326'],
+          'layers': ['org.epsg.grid_2056'],
           'format': 'image/png',
           'styles': [''],
           'customParams': {


### PR DESCRIPTION
this is in response to https://github.com/geoadmin/mf-geoadmin3/issues/3219

Must wait for merge since the lv95 grid layer is not in production yet