### PR TITLE
Fix #3319: Remove feature with bad geometries

### DIFF
--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -70,6 +70,71 @@ goog.require('ga_urlutils_service');
       }
     };
 
+    var shouldRemoveMultiGeom = function(geometry, children) {
+      var coords = [];
+      for (var i = 0, ii = children.length; i < ii; i++) {
+        if (!shouldRemoveGeometry(children[i])) {
+          coords.push(children[i].getCoordinates());
+        }
+      }
+      if (coords.length) {
+        geometry.setCoordinates(coords);
+        return false;
+      }
+      return true;
+    };
+
+    /**
+     * This function tests if all coordinates of a geometry are identical.
+     * Special case , returns true if there is only one coordinate.
+     * Used to test LineStrings and LinearRings.
+     */
+    var uniqueCoords = function(coords) {
+      var unique = true;
+      for (var i = 1, ii = coords.length; i < ii; i++) {
+        var coord = coords[i];
+        var nextCoord = coords[i + 1];
+        if (unique && nextCoord &&
+            (coord[0] != nextCoord[0] ||
+            coord[1] != nextCoord[1] ||
+            coord[2] != nextCoord[2])) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    var shouldRemoveGeometry = function(geom) {
+      var geometries = [geom];
+      if (geom instanceof ol.geom.GeometryCollection) {
+        geometries = geom.getGeometries();
+      }
+      for (var i = 0, ii = geometries.length; i < ii; i++) {
+        var geometry = geometries[i];
+        var remove = false;
+        if (geometry instanceof ol.geom.MultiPolygon) {
+           remove = shouldRemoveMultiGeom(geometry, geometry.getPolygons());
+        } else if (geometry instanceof ol.geom.MultiLineString) {
+           remove = shouldRemoveMultiGeom(geometry, geometry.getLineStrings());
+        } else if (geometry instanceof ol.geom.Polygon) {
+           remove = shouldRemoveMultiGeom(geometry, geometry.getLinearRings());
+        } else if (geometry instanceof ol.geom.LinearRing ||
+            geometry instanceof ol.geom.LineString) {
+          remove = uniqueCoords(geometry.getCoordinates());
+        }
+        if (remove) {
+          geometries.splice(i, 1);
+          i--;
+        }
+      }
+      if (geometries.length && geom instanceof ol.geom.GeometryCollection) {
+        geom.setGeometries(geometries);
+        return false;
+      }
+      return !geometries.length;
+    };
+
+
     this.$get = function($http, $q, $rootScope, $timeout, $translate,
         gaDefinePropertiesForLayer, gaGlobalOptions, gaMapClick, gaMapUtils,
         gaNetworkStatus, gaStorage, gaStyleFactory, gaUrlUtils, gaMeasure) {
@@ -129,14 +194,19 @@ goog.require('ga_urlutils_service');
 
       // Sanitize the feature's properties (id, geometry, style).
       var sanitizeFeature = function(feature, projection) {
-        var geometry = feature.getGeometry();
-        // Remove feature without geometry.
-        if (!geometry) {
+        var geom = feature.getGeometry();
+
+        // Returns true if a geometry has a bad geometry
+        // (ex: only one coordinate for line strings)
+        var remove = shouldRemoveGeometry(geom);
+
+        // Remove feature without good geometry.
+        if (!geom || remove) {
           return;
         }
         // Ensure polygons are closed.
         // Reason: print server failed when polygons are not closed.
-        closeGeometry(geometry);
+        closeGeometry(geom);
 
         // Replace empty id by undefined.
         // Reason: If 2 features have their id empty, an assertion error
@@ -144,8 +214,7 @@ goog.require('ga_urlutils_service');
         if (feature.getId() === '') {
           feature.setId(undefined);
         }
-        feature.getGeometry().transform('EPSG:4326', projection);
-        var geom = feature.getGeometry();
+        geom.transform('EPSG:4326', projection);
         var styles = feature.getStyleFunction().call(feature);
         var style = styles[0];
 


### PR DESCRIPTION
Fix #3319 

- Remove bad geometry on import
- Don't add bad  geometry on draw end


[Test](https://mf-geoadmin3.dev.bgdi.ch/fix_3319/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=192880.00&Y=689840.00&zoom=5&dev3d=true&debug&layers=KML%7C%7Chttps:%2F%2Fpublic.geo.admin.ch%2FhxinPHmDT5-iF_5yOkP6Hg)

