### PR TITLE
fix landscape orientation for ios

### DIFF
--- a/src/components/geolocation/GeolocationDirective.js
+++ b/src/components/geolocation/GeolocationDirective.js
@@ -109,8 +109,32 @@ goog.require('ga_throttle_service');
         // Get heading depending on devices
         var headingFromDevices = function() {
           var hdg = deviceOrientation.getHeading();
+          var orientation = $window.orientation;
           if (!gaBrowserSniffer.ios) {
             hdg = -hdg;
+            if ($window.screen.orientation.angle) {
+              orientation = $window.screen.orientation.angle;
+            }
+          }
+          switch (orientation) {
+            case -90:
+              hdg = hdg - (Math.PI / 2);
+              break;
+
+            case 180:
+              hdg = hdg + Math.PI;
+              break;
+
+            case 90:
+              hdg = hdg + (Math.PI / 2);
+              break;
+
+            case 270:
+              hdg = hdg - (Math.PI / 2);
+              break;
+
+            default:
+              hdg = hdg;
           }
           return hdg;
         };


### PR DESCRIPTION
@gjn I found a way to fix the orientation of the arrow according to the orientation of the device with ios, but I couldn't find something for the other os.. Since I am stuck with this for some time, I create a PR for this and try to come back to the otehr os later.
Linked to: https://github.com/geoadmin/mf-geoadmin3/issues/3204