### PR TITLE
Some fixes

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -402,8 +402,7 @@ goog.require('ga_time_service');
               type: 'FeatureCollection',
               features: encFeatures
             },
-            name: layer.bodId,
-            opacity: (layer.opacity != null) ? layer.opacity : 1.0
+            name: layer.bodId
           });
           return enc;
         },
@@ -530,6 +529,16 @@ goog.require('ga_time_service');
           if (styles && styles.length > 0) {
             angular.extend(encStyle, transformToPrintLiteral(feature,
                 styles[0]));
+
+            // Apply the layer's opacity on fill and stroke
+            if (encStyle.fillOpacity) {
+              encStyle.fillOpacity *= layer.getOpacity();
+            }
+
+            if (encStyle.strokeOpacity) {
+              encStyle.strokeOpacity *= layer.getOpacity();
+            }
+
             encStyles[encStyle.id] = encStyle;
             var styleToEncode = styles[0];
             // If a feature has a style with a geometryFunction defined, we

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -250,6 +250,17 @@ goog.require('ga_topic_service');
               return scope.ol3d && scope.ol3d.getEnabled();
             };
 
+            // Destroy the popup specified when needed
+            var destroyPopup = function() {
+              $timeout(function() {
+                // We destroy the popup only if it's still closed
+                if (popup && popup.scope && popup.scope.toggle === false) {
+                  popup.destroy();
+                  popup = undefined;
+                }
+              }, 0);
+            };
+
             // Destroy popup and highlight
             var initTooltip = function() {
                // Cancel all pending requests
@@ -584,7 +595,10 @@ goog.require('ga_topic_service');
                   showReduce: false,
                   title: 'object_information',
                   content: '<div class="ga-popup-no-info" translate>' +
-                      'no_more_information</div>'
+                      'no_more_information</div>',
+                  onCloseCallback: function() {
+                    destroyPopup();
+                  }
                 });
               }
               popup.open(3000); //Close after 3 seconds
@@ -613,14 +627,7 @@ goog.require('ga_topic_service');
                       }
                       onCloseCB = angular.noop;
                       gaPreviewFeatures.clear(map);
-                      $timeout(function() {
-                        // We destroy the popup only if it's still closed
-                        if (popup && popup.scope &&
-                            popup.scope.toggle === false) {
-                          popup.destroy();
-                          popup = undefined;
-                        }
-                      },0);
+                      destroyPopup();
                     },
                     onMouseEnter: function(evt, nbTooltips) {
                       if (nbTooltips == 1) return;


### PR DESCRIPTION
[Testlink for the print of vector layer with opacity < 1](https://mf-geoadmin3.dev.bgdi.ch/teo_fixes/?lang=fr&topic=ech&bgLayer=voidLayer&X=152800.00&Y=542200.00&zoom=4&dev3d=true&debug&layers=ch.swisstopo.pixelkarte-farbe-pk25.noscale,ch.bafu.hydroweb-messstationen_grundwasser,KML%7C%7Chttp:%2F%2Fwww.bikingspots.ch%2FcreateKMLFile.php%3Ffilename%3Dreno333508077c95ddec.xml%26fc%3D1&layers_opacity=0.75,0.5,0.35)

[Test link for the no info tooltip which was never destroyed](https://mf-geoadmin3.dev.bgdi.ch/teo_fixes/?lang=fr&topic=ech&bgLayer=voidLayer&X=116800.00&Y=666200.00&zoom=3&dev3d=true&debug&layers=ch.swisstopo.pixelkarte-farbe-pk25.noscale) 