### PR TITLE
Add test for PrintStyle service.

### DIFF
--- a/src/components/print/PrintModule.js
+++ b/src/components/print/PrintModule.js
@@ -1,12 +1,12 @@
 goog.provide('ga_print');
 
 goog.require('ga_print_directive');
-goog.require('ga_print_style_service');
+goog.require('ga_printstyle_service');
 (function() {
 
   angular.module('ga_print', [
     'ga_print_directive',
-    'ga_print_style_service'
+    'ga_printstyle_service'
   ]);
 })();
 

--- a/src/components/print/PrintStyleService.js
+++ b/src/components/print/PrintStyleService.js
@@ -1,71 +1,243 @@
-goog.provide('ga_print_style_service');
+goog.provide('ga_printstyle_service');
 (function() {
 
-  var module = angular.module('ga_print_style_service', []);
+  var module = angular.module('ga_printstyle_service', [])
+      .provider('gaPrintStyle', gaPrintStyle);
 
-  module.provider('gaPrintStyleService', function() {
-
-    // Create a ol.geom.Polygon from an ol.geom.Circle, comes from OL2
-    // https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Geometry/Polygon.js#L240
-    function olCircleToPolygon(circle, sides, rotation) {
-      var origin = circle.getCenter();
-      var radius = circle.getRadius();
-      sides = sides || 40;
-      var angle = Math.PI * ((1 / sides) - (1 / 2));
-      if (rotation) {
-        angle += (rotation / 180) * Math.PI;
-      }
-      var points = [];
-      for (var i = 0; i < sides; ++i) {
-        var rotatedAngle = angle + (i * 2 * Math.PI / sides);
-        var x = origin[0] + (radius * Math.cos(rotatedAngle));
-        var y = origin[1] + (radius * Math.sin(rotatedAngle));
-        points.push([x, y]);
-      }
-      points.push(points[0]);// Close the polygon
-      return new ol.geom.Polygon([points]);
-    }
-
-    // Only simple shapes are supported for now (no use of radius2)
-    function olPointToPolygon(olStyle, feature, resolution) {
-      var geometry = feature.getGeometry();
-      var image = olStyle.getImage();
-      var imageRotation = image.getRotation();
-      var origin = geometry.getCoordinates();
-      var pixelRadius = image.getRadius();
-      var radius = resolution * pixelRadius * 0.8;
-
-      // First point always at top
-      var xO, yO;
-      xO = 0;
-      yO = radius;
-
-      // Rotate around origin counter-clock wise
-      var x, y;
-      var coordinates = [];
-      var nbPoints = image.getPoints();
-      var angle = imageRotation;
-      var angleInterval = 2 * Math.PI / nbPoints;
-      for (var i = 1; i <= nbPoints; i++) {
-        x = origin[0] + (xO * Math.cos(angle) - yO * Math.sin(angle));
-        y = origin[1] + (xO * Math.sin(angle) + yO * Math.cos(angle));
-        coordinates.push([x, y]);
-
-        // Next point
-        angle += angleInterval;
-      }
-      // Close the polygon
-      coordinates.push(coordinates[0]);
-      var polygon = new ol.geom.Polygon([coordinates]);
-
-      return new ol.Feature(polygon);
-    }
-
+  function gaPrintStyle() {
     this.$get = function() {
       return {
+        olStyleToPrintLiteral: olStyleToPrintLiteral,
         olPointToPolygon: olPointToPolygon,
         olCircleToPolygon: olCircleToPolygon
       };
     };
-  });
+  };
+
+  // Change a distance according to the change of DPI
+  function adjustDist(dist, dpi) {
+    if (!dist) {
+      return;
+    }
+    return dist * 90 / dpi;
+  };
+
+  // Transform an ol.Color to an hexadecimal string
+  // Move it to a gaColor service?
+  function toHexa(olColor) {
+    var hex = '#';
+    for (var i = 0; i < 3; i++) {
+      var part = olColor[i].toString(16);
+      if (part.length === 1) {
+        hex += '0';
+      }
+      hex += part;
+    }
+    return hex;
+  };
+
+  // Create a ol.geom.Polygon from an ol.geom.Circle, comes from OL2
+  // https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Geometry/Polygon.js#L240
+  function olCircleToPolygon(circle, sides, rotation) {
+    if (!circle || !(circle instanceof ol.geom.Circle)) {
+      return;
+    }
+    var origin = circle.getCenter();
+    var radius = circle.getRadius();
+    sides = sides || 40;
+    rotation = rotation || 0;
+    var angle = Math.PI * ((1 / sides) - (1 / 2));
+    if (rotation) {
+      angle += (rotation / 180) * Math.PI;
+    }
+    var points = [];
+    for (var i = 0; i < sides; ++i) {
+      var rotatedAngle = angle + (i * 2 * Math.PI / sides);
+      var x = origin[0] + (radius * Math.cos(rotatedAngle));
+      var y = origin[1] + (radius * Math.sin(rotatedAngle));
+      points.push([x, y]);
+    }
+    points.push(points[0]);// Close the polygon
+    return new ol.geom.Polygon([points]);
+  }
+
+  // Only simple shapes are supported for now (no use of radius2)
+  function olPointToPolygon(point, radius, resolution, sides, rotation) {
+    if (!point || !radius || !resolution || !(point instanceof ol.geom.Point)) {
+      return;
+    }
+    var origin = point.getCoordinates();
+    var angle = rotation || 0;
+    sides = sides || 4;
+
+    // First point always at top
+    var xO = 0,
+        yO = resolution * radius * 0.8;
+
+    // Rotate around origin counter-clock wise
+    var points = [];
+    var angleInterval = 2 * Math.PI / sides;
+    for (var i = 0; i < sides; i++) {
+      var x = origin[0] + (xO * Math.cos(angle) - yO * Math.sin(angle));
+      var y = origin[1] + (xO * Math.sin(angle) + yO * Math.cos(angle));
+      points.push([x, y]);
+
+      // Next point
+      angle += angleInterval;
+    }
+    // Close the polygon
+    points.push(points[0]);
+    return new ol.geom.Polygon([points]);
+  }
+
+  // Transform a ol.style.Style to a print literal object
+  function olStyleToPrintLiteral(style, dpi) {
+    /**
+     * ol.style.Style properties:
+     *
+     *  fill: ol.style.Fill :
+     *    fill: String
+     *  image: ol.style.Image:
+     *    anchor: array[2]
+     *    rotation
+     *    size: array[2]
+     *    src: String
+     *  stroke: ol.style.Stroke:
+     *    color: String
+     *    lineCap
+     *    lineDash
+     *    lineJoin
+     *    miterLimit
+     *    width: Number
+     *  text
+     *  zIndex
+     */
+
+    /**
+     * Print server properties:
+     *
+     * fillColor
+     * fillOpacity
+     * strokeColor
+     * strokeOpacity
+     * strokeWidth
+     * strokeLinecap
+     * strokeLinejoin
+     * strokeDashstyle
+     * pointRadius
+     * label
+     * fontFamily
+     * fontSize
+     * fontWeight
+     * fontColor
+     * labelAlign
+     * labelXOffset
+     * labelYOffset
+     * labelOutlineColor
+     * labelOutlineWidth
+     * graphicHeight
+     * graphicOpacity
+     * graphicWidth
+     * graphicXOffset
+     * graphicYOffset
+     * zIndex
+     */
+    if (!style || !(style instanceof ol.style.Style) || !dpi) {
+      return;
+    }
+    var literal = {
+      zIndex: style.getZIndex()
+    };
+    var fill = style.getFill();
+    var stroke = style.getStroke();
+    var textStyle = style.getText();
+    var imageStyle = style.getImage();
+
+    if (imageStyle) {
+      var size, anchor, scale = imageStyle.getScale();
+      literal.rotation = imageStyle.getRotation();
+
+      if (imageStyle instanceof ol.style.Icon) {
+        size = imageStyle.getSize();
+        anchor = imageStyle.getAnchor();
+        literal.externalGraphic = imageStyle.getSrc();
+        literal.fillOpacity = 1;
+      } else if (imageStyle instanceof ol.style.Circle ||
+          imageStyle instanceof ol.style.RegularShape) {
+        fill = imageStyle.getFill();
+        stroke = imageStyle.getStroke();
+        var radius = imageStyle.getRadius();
+        var width = adjustDist(2 * radius, dpi);
+        if (stroke) {
+          width += adjustDist(stroke.getWidth() + 1, dpi);
+        }
+        size = [width, width];
+        anchor = [width / 2, width / 2];
+        literal.pointRadius = radius;
+      }
+
+      if (size) {
+        // Print server doesn't handle correctly 0 values for the size
+        literal.graphicWidth = adjustDist((size[0] * scale || 0.1), dpi);
+        literal.graphicHeight = adjustDist((size[1] * scale || 0.1), dpi);
+      }
+      if (anchor) {
+        literal.graphicXOffset = adjustDist(-anchor[0] * scale, dpi);
+        literal.graphicYOffset = adjustDist(-anchor[1] * scale, dpi);
+      }
+
+    }
+
+    if (fill) {
+      var color = ol.color.asArray(fill.getColor());
+      literal.fillColor = toHexa(color);
+      literal.fillOpacity = color[3];
+    } else if (!literal.fillOpacity) {
+      literal.fillOpacity = 0; // No fill
+    }
+
+    if (stroke) {
+      var color = ol.color.asArray(stroke.getColor());
+      literal.strokeWidth = adjustDist(stroke.getWidth(), dpi);
+      literal.strokeColor = toHexa(color);
+      literal.strokeOpacity = color[3];
+      literal.strokeLinecap = stroke.getLineCap() || 'round';
+      literal.strokeLinejoin = stroke.getLineJoin() || 'round';
+
+      if (stroke.getLineDash()) {
+        literal.strokeDashstyle = 'dash';
+      }
+      // TO FIX: Not managed by the print server
+      // literal.strokeMiterlimit = stroke.getMiterLimit();
+    } else {
+      literal.strokeOpacity = 0; // No Stroke
+    }
+
+    if (textStyle && textStyle.getText()) {
+      literal.label = textStyle.getText();
+      literal.labelAlign = textStyle.getTextAlign();
+
+      if (textStyle.getFill()) {
+        var fillColor = ol.color.asArray(textStyle.getFill().getColor());
+        literal.fontColor = toHexa(fillColor);
+      }
+
+      if (textStyle.getFont()) {
+        var fontValues = textStyle.getFont().split(' ');
+        // Fonts managed by print server: COURIER, HELVETICA, TIMES_ROMAN
+        literal.fontFamily = fontValues[2].toUpperCase();
+        literal.fontSize = parseInt(fontValues[1]);
+        literal.fontWeight = fontValues[0];
+      }
+
+      /* TO FIX: Not managed by the print server
+      if (textStyle.getStroke()) {
+        var strokeColor = ol.color.asArray(textStyle.getStroke().getColor());
+        literal.labelOutlineColor = toHexa(strokeColor);
+        literal.labelOutlineWidth = textStyle.getStroke().getWidth();
+      }*/
+    }
+
+    return literal;
+  };
 })();

