### PR TITLE
Iframe copylink changes according to iframe preview

### DIFF
--- a/src/components/share/ShareDirective.js
+++ b/src/components/share/ShareDirective.js
@@ -10,6 +10,18 @@ goog.require('ga_permalink');
     'pascalprecht.translate'
   ]);
 
+  function setIframeValue(input) {
+    var previewFrame = angular.element(document).
+                find('#gaEmbedModal iframe')[0];
+              if (previewFrame) {
+                var url = previewFrame.contentWindow.location.href;
+                var frame = input.val();
+                var prFrame = $(frame)[0];
+                prFrame.src = url;
+                input.val(prFrame.outerHTML);
+              }
+  };
+
   module.directive('gaShareCopyInput', function(gaBrowserSniffer, $translate) {
     return {
       restrict: 'A',
@@ -23,6 +35,7 @@ goog.require('ga_permalink');
             }
           }).on({
             focus: function() {
+              setIframeValue(element);
               this.setSelectionRange(0, 9999);
             }
           });
@@ -45,9 +58,12 @@ goog.require('ga_permalink');
         if (!isCopyAllow) {
           element.remove();
         }
+
         // Use clipboard API to copy URL in OS clipboard
         element.on('click', function() {
+
             var inputToCopy = $(attrs.gaShareCopyBt);
+            setIframeValue(inputToCopy);
             inputToCopy[0].setSelectionRange(0, 9999);
 
             // Execute the copy command

--- a/src/components/share/partials/share.html
+++ b/src/components/share/partials/share.html
@@ -92,7 +92,7 @@
           </div>
         </div>
         <iframe ng-if="loadIframe"
-                ng-src="{{embedValue}}" 
+                ng-src="{{embedValue}}"
                 width="{{iframeWidth}}"
                 height="{{iframeHeight}}"
                 frameborder="0">


### PR DESCRIPTION
Fix for   https://github.com/geoadmin/mf-geoadmin3/issues/3272

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/kom_iframe/?topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.geologie-eiszeit-lgm-raster&X=191633.63&Y=759614.00&zoom=10&swipe_ratio=0.59)