### PR TITLE
Decongestioned robots.txt path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ guard-%:
 prd/robots.txt: scripts/robots.mako-dot-txt .build-artefacts/last-deploy-target
 	mkdir -p $(dir $@)
 	${PYTHON_CMD} ${MAKO_CMD} \
+		--var "apache_base_path=$(APACHE_BASE_PATH)" \
 	    --var "deploy_target=$(DEPLOY_TARGET)" $< > $@
 
 prd/lib/: src/lib/d3.min.js \

--- a/scripts/robots.mako-dot-txt
+++ b/scripts/robots.mako-dot-txt
@@ -9,7 +9,7 @@ Sitemap: https://map.geo.admin.ch/sitemap_index.xml
 
 % else:
 
-Disallow: /
+Disallow: ${apache_base_path}/
 
 % endif
 


### PR DESCRIPTION
For testing https://github.com/geoadmin/mf-geoadmin3/issues/3303, the twitter bot needs access to geoadmin, even on `dev`and `int`.

Unfortunately, the `robots.txt` is denying everything, even in branches:

```Disallow: /```

This PR sets the `robots.txt`correctly for each branches.

To test, simply remove all robots.txt files from the vhosts `mf-geoadmin3 (both in branches and users directory, remove you very own robot.tx,  restart apache2, praying nobody is building it's project in between, and test you branch with a real robot, eg. https://cards-dev.twitter.com/validator
