### PR TITLE
Add translation parameter to wms request

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -713,7 +713,8 @@ goog.require('ga_urlutils_service');
           } else if (layer.type == 'wms') {
             var wmsParams = {
               LAYERS: layer.wmsLayers,
-              FORMAT: 'image/' + layer.format
+              FORMAT: 'image/' + layer.format,
+              LANG: gaLang.get()
             };
             if (timestamp) {
               wmsParams['TIME'] = timestamp;


### PR DESCRIPTION
To have translated labels of wms services. That's a quick fix, and doesn't react on language changes by the user.