### PR TITLE
Simplify targets and update slipjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "d3": "3.5.12",
     "fastclick": "1.0.6",
     "bootstrap": "3.3.6",
-    "slipjs": "pornel/slip#0626afc"
+    "slipjs": "1.4.0"
   },
   "devDependencies": {
     "less": "~2.6.1",

--- a/scripts/fastclick.patch
+++ b/scripts/fastclick.patch
@@ -9,10 +9,10 @@ If, for some reasons, the touchstart event is stopped by some third party librar
  lib/fastclick.js |    5 +++++
  1 file changed, 5 insertions(+)
 
-diff --git a/lib/fastclick.js b/lib/fastclick.js
+diff --git a/fastclick.js b/fastclick.js
 index 3af4f9d..ad4f2bd 100644
---- a/lib/fastclick.js
-+++ b/lib/fastclick.js
+--- a/fastclick.js
++++ b/fastclick.js
 @@ -521,6 +521,11 @@
  	FastClick.prototype.onTouchEnd = function(event) {
  		var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;

--- a/scripts/slipjs.patch
+++ b/scripts/slipjs.patch
@@ -1,13 +1,13 @@
 diff --git a/slip.js b/slip.js
-index 9c5e3aa..6f15743 100644
+index 9e21c6f..2d402fb 100644
 --- a/slip.js
 +++ b/slip.js
 @@ -236,7 +236,7 @@ window['Slip'] = (function(){
  
              undecided: function undecidedStateInit() {
                  this.target.height = this.target.node.offsetHeight;
--                this.target.node.style.willChange = transformProperty;
-+                //this.target.node.style.willChange = transformProperty;
-                 this.target.node.style[transitionPrefix] = '';
+-                this.target.node.style.willChange = transformCSSPropertyName;
++                //this.target.node.style.willChange = transformCSSPropertyName;
+                 this.target.node.style[transitionJSPropertyName] = '';
  
                  if (!this.dispatch(this.target.originalTarget, 'beforewait')) {


### PR DESCRIPTION
Modification of @loicgasser PR https://github.com/geoadmin/mf-geoadmin3/pull/3234 according to comments of @gjn .


I've added a `devlibs`  and `libs` target 

The `libs` (old `node_modules_prod`) target forces a `npm install --prod` command and update the js librairies in `src/lib` 
The `devlibs` target uses `npm install --dev` only if a dev file (`externs/[angular|jquery].js` or `test/lib/*.js`) doesn't exist.


The `devlibs` allows to run multiple  `make dev` or `make prod ` without running npm install each time.


@loicgasser @gjn what do you think? 