### PR TITLE
FF: Assure reloading of page on appcache change

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -394,11 +394,15 @@ goog.require('ga_topic_service');
     }
 
     // An new appcache file is available.
-    if ($window.applicationCache) { // IE9
+    if ($window.applicationCache) {
       $window.applicationCache.addEventListener('obsolete', function(e) {
-        $window.location.reload();
+        // setTimeout is needed for correct appcache update on Firefox
+        setTimeout(function() {
+          $window.location.reload(true);
+        });
       });
     }
+
   });
 })();
 


### PR DESCRIPTION
This improves the update process of the appcache on firefox. With this, the appcache is updated on Firefox without any user interaction. We assume that 1) the appcache file is not cached in browser (older versions of appcache might trigger this, see history section of https://github.com/geoadmin/mf-geoadmin3/issues/3246) and that the internet connection is solid.

It might not fix all troubles we have, but some.

See https://github.com/geoadmin/mf-geoadmin3/issues/3246 for a deeper analysis.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_appcache99/)