### PR TITLE
Fix #3334: Start loop at 0 + test

### DIFF
--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -91,7 +91,7 @@ goog.require('ga_urlutils_service');
      */
     var uniqueCoords = function(coords) {
       var unique = true;
-      for (var i = 1, ii = coords.length; i < ii; i++) {
+      for (var i = 0, ii = coords.length; i < ii; i++) {
         var coord = coords[i];
         var nextCoord = coords[i + 1];
         if (unique && nextCoord &&

--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -428,6 +428,47 @@ describe('ga_kml_service', function() {
         $rootScope.$digest();
       });
 
+      it('don\'t remove geometries with good coordinates, at least 2 (#3334)', function(done) {
+        var uniqCoords = '<coordinates>1,0,0 2,0,0</coordinates>';
+        var linearRing = '<LinearRing>' + uniqCoords + '</LinearRing>'; 
+        var polygon = '<Polygon>' +
+            '<outerBoundaryIs>' + linearRing + '</outerBoundaryIs>' +
+            '<innerBoundaryIs>' + linearRing + '</innerBoundaryIs>' +
+          '</Polygon>';
+        var multiPolygon = '<MultiGeometry>' +
+            polygon + polygon +
+         '</MultiGeometry>';
+        var line = '<LineString>' + uniqCoords + '</LineString>'; 
+        var multiLine = '<MultiGeometry>' +
+            line + line +
+         '</MultiGeometry>';
+         var lineWithOneCoord = '<LineString>0,0,0</LineString>'; 
+        
+        
+        // a heterogenous MultiGeometry creates a GeometryCollection feature
+        var geomColl = '<MultiGeometry>' +
+            polygon +
+            '<Point><coordinates>0,0,0</coordinates></Point>' +
+            line +
+         '</MultiGeometry>';
+
+
+        var kml = '<kml>' +
+            '<Placemark>' + linearRing + '</Placemark>' + 
+            '<Placemark>' + polygon + '</Placemark>' + 
+            '<Placemark>' + multiPolygon + '</Placemark>' +
+            '<Placemark>' + geomColl + '</Placemark>' +
+            '<Placemark>' + line + '</Placemark>' + 
+            '<Placemark>' + multiLine + '</Placemark>' +
+          '</kml>';
+        gaKml.addKmlToMap(map, kml).then(function(olLayer) {
+          var feats = olLayer.getSource().getFeatures();
+          expect(feats.length).to.be(6);
+          done();
+        });
+        $rootScope.$digest();
+      });
+
       it('set empty feature\'s id to undefined', function(done) {
         var kml = '<kml>' + createValidPlkPoint('') + '</kml>';
         gaKml.addKmlToMap(map, kml).then(function(olLayer) {


### PR DESCRIPTION
Fix #3334 

[Test](https://mf-geoadmin3.dev.bgdi.ch/fix_3334/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=129470.00&Y=557160.00&zoom=6&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,KML%7C%7Chttps:%2F%2Fpublic.dev.bgdi.ch%2F9JYxKb_KQdCn882JYOgjyQ&layers_visibility=false,false,false,true&layers_timestamp=18641231,,,)

