### PR TITLE
Assure wms via permalink gets default version

### DIFF
--- a/src/components/map/PermalinkLayersService.js
+++ b/src/components/map/PermalinkLayersService.js
@@ -269,7 +269,7 @@ goog.require('ga_wms_service');
                 gaWms.addWmsToMap(map,
                   {
                     LAYERS: infos[3],
-                    VERSION: infos[4]
+                    VERSION: infos[4] || '1.3.0'
                   },
                   {
                     url: infos[2],


### PR DESCRIPTION
Before https://github.com/geoadmin/mf-geoadmin3/pull/2917, any WMS that was imported via the permalink and that didn't have a version specified in the permalink was automatically transformed to a version 1.3.0 wms. The above PR removed this. 

This parameter again assures that 1.3.0 is assumed if the version is left out.

@oterral Quick review/merge please.