### PR TITLE
Use safari on OS, version 9.0 (with smal screen reslolution)

### DIFF
--- a/test/saucelabs/test.py
+++ b/test/saucelabs/test.py
@@ -87,8 +87,8 @@ if __name__ == '__main__':
         {'platform': "Windows 7", 'browserName': "opera",
             'version': "12.12", 'screenResolution': "1280x1024"},
         # Safari
-        {'platform': "Windows 7", 'browserName': "safari",
-            'version': "5.1", 'screenResolution': "1280x1024"}
+        {'platform': "OS X 10.11", 'browserName': "safari",
+            'version': "9.0", 'screenResolution': "1024x768"}
     ]
 
     config_test_list = {


### PR DESCRIPTION
I see that safari's test are failed this night. Check with configurator [1] to use a more recent version of this browser on OS. Change also screen resolution because "1280x1024" was not supported.

[1] https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/