### PR TITLE
Do not trigger a request if query is an empty str

### DIFF
--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -103,6 +103,8 @@ goog.require('ga_translation_service');
           }
           swisssearchActive = false;
           $rootScope.$broadcast('gaSwisssearchDone');
+        } else {
+          restat.reset();
         }
       };
 

--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -218,7 +218,6 @@ goog.require('ga_urlutils_service');
         var url = gaUrlUtils.append($scope.options.searchUrl,
                                     'type=' + $scope.type);
         url = $scope.typeSpecificUrl(url);
-
         $http.get(url, {
           cache: true,
           timeout: canceler.promise
@@ -300,10 +299,10 @@ goog.require('ga_urlutils_service');
 
       $scope.fuzzy = '';
 
-      $scope.$watch('options.searchUrl', function(newval) {
-        //cancel old requests
+      $scope.$watch('options.searchUrl', function() {
+        // cancel old requests
         cancel();
-        if (newval != '') {
+        if ($scope.options.query != '') {
           blockEvent = false;
           triggerSearch();
         } else {


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3350

ping @gjn 

newval used to refer to the whole url which was actually never equal to an empty string...

[Test Link](https://mf-geoadmin3.dev.bgdi.ch/gal_emptystring/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.pixelkarte-farbe-pk25.noscale,ch.swisstopo.lk25-papierkarte.metadata&layers_visibility=false,false,false,false,true,true&layers_timestamp=18641231,,,,,&X=159577.00&Y=535422.62&zoom=7)