### PR TITLE
Adding query token analysis to search input box

### DIFF
--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -71,7 +71,8 @@ goog.require('ga_translation_service');
   module.controller('GaSearchDirectiveController',
     function($scope, $rootScope, $sce, $timeout, gaPermalink,
              gaUrlUtils, gaSearchGetCoordinate, gaMapUtils, gaMarkerOverlay,
-             gaKml, gaPreviewLayers, gaLang, gaTopic, gaLayers) {
+             gaKml, gaPreviewLayers, gaLang, gaTopic, gaLayers,
+             gaSearchTokenAnalyser) {
       var blockQuery = false;
       var restat = new ResultStats();
       $scope.restat = restat;
@@ -106,6 +107,7 @@ goog.require('ga_translation_service');
       };
 
       $scope.query = '';
+      $scope.childoptions.searchUrl = '';
       $scope.childoptions.query = '';
 
       $scope.clearInput = function() {
@@ -113,6 +115,7 @@ goog.require('ga_translation_service');
         gaMarkerOverlay.remove($scope.map);
         gaPreviewLayers.removeAll($scope.map);
         $scope.query = '';
+        $scope.childoptions.searchUrl = '';
         $scope.childoptions.query = '';
         $scope.input.blur();
       };
@@ -152,16 +155,22 @@ goog.require('ga_translation_service');
                                 [position, position], true);
           } else {
             // Standard query then
+            var tokenized = gaSearchTokenAnalyser.run(q);
+            q = tokenized.query;
             var url = gaUrlUtils.append($scope.options.searchUrl,
                                         'searchText=' + encodeURIComponent(q));
+            for (var i = 0; i < tokenized.parameters.length; i++) {
+              url = gaUrlUtils.append(url, tokenized.parameters[i]);
+            }
             url = gaUrlUtils.append(url, 'lang=' + gaLang.get());
             url = url.replace('{Topic}', gaTopic.get().id);
 
-            $scope.childoptions.baseUrl = url;
+            $scope.childoptions.searchUrl = url;
             $scope.childoptions.query = q;
           }
         } else {
           blockQuery = false;
+          $scope.childoptions.searchUrl = '';
           $scope.childoptions.query = '';
         }
       };

--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -190,7 +190,48 @@ goog.provide('ga_search_service');
     };
   });
 
+  module.provider('gaSearchTokenAnalyser', function() {
 
+    var tokenlist = ['limit', 'origins'];
+    var regs = {};
+
+    for (var i = 0; i < tokenlist.length; i++) {
+      var tk = tokenlist[i];
+      regs[tk] = {
+        tk: tk,
+        list: new RegExp('(^ *' + tk + ': *\\w+|\\s+' + tk + ': *\\w+)', 'i'),
+        value: new RegExp(tk + ': *(\\w+)', 'i')
+      };
+    }
+
+    var apply = function(input, regs) {
+      var res = regs.list.exec(input.query);
+      if (res && res.length) {
+        var value = regs.value.exec(res[0]);
+        if (value && value.length >= 2) {
+          input.parameters.push(regs.tk + '=' + value[1]);
+        }
+        //Strip token and value from query
+        input.query = input.query.replace(res[0], '');
+      }
+    };
+
+    this.$get = function() {
+
+      return {
+        run: function(q) {
+          var res = {
+            query: q,
+            parameters: []
+          };
+          for (var reg in regs) {
+            apply(res, regs[reg]);
+          }
+          return res;
+        }
+      };
+    };
+  });
 
 })();
 

--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -215,7 +215,7 @@ goog.require('ga_urlutils_service');
 
         canceler = $q.defer();
 
-        var url = gaUrlUtils.append($scope.options.baseUrl,
+        var url = gaUrlUtils.append($scope.options.searchUrl,
                                     'type=' + $scope.type);
         url = $scope.typeSpecificUrl(url);
 
@@ -300,7 +300,7 @@ goog.require('ga_urlutils_service');
 
       $scope.fuzzy = '';
 
-      $scope.$watch('options.query', function(newval) {
+      $scope.$watch('options.searchUrl', function(newval) {
         //cancel old requests
         cancel();
         if (newval != '') {

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -216,6 +216,10 @@ itemscope itemtype="http://schema.org/WebApplication"
         </div>
         <div ng-show="time">{{time}}</div>
       </a>
+      <div id="search-container" ng-controller="GaSearchController">
+        <div ga-search ga-search-map="map" ga-search-options="options" ga-search-ol3d="::ol3d"></div>
+      </div>
+
       <div ga-scale-line ga-scale-line-map="map" ng-show="!globals.is3dActive"></div>
   % endif
 

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -1742,6 +1742,11 @@ body:not(.embed) {
 }
 
 .embed {
+
+  #search-container {
+    display: none;
+  }
+
   #bigMapLink {
     position: absolute;
     z-index: 1000;


### PR DESCRIPTION
[Our search service](http://api3.geo.admin.ch/services/sdiservices.html#search) offers some parameters that are not accessible by the user via the search box in map.geo.admin.ch

This PR tries to address this by adding search tokens to the input box that directly translate to parameters to the search engine that is behind it. Currently, the `limit:` and `origins:` tokens are supported. With it, you can specify the `limit` and `origins` parameter to the search. Tokens can be combined. Other tokes might be added.

This is geared towards power users. It's similar as google search wheren you can filter your search with search tokens. To use it, the user has to specify the token, a colon and a value. For example adding `limit: 1` in the search box, will limit the results to exactly 1.

As we use the searchbox as the driver behind the `swisssearch` permalink parameter, this also works using the `swisssearch` parameters. The swisssearch parameter does not currently work in embed because the searchbox is missing. This PR also adds a hidden searchbox to the embed view which automatically enables the swissearch parameter in the iframe.

This fixes https://github.com/geoadmin/mf-geoadmin3/issues/3299

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/gjn_stoken/)

[Testling with `trimmis limit: 2`](https://mf-geoadmin3.dev.bgdi.ch/gjn_stoken/?swisssearch=trimmis limit: 2)

[Testling with `trimmis limit: 2 origins: address`](https://mf-geoadmin3.dev.bgdi.ch/gjn_stoken/?swisssearch=trimmis limit: 2 origins: address)

[Example in iframe with limit 1 that selects the result automatically](http://codepen.io/gjn19/pen/BKEpWo)
