### PR TITLE
Missing twitter image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ API_URL ?= //mf-chsdi3.dev.bgdi.ch
 LAST_API_URL := $(shell if [ -f .build-artefacts/last-api-url ]; then cat .build-artefacts/last-api-url 2> /dev/null; else echo '-none-'; fi)
 PUBLIC_URL ?= //public.dev.bgdi.ch
 E2E_TARGETURL ?= https://mf-geoadmin3.dev.bgdi.ch
+APPLICATION_URL ?= $(E2E_TARGETURL)
 PUBLIC_URL_REGEXP ?= ^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*
 ADMIN_URL_REGEXP ?= ^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)
 MAPPROXY_URL ?= //wmts{s}.dev.bgdi.ch
@@ -362,6 +363,7 @@ define buildpage
 		--var "versionslashed=$4" \
 		--var "apache_base_path=$(APACHE_BASE_PATH)" \
 		--var "api_url=$(API_URL)" \
+		--var "application_url=$(APPLICATION_URL)" \
 		--var "mapproxy_url=$(MAPPROXY_URL)" \
 		--var "shop_url=$(SHOP_URL)" \
 		--var "default_topic_id=$(DEFAULT_TOPIC_ID)" \

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -50,8 +50,8 @@ itemscope itemtype="http://schema.org/WebApplication"
     <meta property="og:title" content="Swiss Geoportal"/>
     <meta property="og:description" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
     <meta property="og:type" content="WebApplication"/>
-    <meta property="og:url" content="https://map.geo.admin.ch"/>
-    <meta property="og:image" content="https://map.geo.admin.ch/${versionslashed}img/logo_geoportal.png"/>
+    <meta property="og:url" content="${application_url}"/>
+    <meta property="og:image" content="${application_url}/${versionslashed}img/logo_geoportal.png"/>
 
     <!-- Twitter Card Infos -->
     <meta name="twitter:card" content="summary"/>
@@ -59,15 +59,15 @@ itemscope itemtype="http://schema.org/WebApplication"
     <meta name="twitter:creator" content="@swiss_geoportal"/>
     <meta name="twitter:title" content="geo.admin.ch"/>
     <meta name="twitter:description" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
-    <meta name="twitter:image" content="https://map.geo.admin.ch/${versionslashed}img/logo_geoportal.png"/>
-    <meta name="twitter:url" content="https://map.geo.admin.ch"/>
+    <meta name="twitter:image" content="${application_url}/${versionslashed}img/logo_geoportal.png"/>
+    <meta name="twitter:url" content="${application_url}"/>
 
     <!-- Facebook Specific fb:admins and fb.appid -->
 
     <!-- Google+ Specific Tags -->
     <meta itemprop="name" content="geo.admin.ch"/>
     <meta itemprop="description" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
-    <meta itemprop="image" content="https://map.geo.admin.ch/${versionslashed}img/logo_geoportal.png"/>
+    <meta itemprop="image" content="${application_url}/${versionslashed}img/logo_geoportal.png"/>
 
     <script>
       (function(){


### PR DESCRIPTION
See https://github.com/geoadmin/mf-geoadmin3/issues/3303


IFramely
http://iframely.com/debug?uri=https%3A%2F%2Fmf-geoadmin3.dev.bgdi.ch%2Fmom_twitter_image%2F

Twitter Validator
https://cards-dev.twitter.com/validator (ERROR: Fetching the page failed because it's denied by robots.txt.
!!!)

And if you wonder if the Twitter Bot begs to do some requests:
https://log0.prod.bgdi.ch/kibana/#/dashboard/elasticsearch/ltmom%20-%20twitter%20image

