### PR TITLE
Resolutions support in gaStylesFromLiterals

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -825,8 +825,9 @@ goog.require('ga_urlutils_service');
                 cache: true
               }).success(function(data) {
                 var olStyleForVector = gaStylesFromLiterals(data);
-                olLayer.setStyle(function(feature) {
-                  return [olStyleForVector.getFeatureStyle(feature)];
+                olLayer.setStyle(function(feature, resolution) {
+                  return [olStyleForVector.getFeatureStyle(
+                      feature, resolution)];
                 });
               });
               // Handle error

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -118,6 +118,96 @@ describe('ga_stylesfromliterals_service', function() {
     expect(olImage.getStroke().getWidth() === 2).to.be(true);
   });
 
+  it('supports simple unique type style assignment resolution dependent', function() {
+
+    // ]maxResolution, minResolution]
+
+    var uniqueTypeStyleWithRes = {
+      type: 'unique',
+      property: 'foo',
+      values: [
+        {
+          geomType: 'point',
+          minResolution: 1.5,
+          maxResolution: 750,
+          value: 'bar',
+          vectorOptions: {
+            type: 'circle',
+            radius: 8,
+            fill: {
+              color: '#FF1FF1'
+            },
+            stroke: {
+              color: '#FFFFFF',
+              width: 3
+            }
+          }
+        }, {
+          geomType: 'point',
+          minResolution: 750,
+          value: 'bar',
+          vectorOptions: {
+            type: 'circle',
+            radius: 3,
+            fill: {
+              color: '#C03199'
+            },
+            stroke: {
+              color: '#C03199',
+              width: 1
+            }
+          }
+        }, {
+          geomType: 'point',
+          minResolution: 50,
+          maxResolution: 750,
+          value: 'toto',
+          vectorOptions: {
+            type: 'circle',
+            radius: 8,
+            fill: {
+              color: '#FF2222'
+            },
+            stroke: {
+              color: '#F55555',
+              width: 3
+            }
+          }
+        }, {
+          geomType: 'point',
+          minResolution: 750,
+          value: 'toto',
+          vectorOptions: {
+            type: 'circle',
+            radius: 3,
+            fill: {
+              color: '#C03122'
+            },
+            stroke: {
+              color: '#C03122',
+              width: 1
+            }
+          }
+        }
+      ]
+    };
+    var gaStyle = gaStylesFromLiterals(uniqueTypeStyleWithRes);
+    var geoJsonFormat = new ol.format.GeoJSON();
+    var olFeature = geoJsonFormat.readFeature(
+      '{"type": "Feature",' +
+        '"geometry": {' +
+          '"coordinates": [' +
+            '10000,' +
+            '20000' +
+          '],' +
+          '"type": "Point"' +
+        '},' +
+        '"properties": {' +
+          '"foo": "bar"' +
+        '}}'
+    );
+    var olStyle = gaStyle.getFeatureStyle(olFeature, 5.0);
+  });
 
   it('supports range type style assignment', function() {
     var rangeTypeStyle = {

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -29,10 +29,10 @@ describe('ga_stylesfromliterals_service', function() {
     expect(olStyle instanceof ol.style.Style).to.be(true);
     expect(olImage instanceof ol.style.Image).to.be(true);
     expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
-    expect(olImage.getFill().getColor() === '#FFFFFF').to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FFFFFF');
     expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
-    expect(olImage.getStroke().getColor() === '#FFFFFF').to.be(true);
-    expect(olImage.getStroke().getWidth() === 2).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
+    expect(olImage.getStroke().getWidth()).to.equal(2);
   });
 
   it('supports simple unique type style assignment', function() {
@@ -86,16 +86,16 @@ describe('ga_stylesfromliterals_service', function() {
           '"foo": "bar"' +
         '}}'
     );
-    var olStyle = gaStyle.getFeatureStyle(olFeature);
-    var olImage = olStyle.getImage();
+    olStyle = gaStyle.getFeatureStyle(olFeature);
+    olImage = olStyle.getImage();
     expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
     expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
-    expect(olImage.getFill().getColor() === '#FF1FF1').to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
     expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
-    expect(olImage.getStroke().getColor() === '#FFFFFF').to.be(true);
-    expect(olImage.getStroke().getWidth() === 3).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
+    expect(olImage.getStroke().getWidth()).to.equal(3);
 
-    var olFeature = geoJsonFormat.readFeature(
+    olFeature = geoJsonFormat.readFeature(
       '{"type": "Feature",' +
         '"geometry": {' +
           '"coordinates": [' +
@@ -108,20 +108,18 @@ describe('ga_stylesfromliterals_service', function() {
           '"foo": "toto"' +
         '}}'
     );
-    var olStyle = gaStyle.getFeatureStyle(olFeature);
-    var olImage = olStyle.getImage();
+    olStyle = gaStyle.getFeatureStyle(olFeature);
+    olImage = olStyle.getImage();
     expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
     expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
-    expect(olImage.getFill().getColor() === '#FF2222').to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FF2222');
     expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
-    expect(olImage.getStroke().getColor() === '#F55555').to.be(true);
-    expect(olImage.getStroke().getWidth() === 2).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#F55555');
+    expect(olImage.getStroke().getWidth()).to.equal(2);
   });
 
   it('supports simple unique type style assignment resolution dependent', function() {
-
     // ]maxResolution, minResolution]
-
     var uniqueTypeStyleWithRes = {
       type: 'unique',
       property: 'foo',
@@ -159,8 +157,6 @@ describe('ga_stylesfromliterals_service', function() {
           }
         }, {
           geomType: 'point',
-          minResolution: 50,
-          maxResolution: 750,
           value: 'toto',
           vectorOptions: {
             type: 'circle',
@@ -170,22 +166,7 @@ describe('ga_stylesfromliterals_service', function() {
             },
             stroke: {
               color: '#F55555',
-              width: 3
-            }
-          }
-        }, {
-          geomType: 'point',
-          minResolution: 750,
-          value: 'toto',
-          vectorOptions: {
-            type: 'circle',
-            radius: 3,
-            fill: {
-              color: '#C03122'
-            },
-            stroke: {
-              color: '#C03122',
-              width: 1
+              width: 2
             }
           }
         }
@@ -206,7 +187,54 @@ describe('ga_stylesfromliterals_service', function() {
           '"foo": "bar"' +
         '}}'
     );
-    var olStyle = gaStyle.getFeatureStyle(olFeature, 5.0);
+    var olStyle = gaStyle.getFeatureStyle(olFeature, 5);
+    var olImage = olStyle.getImage();
+    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
+    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
+    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
+    expect(olImage.getStroke().getWidth()).to.equal(3);
+
+    olStyle = gaStyle.getFeatureStyle(olFeature, 750);
+    olImage = olStyle.getImage();
+    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
+    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#C03199');
+    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#C03199');
+    expect(olImage.getStroke().getWidth()).to.equal(1);
+
+    olStyle = gaStyle.getFeatureStyle(olFeature, 2000);
+    olImage = olStyle.getImage();
+    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
+    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#C03199');
+    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#C03199');
+    expect(olImage.getStroke().getWidth()).to.equal(1);
+
+    olFeature = geoJsonFormat.readFeature(
+      '{"type": "Feature",' +
+        '"geometry": {' +
+          '"coordinates": [' +
+            '10000,' +
+            '20000' +
+          '],' +
+          '"type": "Point"' +
+        '},' +
+        '"properties": {' +
+          '"foo": "toto"' +
+        '}}'
+    );
+    olStyle = gaStyle.getFeatureStyle(olFeature, 2000);
+    olImage = olStyle.getImage();
+    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
+    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FF2222');
+    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#F55555');
+    expect(olImage.getStroke().getWidth()).to.equal(2);
   });
 
   it('supports range type style assignment', function() {
@@ -260,14 +288,14 @@ describe('ga_stylesfromliterals_service', function() {
           '"foo": 3' +
         '}}'
     );
-    var olStyle = gaStyle.getFeatureStyle(olFeature);
-    var olImage = olStyle.getImage();
+    olStyle = gaStyle.getFeatureStyle(olFeature);
+    olImage = olStyle.getImage();
     expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
     expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
-    expect(olImage.getFill().getColor() === '#FF1FF1').to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
     expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
-    expect(olImage.getStroke().getColor() === '#FFFFFF').to.be(true);
-    expect(olImage.getStroke().getWidth() === 3).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
+    expect(olImage.getStroke().getWidth()).to.equal(3);
 
     var olFeature = geoJsonFormat.readFeature(
       '{"type": "Feature",' +
@@ -286,9 +314,118 @@ describe('ga_stylesfromliterals_service', function() {
     var olImage = olStyle.getImage();
     expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
     expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
-    expect(olImage.getFill().getColor() === '#FF2222').to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FF2222');
     expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
-    expect(olImage.getStroke().getColor() === '#F55555').to.be(true);
-    expect(olImage.getStroke().getWidth() === 2).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#F55555');
+    expect(olImage.getStroke().getWidth()).to.equal(2);
+  });
+
+  it('supports range type style assignment resolution dependent', function() {
+    var rangeTypeStyle = {
+      type: 'range',
+      property: 'foo',
+      ranges: [
+        {
+          geomType: 'point',
+          range: [0, 10],
+          minResolution: 1.5,
+          maxResolution: 750,
+          vectorOptions: {
+            type: 'circle',
+            radius: 8,
+            fill: {
+              color: '#FF1FF1'
+            },
+            stroke: {
+              color: '#FFFFFF',
+              width: 3
+            }
+          }
+        }, {
+          geomType: 'point',
+          minResolution: 750,
+          range: [0, 10],
+          vectorOptions: {
+            type: 'circle',
+            radius: 2,
+            fill: {
+              color: '#GGGGGG'
+            },
+            stroke: {
+              color: '#AAAAAA',
+              width: 1
+            }
+          }
+        }, {
+          geomType: 'point',
+          range: [10, 20],
+          vectorOptions: {
+            type: 'circle',
+            radius: 8,
+            fill: {
+              color: '#FF2222'
+            },
+            stroke: {
+              color: '#F55555',
+              width: 2
+            }
+          }
+        }
+      ]
+    };
+    var gaStyle = gaStylesFromLiterals(rangeTypeStyle);
+    var geoJsonFormat = new ol.format.GeoJSON();
+    var olFeature = geoJsonFormat.readFeature(
+      '{"type": "Feature",' +
+        '"geometry": {' +
+          '"coordinates": [' +
+            '10000,' +
+            '20000' +
+          '],' +
+          '"type": "Point"' +
+        '},' +
+        '"properties": {' +
+          '"foo": 3' +
+        '}}'
+    );
+    var olStyle = gaStyle.getFeatureStyle(olFeature, 10);
+    var olImage = olStyle.getImage();
+    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
+    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
+    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
+    expect(olImage.getStroke().getWidth()).to.equal(3);
+
+    olStyle = gaStyle.getFeatureStyle(olFeature, 1000);
+    olImage = olStyle.getImage();
+    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
+    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#GGGGGG');
+    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#AAAAAA');
+    expect(olImage.getStroke().getWidth()).to.equal(1);
+
+    olFeature = geoJsonFormat.readFeature(
+      '{"type": "Feature",' +
+        '"geometry": {' +
+          '"coordinates": [' +
+            '15000,' +
+            '25000' +
+          '],' +
+          '"type": "Point"' +
+        '},' +
+        '"properties": {' +
+          '"foo": 11' +
+        '}}'
+    );
+    olStyle = gaStyle.getFeatureStyle(olFeature, 2000);
+    olImage = olStyle.getImage();
+    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
+    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olImage.getFill().getColor()).to.equal('#FF2222');
+    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke().getColor()).to.equal('#F55555');
+    expect(olImage.getStroke().getWidth()).to.equal(2);
   });
 });


### PR DESCRIPTION
https://github.com/geoadmin/mf-geoadmin3/issues/3378

ping @AFoletti You can use this branch for your test with the resolution dependent styles for the bike geojson (you need to change the BOD), it should be ready.
ping @oterral for the review.