### PR TITLE
Use regex to remove also the comma when needed

### DIFF
--- a/src/components/draw/DrawDirective.js
+++ b/src/components/draw/DrawDirective.js
@@ -647,8 +647,9 @@ goog.require('ga_permalink');
             }).success(function(data) {
               scope.userShortenUrl = data.shorturl;
             });*/
-            scope.adminShortenUrl = gaPermalink.getHref().replace(
-                gaUrlUtils.encodeUriQuery(layer.id, true), '') +
+            var regex = new RegExp(',{0,1}' +
+                gaUrlUtils.encodeUriQuery(layer.id, true));
+            scope.adminShortenUrl = gaPermalink.getHref().replace(regex, '') +
                 '&adminId=' + adminId;
             scope.userShortenUrl = gaPermalink.getHref();
           };


### PR DESCRIPTION
fix #3275 

[test](https://mf-geoadmin3.dev.bgdi.ch/teo_comma/?topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-grau&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.swisstlm3d-wanderwege,KML||http:%2F%2Fgeoshare.impulsthun.ch%2Fkml%2Fimpuls.kml&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&X=178268.93&Y=614662.68&zoom=11&adminId=iZcLy04ISX6okEuwZYDk7Q)