### PR TITLE
Adding retry logic for tiles and images

### DIFF
--- a/src/components/map/LayerRetryService.js
+++ b/src/components/map/LayerRetryService.js
@@ -1,0 +1,145 @@
+goog.provide('ga_layer_retry_service');
+
+goog.require('ga_map_service');
+
+
+(function() {
+
+  var module = angular.module('ga_layer_retry_service', [
+    'ga_map_service'
+  ]);
+
+ /**
+   * This service provide functionality to enable layers on
+   * an ol3 map to retry failed downloading attempts. This
+   * functionality existed in ol2.
+   */
+  module.provider('gaLayerRetry', function() {
+
+    var canObserve = function(l) {
+      if ((l instanceof ol.layer.Tile ||
+          l instanceof ol.layer.Image) &&
+          (l.getSource() instanceof ol.source.WMTS ||
+           l.getSource() instanceof ol.source.TileWMS ||
+           l.getSource() instanceof ol.source.ImageWMS)) {
+        return true;
+      }
+      return false;
+    };
+
+    var isRetryLayer = function(l) {
+      if (l.type == 'aggregate') {
+        var is = false;
+        angular.forEach(l.getLayers(), function(subLayer) {
+          is = is || isRetryLayer(subLayer);
+        });
+        return is;
+      }
+      return canObserve(l);
+    };
+
+    var reg = {};
+    var MAX_RETRIES = 3;
+    var RETRIES_INTERVAL = 5000;
+
+    this.$get = function($timeout, gaLayerFilters) {
+
+      var registerNewLayers = function(layers) {
+
+        angular.forEach(layers, function(layer) {
+          if (layer.type == 'aggregate') {
+            registerNewLayers(layer.getLayers());
+          } else if (canObserve(layer)) {
+            var end = 'tileloadend';
+            var error = 'tileloaderror';
+            var el = 'tile';
+            var src = layer.getSource();
+            var unreg = [];
+            if (!reg[layer.id]) {
+
+              if (src instanceof ol.source.ImageWMS) {
+                end = 'imageloadend';
+                error = 'imageloaderror';
+                el = 'image';
+              }
+
+              unreg.push(src.on(error, function(evt) {
+                if (evt[el]._retries == undefined) {
+                  evt[el]._retries = 0;
+                }
+                evt[el]._retries++;
+                if (evt[el]._retries <= MAX_RETRIES) {
+                  $timeout(function() {
+                    evt[el].state = 0;
+                    evt[el].load();
+                  }, RETRIES_INTERVAL * evt[el]._retries, false);
+                }
+              }));
+
+              unreg.push(src.on(end, function(evt) {
+                if (evt[el]._retries) {
+                  evt[el]._retries = 0;
+                  this.changed();
+                }
+              }));
+
+              reg[layer.id] = {
+                unregs: unreg,
+                src: src
+              };
+            }
+          }
+        });
+      };
+
+      var unregisterOldLayers = function(layers) {
+
+        var layerActive = function(layerId, ls) {
+          var hasIt = false;
+          angular.forEach(ls, function(layer) {
+            if (layer.type == 'aggregate') {
+              hasIt = layerActive(layerId, layer.getLayers());
+            } else if (layer.id == layerId) {
+              hasIt = true;
+            }
+          });
+          return hasIt;
+        };
+
+        angular.forEach(reg, function(r, layerId) {
+          if (!layerActive(layerId, layers)) {
+            angular.forEach(r.unregs, function(unreg) {
+              r.src.unByKey(unreg);
+            });
+            delete reg[layerId];
+          }
+        });
+
+      };
+
+      var LayerRetry = function() {
+
+        this.init = function(scope) {
+          scope.maploadLayers = scope.map.getLayers().getArray();
+          scope.maploadFilter = function(l) {
+            return ((gaLayerFilters.selectedAndVisible(l) ||
+                   gaLayerFilters.background(l)) &&
+                   isRetryLayer(l));
+          };
+
+          //React on adding/removing layers
+          scope.$watchCollection('maploadLayers | filter:maploadFilter',
+                                 function(layers) {
+            registerNewLayers(layers);
+            unregisterOldLayers(layers);
+          });
+
+        };
+      };
+
+      return new LayerRetry();
+
+    };
+  });
+})();
+

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -26,9 +26,11 @@ goog.require('ga_identify_service');
 goog.require('ga_importkml');
 goog.require('ga_importwms');
 goog.require('ga_importwms_controller');
