### PR TITLE
Some shop directive improvments

### DIFF
--- a/src/components/shop/ShopDirective.js
+++ b/src/components/shop/ShopDirective.js
@@ -25,7 +25,6 @@ goog.require('ga_price_filter');
       },
       link: function(scope, elt, attrs, controller) {
         scope.clipperFeatures = {};
-        scope.showConfirm = false;
         scope.showRectangle = false;
         scope.price = null;
         // Remove the element if no feature defined
@@ -58,17 +57,17 @@ goog.require('ga_price_filter');
 
         // Remove the element if no shop config available
         if (!layerConfig || !layerConfig.shop ||
-            layerConfig.shop.length == 0) {
+            layerConfig.shop.length == 0 || (scope.feature.properties &&
+            !angular.isDefined(scope.feature.properties.available))) {
           elt.remove();
           return;
         }
 
         // The feature is not available in the shop so we display a message
-        if (scope.feature.properties && !scope.feature.properties.available) {
-          if (layerConfig.shop.length <= 1) {
-            scope.notAvailable = true;
-            return;
-          }
+        if (scope.feature.properties && !scope.feature.properties.available &&
+            layerConfig.shop.length <= 1) {
+          scope.notAvailable = true;
+          return;
         }
 
         scope.getClipperFeatureLabel = function(orderType) {

--- a/src/components/shop/ShopDirective.js
+++ b/src/components/shop/ShopDirective.js
@@ -115,8 +115,15 @@ goog.require('ga_price_filter');
             ];
             gaIdentify.get(scope.map, layers, scope.clipperGeometry, 1,
                 false).then(function(response) {
-              scope.clipperFeatures[scope.orderType] = response.data.results[0];
-              scope.updatePrice();
+              var results = response.data.results;
+              if (results.length) {
+                scope.clipperFeatures[scope.orderType] = results[0];
+                scope.updatePrice();
+              } else {
+                scope.price = null;
+              }
+            }, function() {
+              scope.price = null;
             });
           } else {
             scope.updatePrice();
@@ -137,6 +144,8 @@ goog.require('ga_price_filter');
             gaShop.getPrice(scope.orderType, layerBodId,
                 getFeatureIdToRequest(), geometry).then(function(price) {
               scope.price = price;
+            }, function() {
+              scope.price = null;
             });
           } else {
             scope.price = null;

--- a/src/components/shop/style/shop.less
+++ b/src/components/shop/style/shop.less
@@ -4,36 +4,20 @@
   padding: 5px;
 
   .ga-shop-order {
-    height: 44px;
+    height: auto;
 
     @media (max-width: @screen-phone) {
-      height: auto;
-      
       option[value="string:rectangle"] {
         display: none;
       }
     }
 
-    select {
-      float: left;
-      width: 130px;
-    }
-    
-    button {
-      float: right;
-      max-width: 58%;
-    }
-
     button, select {
-      margin: 5px;
-
-      @media (max-width: @screen-phone) {
-        display: block;
-        float: none;
-        max-width: 100%;
-        margin: 5px 0;
-        width: 100%;
-      }
+      display: block;
+      float: none;
+      max-width: 100%;
+      margin: 5px 0;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
- Don't display not available message for geocover after zoom level 6 [Test](https://mf-geoadmin3.dev.bgdi.ch/teo_shop/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=88750.00&Y=710740.00&zoom=7&dev3d=true&debug&layers=ch.swisstopo.pixelkarte-farbe-pk25.noscale,ch.swisstopo.geologie-geocover&layers_opacity=1,0.75&layers_visibility=false,true)

- Display order button and select box one upper the other (full popup width) [Test](https://mf-geoadmin3.dev.bgdi.ch/teo_shop/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=88810.01&Y=709772.59&zoom=4&dev3d=true&debug&layers=ch.swisstopo.pixelkarte-farbe-pk25.noscale,ch.swisstopo.geologie-geocover&layers_opacity=1,0.75&layers_visibility=true,false)

- Don't display price if commune doesn't exist [Test](https://mf-geoadmin3.dev.bgdi.ch/teo_shop/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=88640.00&Y=694940.00&zoom=6&dev3d=true&debug&layers=ch.swisstopo.pixelkarte-farbe-pk25.noscale,ch.swisstopo.geologie-geocover&layers_opacity=1,0.75&layers_visibility=true,false)