### PR TITLE
Add MAP_RESOLUTION parameter for print WMS layers

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -433,7 +433,8 @@ goog.require('ga_time_service');
                 'EXCEPTIONS': 'XML',
                 'TRANSPARENT': 'true',
                 'CRS': 'EPSG:21781',
-                'TIME': params.TIME
+                'TIME': params.TIME,
+                'MAP_RESOLUTION': getDpi($scope.layout.name, $scope.dpi)
               },
               singleTile: config.singleTile || false
             });
@@ -729,7 +730,8 @@ goog.require('ga_time_service');
           'format': 'image/png',
           'styles': [''],
           'customParams': {
-            'TRANSPARENT': true
+            'TRANSPARENT': true,
+            'MAP_RESOLUTION': getDpi($scope.layout.name, $scope.dpi)
           }
         };
         encLayers.push(graticule);


### PR DESCRIPTION
This PR addresses an issue we have when printing WMS layers. Per default, the printserver sends a `DPI` parameter along with the WMS request. But this parameter is ignored by our WMS server.

Instead, we need to use the `MAP_RESOLUTION` parameter, which our wms is supporting. This PR adds this parameter. 

For the description of the effect, please see https://github.com/geoadmin/mf-geoadmin3/issues/3208

Note: this change only affects WMS layers.

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_print_wms/?topic=ech&lang=de&bgLayer=voidLayer&layers=ch.bfe.sachplan-geologie-tiefenlager,ch.swisstopo.geologie-gisgeol-punkte&X=243520.00&Y=644240.00&zoom=5&layers_opacity=0.75,1)

Here's how it looks in the browser:
![image](https://cloud.githubusercontent.com/assets/2572317/14491976/64a09ba4-017c-11e6-9e0c-883c0b40a4e1.png)

Here's how it looks with current print in the pdf:
![image](https://cloud.githubusercontent.com/assets/2572317/14491988/797e071e-017c-11e6-99d7-e6b2718c4f5b.png)

Here's how it looks with this PR in the pdf:
![image](https://cloud.githubusercontent.com/assets/2572317/14492018/b4f8ff2e-017c-11e6-8863-9693c0ba7c0f.png)

The new version resembles better the image in the browser. The icons and line widths have the correct pixel sizes.

@davidoesch @procrastinatio @ltclm Thoughts on this?