### PR TITLE
Support attributions with no/invalid URLs

### DIFF
--- a/src/components/attribution/AttributionService.js
+++ b/src/components/attribution/AttributionService.js
@@ -31,8 +31,11 @@ goog.require('ga_urlutils_service');
           attribs[lang] = {};
         }
         if (!attribs[lang][key]) {
-          attribs[lang][key] = '<a target="new" href="' +
-              config.attributionUrl + '">' + config.attribution + '</a>';
+          attribs[lang][key] = config.attribution;
+          if (gaUrlUtils.isValid(config.attributionUrl)) {
+            attribs[lang][key] = '<a target="new" href="' +
+                config.attributionUrl + '">' + config.attribution + '</a>';
+          }
         }
         return attribs[lang][key];
       };

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -520,8 +520,8 @@ goog.require('ga_urlutils_service');
                 serverLayerName: 'ch.swisstopo.terrain.3d',
                 timestamps: ['20160115'],
                 attribution: 'swisstopo',
-                attributionUrl: 'http://www.swisstopo.admin.ch/internet/' +
-                    'swisstopo/' + lang + '/home.html'
+                attributionUrl: 'https://www.swisstopo.admin.ch/' + lang +
+                    '/home.html'
               };
             }
             if (!layers) { // First load

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -280,7 +280,7 @@ itemscope itemtype="http://schema.org/WebApplication"
       </div>
   % endif
      <div class="pull-right">
-        <a target="_blank" href="http://www.geo.admin.ch/internet/geoportal/{{langId}}/home/geoadmin/contact.html#copyright" translate>copyright_label</a>
+        <a target="_blank" href="https://www.geo.admin.ch/{{langId}}/about-swiss-geoportal/impressum.html#copyright" translate>copyright_label</a>
       </div>
   % if device == 'desktop':
       <div class="pull-right">
@@ -515,7 +515,7 @@ itemscope itemtype="http://schema.org/WebApplication"
               <p>
                 <a target="_blank" translate translate-attr-href="{{topicId + '_service_link_href'}}" >{{topicId + '_service_link_label'}}</a>
                 <br>
-                <a target="_blank" href="http://www.geo.admin.ch/internet/geoportal/{{langId}}/home/geoadmin/contact.html#copyright" translate>copyright_label</a>
+                <a target="_blank" href="https://www.geo.admin.ch/{{langId}}/about-swiss-geoportal/impressum.html#copyright" translate>copyright_label</a>
               </p>
             </div>
           </div>

--- a/test/specs/attribution/AttributionService.spec.js
+++ b/test/specs/attribution/AttributionService.spec.js
@@ -1,6 +1,7 @@
 describe('ga_attribution_service', function() {
   var gaAttribution, def, gaLang, lang = 'somelang';
   var bodAttribTemplate = '<a target="new" href="{{Url}}">{{Text}}</a>';
+  var bodAttribTemplateNoLink = '{{Text}}';
   var thirdPartyAttribTemplate = '<span class="ga-warning-tooltip">{{Text}}</span>';
   var layersConfig = {
     'layer': {
@@ -8,36 +9,35 @@ describe('ga_attribution_service', function() {
       attribution: 'Some text',
       attributionUrl: 'http://foo.com/bar.html',
       config3d: 'layer3d'
+    },
+    'layerNoLink': {
+      bodId: 'layerNoLink',
+      attribution: 'Some text',
+      attributionUrl: 'just.some.stuff',
+      config3d: 'layer3dNoLink'
     }
-  };
-  var layersConfigFR = {
-    'layer': {
-      bodId: 'layer',
-      attribution: 'Du texte',
-      attributionUrl: 'http://foo.com/fr/bar.html',
-      config3d: 'layer3d'
-    }
-  };
 
+  };
   var layersConfig3d = {
     'layer3d': {
       bodId: 'layer',
       attribution: 'Some 3d text',
       attributionUrl: 'http://foo3d.com/bar.html'
+    },
+    'layer3dNoLink': {
+      bodId: 'layerNoLink',
+      attribution: 'Some 3d text',
+      attributionUrl: 'just.some.stuff'
     }
   };
- 
-  var layersConfig3Fr = {
-    'layer3d': {
-      bodId: 'layer',
-      attribution: 'Du texte 3d',
-      attributionUrl: 'http://foo3d.com/fr/bar.html'
-    }
-  }; 
 
   var getBodAttrib = function(config) {
     return bodAttribTemplate.replace('{{Text}}', config.attribution).
         replace('{{Url}}', config.attributionUrl);
+  };
+
+  var getBodAttribNoLink = function(config) {
+    return bodAttribTemplateNoLink.replace('{{Text}}', config.attribution);
   };
 
   var getThirdPartyAttrib = function(text) {
@@ -88,6 +88,18 @@ describe('ga_attribution_service', function() {
     expect(attrib).to.be.eql(getBodAttrib(layerConfig));
     attrib = gaAttribution.getHtmlFromLayer(olLayer, true);
     expect(attrib).to.be.eql(getBodAttrib(layerConfig3d));
+    attrib = gaAttribution.getTextFromLayer(olLayer);
+    expect(attrib).to.be.eql(layerConfig.attribution);
+  });
+
+  it('gets attribution of bod layer with no link', function() {
+    var olLayer = {bodId: 'layerNoLink'};
+    var layerConfig = layersConfig['layerNoLink'];
+    var layerConfig3d = layersConfig3d['layer3dNoLink'];  
+    var attrib = gaAttribution.getHtmlFromLayer(olLayer); 
+    expect(attrib).to.be.eql(getBodAttribNoLink(layerConfig));
+    attrib = gaAttribution.getHtmlFromLayer(olLayer, true);
+    expect(attrib).to.be.eql(getBodAttribNoLink(layerConfig3d));
     attrib = gaAttribution.getTextFromLayer(olLayer);
     expect(attrib).to.be.eql(layerConfig.attribution);
   });


### PR DESCRIPTION
This PR

- adds support for attributions that don't have an URL. Currently, such attributions contain a link that is not valid. Now, the attribution text appears without a link
- Removes unneeded code
- Assures link to hardcoded 3D attribution points to correct location

It's part of https://github.com/geoadmin/mf-geoadmin3/issues/3386 fixes.

[Testlink (look at attribution just below background switcher)](https://mf-geoadmin3.dev.bgdi.ch/gjn_attribution/?lang=en&topic=swisstopo&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung,ch.bazl.sachplan-infrastruktur-luftfahrt_kraft&layers_opacity=0.75,1&X=226481.36&Y=659634.32&zoom=0)