--- a/test/specs/print/PrintStyleService.spec.js
+++ b/test/specs/print/PrintStyleService.spec.js
@@ -1,0 +1,330 @@
+describe('ga_printstyle_service', function() {
+  var gaStylesFromLiterals;
+
+  beforeEach(function() {
+    inject(function($injector) {
+      gaPrintStyle = $injector.get('gaPrintStyle');
+    });
+  });
+   
+  describe('#olPointToPolygon()', function() {
+    var pt = new ol.geom.Point([1, 2]);
+    
+    it('returns nothing if mandatory values are not defined', function() {
+      var poly = gaPrintStyle.olPointToPolygon();
+      expect(poly).to.be(undefined);
+      poly = gaPrintStyle.olPointToPolygon(pt, 100);
+      expect(poly).to.be(undefined);
+      poly = gaPrintStyle.olPointToPolygon(new ol.geom.Polygon(), 100, 100);
+      expect(poly).to.be(undefined);
+    });
+
+    describe('transforms a point to polygon', function() {
+
+      it('using default values', function() {
+        var poly = gaPrintStyle.olPointToPolygon(pt, 100, 50);
+        expect(poly).to.be.an(ol.geom.Polygon);
+        expect(poly.getCoordinates()).to.eql([[
+          [1, 4002],
+          [-3999, 2.000000000000245],
+          [0.9999999999995102, -3998],
+          [4001, 1.9999999999992653],
+          [1, 4002]
+        ]]);
+      });
+
+      it('using all parameters', function() {
+        var poly = gaPrintStyle.olPointToPolygon(pt, 100, 50, 10, 45);
+        expect(poly).to.be.an(ol.geom.Polygon);
+        expect(poly.getCoordinates()).to.eql([[
+          [-3402.614098136474, 2103.287955270919],
+          [-3987.687718614618, -298.616505489822],
+          [-3049.218201091239, -2585.695678732669],
+          [-945.6690038545548, -3884.363055240854],
+          [1519.4755767585675, -3698.5718372689016],
+          [3404.6140981365106, -2099.2879552708587],
+          [3989.687718614613, 302.61650548989235],
+          [3051.2182010911934, 2589.6956787327226],
+          [947.6690038544864, 3888.363055240871],
+          [-1517.4755767586328, 3702.5718372688752],
+          [-3402.614098136474, 2103.287955270919]
+        ]]);
+      });
+    });
+  });  
+ 
+  describe('#olCircleToPolygon()', function() {
+    
+    it('returns nothing if mandatory values are not defined', function() {
+      var poly = gaPrintStyle.olCircleToPolygon();
+      expect(poly).to.be(undefined);
+      poly = gaPrintStyle.olCircleToPolygon(new ol.geom.Point());
+      expect(poly).to.be(undefined);
+    });
+
+    describe('transforms a circle to polygon', function() {
+      var circle = new ol.geom.Circle([1, 2], 100);
+      
+      it('using default values', function() {
+        var poly = gaPrintStyle.olCircleToPolygon(circle);
+        expect(poly).to.be.an(ol.geom.Polygon);
+        expect(poly.getCoordinates()).to.eql([[
+          [8.8459095727845, -97.6917333733128],
+          [24.344536385590548, -95.23699203976766],
+          [39.26834323650898, -90.38795325112868],
+          [53.24985647159489, -83.26401643540922],
+          [65.94480483301837, -74.0405965600031],
+          [77.0405965600031, -62.94480483301837],
+          [86.26401643540922, -50.24985647159488],
+          [93.38795325112868, -36.268343236508976],
+          [98.23699203976766, -21.34453638559054],
+          [100.6917333733128, -5.845909572784494],
+          [100.6917333733128, 9.845909572784494],
+          [98.23699203976767, 25.34453638559052],
+          [93.38795325112868, 40.268343236508976],
+          [86.26401643540922, 54.24985647159488],
+          [77.0405965600031, 66.94480483301837],
+          [65.94480483301837, 78.0405965600031],
+          [53.24985647159489, 87.26401643540922],
+          [39.26834323650898, 94.38795325112868],
+          [24.344536385590548, 99.23699203976766],
+          [8.8459095727845, 101.6917333733128],
+          [-6.845909572784487, 101.6917333733128],
+          [-22.344536385590533, 99.23699203976767],
+          [-37.268343236508926, 94.38795325112869],
+          [-51.24985647159488, 87.26401643540923],
+          [-63.94480483301835, 78.04059656000311],
+          [-75.0405965600031, 66.94480483301838],
+          [-84.26401643540922, 54.24985647159489],
+          [-91.38795325112868, 40.26834323650899],
+          [-96.23699203976766, 25.34453638559055],
+          [-98.6917333733128, 9.845909572784507],
+          [-98.6917333733128, -5.845909572784482],
+          [-96.23699203976767, -21.344536385590526],
+          [-91.38795325112868, -36.26834323650897],
+          [-84.26401643540923, -50.24985647159487],
+          [-75.04059656000311, -62.94480483301835],
+          [-63.94480483301841, -74.04059656000305],
+          [-51.24985647159486, -83.26401643540925],
+          [-37.26834323650903, -90.38795325112865],
+          [-22.344536385590516, -95.23699203976767],
+          [-6.8459095727845565, -97.6917333733128],
+          [8.8459095727845, -97.6917333733128]
+        ]]);
+      });
+
+      it('using all parameters', function() {
+        var poly = gaPrintStyle.olCircleToPolygon(circle, 5, 45);
+        expect(poly).to.be.an(ol.geom.Polygon);
+        expect(poly.getCoordinates()).to.eql([[
+          [99.76883405951378, -13.643446504023087],
+          [46.39904997395468, 91.10065241883677],
+          [-69.71067811865474, 72.71067811865476],
+          [-88.10065241883679, -43.39904997395467],
+          [16.643446504023068, -96.76883405951378],
+          [99.76883405951378, -13.643446504023087]
+        ]]);
+      });
+    });
+
+  });
+ 
+  describe('#olStyleToPrintLiterals()', function() {
+    
+    var dfltFill = new ol.style.Fill({
+      color: [21, 22, 23, 0.1]
+    });
+
+    var dfltStroke = new ol.style.Stroke({
+      color: [24, 25, 26, 0.2],
+      width: 3.2,
+      lineCap: 'round',
+      lineJoin: 'bevel',
+      lineDash: [5, 6]
+    });
+        
+    it('returns nothing if style and/or dpi are not defined', function() {
+      var literal = gaPrintStyle.olStyleToPrintLiteral();
+      expect(literal).to.be(undefined);
+      literal = gaPrintStyle.olStyleToPrintLiteral(new ol.style.Style());
+      expect(literal).to.be(undefined);
+      literal = gaPrintStyle.olStyleToPrintLiteral(undefined, 96);
+      expect(literal).to.be(undefined);
+      literal = gaPrintStyle.olStyleToPrintLiteral({}, 96);
+      expect(literal).to.be(undefined);
+    });
+
+    it('transforms correctly a minimal style', function() {
+      var literal = gaPrintStyle.olStyleToPrintLiteral(new ol.style.Style(), 96);
+      expect(literal).to.eql({
+        zIndex: undefined,
+        fillOpacity: 0,
+        strokeOpacity: 0
+      });
+    });
+    
+    it('transforms correctly a complete style', function() {
+      var allStyle = new ol.style.Style({
+        zIndex: 3,
+        fill: dfltFill,
+        stroke: dfltStroke,
+        text: new ol.style.Text({
+          text: 'test',
+          textAlign: 'center', 
+          fill: new ol.style.Fill({
+            color: [27, 28, 29, 0.3]
+          }),
+          font: 'bold 14px Arial'
+        }),
+        image: new ol.style.Icon({
+          scale: 0.4,
+          rotation: 34,
+          size: [15, 16],
+          anchor: [0.6, 0.7],
+          src: 'http://test.png'
+        })
+      });
+      var literal = gaPrintStyle.olStyleToPrintLiteral(allStyle, 96);
+      expect(literal).to.eql({
+        zIndex: 3,
+        rotation: 34,
+        externalGraphic: 'http://test.png',
+        fillOpacity: 0.1,
+        graphicWidth: 5.625,
+        graphicHeight: 6,
+        graphicXOffset: -3.375,
+        graphicYOffset: -4.199999999999999,
+        fillColor: '#151617',
+        strokeWidth: 3,
+        strokeColor: '#18191a',
+        strokeOpacity: 0.2,
+        strokeLinecap: 'round',
+        strokeLinejoin: 'bevel',
+        strokeDashstyle: 'dash',
+        label: 'test',
+        labelAlign: 'center',
+        fontColor: '#1b1c1d',
+        fontFamily: 'ARIAL',
+        fontSize: 14,
+        fontWeight: 'bold'
+      });
+    });
+     
+    it('transforms correctly a color with an hexa value of one letter(#3322)', function() {
+       var style = new ol.style.Style({
+          fill: new ol.style.Fill({
+            color: [12, 0, 1, 0.2]
+          })
+        });
+        var literal = gaPrintStyle.olStyleToPrintLiteral(style, 96);
+        expect(literal).to.eql({
+          zIndex: undefined,
+          fillColor: '#0c0001',
+          fillOpacity: 0.2,
+          strokeOpacity: 0
+        });
+    });
+
+    describe('transforms correctly a image style', function() {
+       
+      it('containing an ol.style.Circle', function() {
+        var style = new ol.style.Style({
+          image: new ol.style.Circle({
+            fill: dfltFill,
+            stroke: dfltStroke,
+            radius: 567.2
+          })
+        });
+        var literal = gaPrintStyle.olStyleToPrintLiteral(style, 96);
+        expect(literal).to.eql({
+          zIndex: undefined,
+          rotation: 0,
+          pointRadius: 567.2,
+          graphicWidth: 1000.7226562500001,
+          graphicHeight: 1000.7226562500001,
+          graphicXOffset: -500.36132812500006,
+          graphicYOffset: -500.36132812500006,
+          fillColor: '#151617',
+          fillOpacity: 0.1,
+          strokeWidth: 3,
+          strokeColor: '#18191a',
+          strokeOpacity: 0.2,
+          strokeLinecap: 'round',
+          strokeLinejoin: 'bevel',
+          strokeDashstyle: 'dash' 
+        });
+      });
+
+      it('containing an ol.style.RegularShape', function() {
+        var style = new ol.style.Style({
+          image: new ol.style.RegularShape({
+            fill: dfltFill,
+            stroke: dfltStroke,
+            radius: 567.2
+          })
+        });
+        var literal = gaPrintStyle.olStyleToPrintLiteral(style, 96);
+        expect(literal).to.eql({
+          zIndex: undefined,
+          rotation: 0,
+          pointRadius: 567.2,
+          graphicWidth: 1000.7226562500001,
+          graphicHeight: 1000.7226562500001,
+          graphicXOffset: -500.36132812500006,
+          graphicYOffset: -500.36132812500006,
+          fillColor: '#151617',
+          fillOpacity: 0.1,
+          strokeWidth: 3,
+          strokeColor: '#18191a',
+          strokeOpacity: 0.2,
+          strokeLinecap: 'round',
+          strokeLinejoin: 'bevel',
+          strokeDashstyle: 'dash' 
+        });
+      });
+
+      it('uses an image size of 0.1 if no image size defined', function() {
+        var style = new ol.style.Style({
+          image: new ol.style.Icon({
+            src: 'https://test.png',
+            size: [0, 0]
+          })
+        });
+        var literal = gaPrintStyle.olStyleToPrintLiteral(style, 96);
+        expect(literal).to.eql({
+          zIndex: undefined,
+          rotation: 0,
+          externalGraphic: 'https://test.png',
+          fillOpacity: 1,
+          graphicWidth: 0.09375,
+          graphicHeight: 0.09375,
+          graphicXOffset: undefined,
+          graphicYOffset: undefined,
+          strokeOpacity: 0
+        });
+      });
+    });
+
+    describe('transforms correctly a stroke style', function() {
+      
+      it('using default values (lineCap, lineJoin, lineDash ...)', function() {
+        var style = new ol.style.Style({
+          stroke: new ol.style.Stroke({
+            color: [28, 255, 0, 0.2],
+            width: 1.2,
+          })
+        });
+        var literal = gaPrintStyle.olStyleToPrintLiteral(style, 96);
+        expect(literal).to.eql({
+          zIndex: undefined,
+          fillOpacity: 0,
+          strokeWidth: 1.125,
+          strokeColor: '#1cff00',
+          strokeOpacity: 0.2,
+          strokeLinecap: 'round',
+          strokeLinejoin: 'round' 
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_printstyle/?lang=fr&widgets=print&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=191700.00&Y=596700.00&zoom=3&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttp:%2F%2Fwww.bikingspots.ch%2FcreateKMLFile.php%3Ffilename%3Dreno333508077c95ddec.xml%26fc%3D1,ch.bafu.hydroweb-messstationen_grundwasser,KML%7C%7Chttps:%2F%2Fpublic.dev.bgdi.ch%2F8t0V4bo_Sk6ENHucpfgdgg&layers_visibility=false,false,false,false,true,true,true&layers_timestamp=18641231,,,,,,)

This PR contains :  
  - tests for gaPrintStyle service
  - add transformation of ol.style.Style in json literals to the gaPrintStyle service
  - Harmonize olPointToPolygon function with olCircleToPolygon (variable name, parameters)


@loicgasser I will be glad if you can tell how to test printing of a regular shape .


How to test : try to print all kind of KML or GeoJSON layer