+goog.require('ga_layer_retry_service');
 goog.require('ga_layermanager');
 goog.require('ga_main_controller');
 goog.require('ga_map');
+goog.require('ga_map_service');
 goog.require('ga_measure');
 goog.require('ga_modal_directive');
 goog.require('ga_mouseposition');
@@ -75,7 +77,9 @@ goog.require('ga_waitcursor_service');
     'ga_importkml',
     'ga_importwms',
     'ga_help',
+    'ga_layer_retry_service',
     'ga_map',
+    'ga_map_service',
     'ga_mouseposition',
     'ga_offline',
     'ga_popup',

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -2,6 +2,7 @@ goog.provide('ga_main_controller');
 
 goog.require('ga_background_service');
 goog.require('ga_cesium');
+goog.require('ga_layer_retry_service');
 goog.require('ga_map');
 goog.require('ga_networkstatus_service');
 goog.require('ga_storage_service');
@@ -11,6 +12,7 @@ goog.require('ga_topic_service');
 
   var module = angular.module('ga_main_controller', [
     'pascalprecht.translate',
+    'ga_layer_retry_service',
     'ga_map',
     'ga_networkstatus_service',
     'ga_storage_service',
@@ -26,7 +28,7 @@ goog.require('ga_topic_service');
       gaPermalinkFeaturesManager, gaPermalinkLayersManager, gaMapUtils,
       gaRealtimeLayersManager, gaNetworkStatus, gaPermalink, gaStorage,
       gaGlobalOptions, gaBackground, gaTime, gaLayers, gaTopic,
-      gaOpaqueLayersManager) {
+      gaOpaqueLayersManager, gaLayerRetry) {
 
     var createMap = function() {
       var toolbar = $('#zoomButtons')[0];
@@ -91,6 +93,9 @@ goog.require('ga_topic_service');
     // The main controller creates the OpenLayers map object. The map object
     // is central, as most directives/components need a reference to it.
     $scope.map = createMap();
+
+    // Activate retry mechanism for all layers
+    gaLayerRetry.init($scope);
 
     // Set up 3D
     var startWith3D = false;


### PR DESCRIPTION
This adresses and potentially fixes https://github.com/geoadmin/mf-geoadmin3/issues/3206

In OL2, the libary supported a number of retries per tiles. This came in handy when the network was not stable (2G, wifi holes, etc). OL3 removed this out of the box. There an PR in ol3 for this https://github.com/openlayers/ol3/pull/5270, but it lacks a little bit of subtility (no way to limit number of retries or to wait between retries).

This PR allows to define the maximum number of retries (currently 100) and the interval between 2 retries (currently 5 seconds). It supports wmts layers and integrated wms layers (single tile and tiled)

To test it, you need to have either a spotty internet connection or work with the developer console (F12 in chrome). Open the network tab and when tiles start loading, cut the internet connection [1] by selecting 'offline' from the dropdown list. The map is not complete and contains white tiles. After a while, re-enable the internet connection (no throttle option) and the tiles/images should appear again.

A couple of questions:
- I'm not sure about the current settings (interval, max_retries)
- Should be tested together with offline -> @oterral 
- Should be tested more with mobile device on the field.

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_reload/index.html?lang=de&topic=ech&bgLayer=ch.swisstopo.swissimage&X=199206.24&Y=689021.88&zoom=2&layers=ch.bakom.mobil-antennenstandorte-gsm,ch.bazl.luftfahrthindernis)

[1]
![image](https://cloud.githubusercontent.com/assets/2572317/15609975/47398f5c-2423-11e6-904f-4e8eca444c4a.png)

ping @oterral @davidoesch @procrastinatio 
