### PR TITLE
add clipper to dhm25 layer for price service

### DIFF
--- a/src/components/shop/ShopService.js
+++ b/src/components/shop/ShopService.js
@@ -32,8 +32,9 @@ goog.require('ga_translation_service');
         'ch.swisstopo.pixelkarte-farbe-pk100.noscale':
             'ch.swisstopo.pixelkarte-pk100.metadata',
         'ch.swisstopo.pixelkarte-farbe-pk200.noscale':
-            'ch.swisstopo.pixelkarte-pk200.metadata'
-        //,'ch.swisstopo.digitales-hoehenmodell_25_reliefschattierung': '
+            'ch.swisstopo.pixelkarte-pk200.metadata',
+        'ch.swisstopo.digitales-hoehenmodell_25_reliefschattierung':
+            'ch.swisstopo.digitales-hoehenmodell_25_reliefschattierung'
       };
       var getParams = function(orderType, layerBodId, featureId, geometry) {
         var params = {


### PR DESCRIPTION
this PR is to able mapsheet order of dhm25, now that the price service is ready.
Here is a [test link](https://mf-geoadmin3.dev.bgdi.ch/frr_dhm25_price/?topic=ech&lang=fr&X=190000.00&Y=660000.00&zoom=1&bgLayer=ch.swisstopo.swissimage&layers=ch.swisstopo.digitales-hoehenmodell_25_reliefschattierung) to see if prices are correct. I still need to see if there is a mapsheet name that we can provide.