### PR TITLE
Use a common function to get the timeInstant param

### DIFF
--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -55,7 +55,7 @@ goog.require('ga_urlutils_service');
       '<div class="ga-layer-timestamps">' +
         '<div tabindex="1" ng-if="tmpLayer.type == \'wms\'" ' +
              'ng-class="{badge: !tmpLayer.time}" ' +
-             'ng-click="setLayerTime(tmpLayer, null)" ' +
+             'ng-click="setLayerTime(tmpLayer)" ' +
              'translate>time_all</div> ' +
         '<div tabindex="1" ng-repeat="i in tmpLayer.timestamps" ' +
              'ng-class="{badge: (tmpLayer.time == i)}" ' +
@@ -296,9 +296,7 @@ goog.require('ga_urlutils_service');
         };
 
         scope.setLayerTime = function(layer, time) {
-          if (angular.isDefined(time)) {
-            layer.time = time;
-          }
+          layer.time = time;
           destroyPopover(null, element);
         };
 

--- a/src/components/layermanager/partials/layermanager.html
+++ b/src/components/layermanager/partials/layermanager.html
@@ -19,7 +19,6 @@
         </button>
         <select ng-if="mobile"
                 ng-model="layer.time"
-                ng-change="setLayerTime(layer)"
                 ng-options="(i | gaTimeLabel:layer) for i in layer.timestamps"></select>
       </div>
       <button class="ga-icon ga-btn fa fa-user"

--- a/src/components/timeselector/TimeService.js
+++ b/src/components/timeselector/TimeService.js
@@ -122,6 +122,18 @@ goog.require('ga_permalink_service');
           }
         };
        };
+
+       // Returns the year (as integer) from a complete timestmap
+       // (ex: 1999:12:31).
+       // Returns undefined when timestamp is 'current' or '99991231
+       this.getYearFromTimestamp = function(timestamp) {
+         if (timestamp && timestamp.length) {
+          timestamp = parseInt(timestamp.substr(0, 4));
+          if (timestamp <= new Date().getFullYear()) {
+            return timestamp;
+          }
+        }
+       };
        return new Time();
     };
   });

--- a/src/components/timeselector/TimeService.js
+++ b/src/components/timeselector/TimeService.js
@@ -121,20 +121,20 @@ goog.require('ga_permalink_service');
             $rootScope.$broadcast('gaTimeChange', time, oldTime);
           }
         };
-       };
 
-       // Returns the year (as integer) from a complete timestmap
-       // (ex: 1999:12:31).
-       // Returns undefined when timestamp is 'current' or '99991231
-       this.getYearFromTimestamp = function(timestamp) {
-         if (timestamp && timestamp.length) {
-          timestamp = parseInt(timestamp.substr(0, 4));
-          if (timestamp <= new Date().getFullYear()) {
-            return timestamp;
+        // Returns the year (as integer) from a complete timestmap
+        // (ex: 1999:12:31).
+        // Returns undefined when timestamp is 'current' or '99991231
+        this.getYearFromTimestamp = function(timestamp) {
+          if (timestamp && timestamp.length) {
+            timestamp = parseInt(timestamp.substr(0, 4));
+            if (timestamp <= new Date().getFullYear()) {
+              return timestamp;
+            }
           }
-        }
-       };
-       return new Time();
+        };
+      };
+      return new Time();
     };
   });
 })();

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -79,16 +79,6 @@ goog.require('ga_topic_service');
           return layersToQuery;
         };
 
-        // Return a year as number from a timestamp string
-        var yearFromString = function(timestamp) {
-          if (timestamp && timestamp.length) {
-            timestamp = parseInt(timestamp.substr(0, 4));
-            if (timestamp <= new Date().getFullYear()) {
-              return timestamp;
-            }
-          }
-        };
-
         // Test if a feature is queryable.
         var isFeatureQueryable = function(feature) {
           return feature && feature.get('name') || feature.get('description');
@@ -385,7 +375,7 @@ goog.require('ga_topic_service');
                   // Only timeEnabled layers use the timeInstant parameter
                   if (layerToQuery.timeEnabled) {
                     params.timeInstant = gaTime.get() ||
-                        yearFromString(layerToQuery.time);
+                        gaTime.getYearFromTimestamp(layerToQuery.time);
                   }
 
                   all.push($http.get(identifyUrl, {


### PR DESCRIPTION
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fixes/?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter,ch.bafu.schutzgebiete-paerke_nationaler_bedeutung,ch.bafu.showme-kantone_sturzprozesse,ch.bafu.showme-kantone_rutschungen,ch.bafu.showme-kantone_lawinen,ch.bafu.showme-kantone_hochwasser,ch.bafu.showme-gemeinden_sturzprozesse,ch.bafu.showme-gemeinden_rutschungen,ch.bafu.showme-gemeinden_lawinen,ch.bafu.showme-gemeinden_hochwasser,ch.swisstopo.geologie-geologischer_atlas,ch.swisstopo.geologie-geocover,ch.swisstopo.geologie-generalkarte-ggk200,ch.swisstopo.pixelkarte-farbe-pk500.noscale&layers_opacity=0.85,0.85,0.75,0.75,0.75,0.75,0.75,0.75,0.75,0.75,1,0.75,1,1&layers_visibility=false,false,false,false,false,false,false,false,false,false,false,false,true,true&X=206368.35&Y=649611.89&zoom=1)