### PR TITLE
Switch back to locations indices for search

### DIFF
--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -331,7 +331,7 @@ goog.require('ga_urlutils_service');
 
             // Can be removed onnce real type contains gazetter
             $scope.typeSpecificUrl = function(url) {
-              return url.replace('type=locations', 'type=locations_preview');
+              return url;
             };
 
             $scope.select = function(res) {


### PR DESCRIPTION
Switch back to using the officla `locations` search type. `locations_preview` will be deprecated in a couple of weeks.


This needs https://github.com/geoadmin/service-sphinxsearch/pull/261 to be merged and deployed first. This was done in `dev`.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_locations)
