### PR TITLE
Fix #3323: Display root layer if the WMS contains no children

### DIFF
--- a/src/components/importwms/ImportWmsDirective.js
+++ b/src/components/importwms/ImportWmsDirective.js
@@ -87,7 +87,7 @@ goog.require('ga_wms_service');
                 var root = getChildLayers(result.Capability.Layer,
                     $scope.map, result.version);
                 if (root) {
-                  $scope.layers = root.Layer;
+                  $scope.layers = root.Layer || [root];
                 }
               }
 


### PR DESCRIPTION
Minor fixes , allow to display WMS from  http://landsatlook.usgs.gov/arcgis/services/Sentinel2/ImageServer/WMSServer