### PR TITLE
Add vector label support

### DIFF
--- a/JSONSTYLES.md
+++ b/JSONSTYLES.md
@@ -1,0 +1,192 @@
+JSON Geadmin Vector Styling Specs
+=================================
+
+3 main categories are currently available via json style sheet in geoadmin.
+This property is defined at top as follow:
+
+```json
+{
+  "type": "single|unique|range",
+  // ...
+}
+```
+
+Type single
+-----------
+
+The type `single` is used when all the features should have the same style.
+
+A JSON stylesheet of `single` type is structured as follow:
+
+```json
+{
+  "type": "single",
+  "geomType": "point|line|polygon",
+  "vectorOptions": {
+    // ...
+  }
+}
+```
+
+Just after defining the type of style sheet, one must define the geometry type to expect.
+
+* point: A Point or MultiPoint layer
+* line: A Line or MultiLine layer
+* polygon: A Polygon or MultiPolygon layer
+
+The `vectorOptions` property defines the style to apply and is structured as follow:
+
+```json
+{
+  "type": "single",
+  "geomType": "point",
+  "vectorOptions": {
+    "type": "circle|icon|square|triangle|star|cross",
+    "radius": 10,
+    "stroke": {
+      // The stroke style
+    },
+    "fill": {
+      // The fill style
+    },
+    "label": {
+      "property": "aPropertyName",
+      "text": {
+        // The text style
+      }
+    }
+  }
+}
+```
+
+For `point` geomType one has couple of options to choose from.
+
+* circle: creates an instance of [ol.style.Circle](http://openlayers.org/en/latest/apidoc/ol.style.Circle.html).
+* icon: creates an instance of [ol.style.Icon](http://openlayers.org/en/latest/apidoc/ol.style.Icon.html).
+* square|triangle|star|cross: creates an instance of [ol.style.RegularShape](http://openlayers.org/en/latest/apidoc/ol.style.RegularShape.html).
+
+For `point` geomType the radius (given in pixels) determines the size of the symbol.
+
+* stroke: same options as defined in [ol.style.Stroke](http://openlayers.org/en/latest/apidoc/ol.style.Stroke.html).
+* fill: same options as defined in [ol.style.Fill](http://openlayers.org/en/latest/apidoc/ol.style.Fill.html).
+* label->text: same options as defined in [ol.style.Text](http://openlayers.org/en/latest/apidoc/ol.style.Text.html)
+
+Type unique
+-----------
+
+The type `unique` is used when style is based on a unique property value.
+
+A JSON stylesheet of `single` type is structured as follow:
+
+```json
+{
+  "type": "unique",
+  "property": "aPropertyName",
+  "values": [
+    {
+      "geomType": "point|line|polygon",
+      "value": "aPropertyValue",
+      "minResolution": "optionalMinResolution",
+      "maxResolution": "optionalMaxResolution",
+      "vectorOptions": {
+        // As defined for single type
+      }
+    },
+    {
+      // ...
+    }
+  ]
+}
+```
+
+A `unique` JSON style is always based on a property available on all the features.
+Once a `property` is defined, an array of possible `values` determine all the possible combinations for a given layer.
+Notice the use of `value` which determine for which value of the features the style should be apply.
+Optionally, one can define a `minResolution` and `maxResolution` at which the style should be applied. `[minResolution, maxResolution[`
+
+
+**Example**:
+
+```json
+{
+  "type": "unique",
+  "property": "foo",
+  "values": [
+    {
+      "geomType": "line",
+      "value": "bar",
+      "minResolution": 10,
+      "maxResolution": 1000,
+      "vectorOptions": {
+        "stroke": {
+          "color": "#FFFFFF",
+          "width": 3
+        },
+        "label": {
+          "property": "oraison",
+          "text": {
+            "textAlign": "center",
+            "textBaseline": "middle",
+            "font": "bold 10px Helvetica",
+            "scale": 1.1,
+            "offsetX": 1,
+            "offsetY": 2,
+            "stroke": {
+              "color": "rgba(22, 22, 22, 0.4)",
+              "width": 4
+            },
+            "fill": {
+              "color": "rgba(52, 52, 52, 0.3)",
+            }
+          }
+        }
+      }
+    }, {
+      "geomType": "point",
+      "value": "toto",
+      "vectorOptions": {
+        "type": "circle",
+        "radius": 2,
+        "fill": {
+          "color": "#FF2222"
+        },
+        "stroke": {
+          "color": "#F55555",
+          "width": 3
+        }
+      }
+    }
+  ]
+}
+```
+
+Type range
+----------
+
+The type `range` is used when a style is based on numerical values belonging to a given range.
+
+A JSON stylesheet of `range` type is structured as follow:
+
+```json
+{
+  "type": "range",
+  "property": "aPropertyName",
+  "ranges": [
+    {
+      "geomType": "point|line|polygon",
+      "range": [0, 100],
+      "minResolution": "optionalMinResolution",
+      "maxResolution": "optionalMaxResolution",
+      "vectorOptions": {
+        // As defined for single type
+      }
+    },
+    {
+      // ...
+    }
+  ]
+}
+```
+
+Once a `property` is defined, an array of possible `ranges` determine all the possible combinations for a given layer. `[minVal, maxVal[`
+`minResolution`, `maxResolution` and `vectorOptions` work as defined earlier.

--- a/JSONSTYLES.md
+++ b/JSONSTYLES.md
@@ -81,11 +81,11 @@ A JSON stylesheet of `single` type is structured as follow:
 ```json
 {
   "type": "unique",
-  "property": "aPropertyName",
+  "property": "optionalPropertyName",
   "values": [
     {
       "geomType": "point|line|polygon",
-      "value": "aPropertyValue",
+      "value": "optionalPropertyValue",
       "minResolution": "optionalMinResolution",
       "maxResolution": "optionalMaxResolution",
       "vectorOptions": {
@@ -99,8 +99,8 @@ A JSON stylesheet of `single` type is structured as follow:
 }
 ```
 
-A `unique` JSON style is always based on a property available on all the features.
-Once a `property` is defined, an array of possible `values` determine all the possible combinations for a given layer.
+A `unique` JSON style can be based on a property available on all features, a resolution range or a combination of both.
+If `property` is defined, an array of possible `values` determine all the possible combinations for a given layer.
 Notice the use of `value` which determine for which value of the features the style should be apply.
 Optionally, one can define a `minResolution` and `maxResolution` at which the style should be applied. `[minResolution, maxResolution[`
 

--- a/src/components/StylesFromLiteralsService.js
+++ b/src/components/StylesFromLiteralsService.js
@@ -146,7 +146,7 @@ goog.provide('ga_stylesfromliterals_service');
           for (range in this.styles[geomType]) {
             range = range.split(',');
             if (value >= parseFloat(range[0]) &&
-                value <= parseFloat(range[1])) {
+                value < parseFloat(range[1])) {
               var style = this.styles[geomType][range];
               olStyle = style;
               break;

--- a/src/components/StylesFromLiteralsService.js
+++ b/src/components/StylesFromLiteralsService.js
@@ -70,7 +70,7 @@ goog.provide('ga_stylesfromliterals_service');
           var basicStyles = getOlBasicStyles(style);
           var olImage = angular.extend({}, style, basicStyles);
           delete olImage.label;
-          olImage = getOlStyleForPoint(basicStyles, style.type);
+          olImage = getOlStyleForPoint(olImage, style.type);
           olStyles.image = olImage;
           olStyles.text = olText;
         } else {
@@ -100,23 +100,23 @@ goog.provide('ga_stylesfromliterals_service');
 
       function getLabelProperty(value) {
         if (value) {
-          return value.property !== undefined ? value.property : null;
+          return value.property;
         }
-        return null;
       }
 
       function getMinResolution(value) {
-        return value.minResolution !== undefined ? value.minResolution : 0;
+        return value.minResolution || 0;
       }
 
       function getMaxResolution(value) {
-        return value.maxResolution !== undefined ? value.maxResolution :
-            Infinity;
+        return value.maxResolution || Infinity;
       }
 
 
       var olStyleForPropertyValue = function(properties) {
         this.singleStyle = null;
+
+        this.defaultVal = 'defaultVal';
 
         this.styles = {
           point: {},
@@ -170,6 +170,10 @@ goog.provide('ga_stylesfromliterals_service');
 
       olStyleForPropertyValue.prototype.pushOrInitialize_ = function(
           geomType, key, styleSpec) {
+        // Happens when styling is only resolution dependent (unique type only)
+        if (key === undefined) {
+          key = this.defaultVal;
+        }
         if (!this.styles[geomType][key]) {
           this.styles[geomType][key] = [styleSpec];
         } else {
@@ -184,8 +188,7 @@ goog.provide('ga_stylesfromliterals_service');
           range = range.split(',');
           if (value >= parseFloat(range[0]) &&
               value < parseFloat(range[1])) {
-            var style = this.styles[geomType][range];
-            olStyle = style;
+            olStyle = this.styles[geomType][range];
             break;
           }
         }
@@ -218,7 +221,7 @@ goog.provide('ga_stylesfromliterals_service');
           return this.singleStyle.olStyle;
         } else if (this.type === 'unique') {
           var properties = feature.getProperties();
-          var value = properties[this.key];
+          var value = properties[this.key] || this.defaultVal;
           var geomType = getGeomTypeFromGeometry(feature.getGeometry());
           var olStyles = this.styles[geomType][value];
           var res = this.getOlStyleForResolution_(olStyles, resolution);

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -162,7 +162,7 @@ describe('ga_stylesfromliterals_service', function() {
   });
 
   it('supports simple unique type style assignment resolution dependent', function() {
-    // ]maxResolution, minResolution]
+    // [minResolution, maxResolution[
     var uniqueTypeStyleWithRes = {
       type: 'unique',
       property: 'foo',
@@ -340,7 +340,7 @@ describe('ga_stylesfromliterals_service', function() {
     expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
     expect(olImage.getStroke().getWidth()).to.equal(3);
 
-    var olFeature = geoJsonFormat.readFeature(
+    olFeature = geoJsonFormat.readFeature(
       '{"type": "Feature",' +
         '"geometry": {' +
           '"coordinates": [' +
@@ -353,8 +353,30 @@ describe('ga_stylesfromliterals_service', function() {
           '"foo": 11' +
         '}}'
     );
-    var olStyle = gaStyle.getFeatureStyle(olFeature);
-    var olImage = olStyle.getImage();
+    olStyle = gaStyle.getFeatureStyle(olFeature);
+    olImage = olStyle.getImage();
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
+    expect(olImage.getFill().getColor()).to.equal('#FF2222');
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
+    expect(olImage.getStroke().getColor()).to.equal('#F55555');
+    expect(olImage.getStroke().getWidth()).to.equal(2);
+
+    olFeature = geoJsonFormat.readFeature(
+      '{"type": "Feature",' +
+        '"geometry": {' +
+          '"coordinates": [' +
+            '11000,' +
+            '21000' +
+          '],' +
+          '"type": "Point"' +
+        '},' +
+        '"properties": {' +
+          '"foo": 10' +
+        '}}'
+    );
+    olStyle = gaStyle.getFeatureStyle(olFeature);
+    olImage = olStyle.getImage();
     expect(olStyle.getImage()).to.be.an(ol.style.Image);
     expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF2222');

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -7,7 +7,7 @@ describe('ga_stylesfromliterals_service', function() {
     });
   });
   
-  it('supports single type style assignment for a point', function() {
+  it('supports single type style assignment for a point, line and polygon', function() {
     var singleTypeStyle = {
       type: 'single',
       geomType: 'point',
@@ -26,13 +26,56 @@ describe('ga_stylesfromliterals_service', function() {
     var gaStyle = gaStylesFromLiterals(singleTypeStyle);
     var olStyle = gaStyle.getFeatureStyle();
     var olImage = olStyle.getImage();
-    expect(olStyle instanceof ol.style.Style).to.be(true);
-    expect(olImage instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle).to.be.an(ol.style.Style);
+    expect(olImage).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FFFFFF');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
     expect(olImage.getStroke().getWidth()).to.equal(2);
+
+    singleTypeStyle = {
+      type: 'single',
+      geomType: 'line',
+      vectorOptions: {
+        stroke: {
+          color: '#FF1FF1',
+          width: 3,
+          lineCap: 'square',
+          lineJoin: 'square'
+        }
+      }
+    };
+    gaStyle = gaStylesFromLiterals(singleTypeStyle);
+    olStyle = gaStyle.getFeatureStyle();
+    expect(olStyle).to.be.an(ol.style.Style);
+    expect(olStyle.getStroke()).to.be.an(ol.style.Stroke);
+    expect(olStyle.getStroke().getColor()).to.equal('#FF1FF1');
+    expect(olStyle.getStroke().getWidth()).to.equal(3);
+    expect(olStyle.getStroke().getLineCap()).to.equal('square');
+    expect(olStyle.getStroke().getLineJoin()).to.equal('square');
+
+    singleTypeStyle = {
+      type: 'single',
+      geomType: 'polygon',
+      vectorOptions: {
+        fill: {
+          color: '#FF2FF2',
+        },
+        stroke: {
+          color: '#GG1GG1',
+          width: 5
+        }
+      }
+    };
+    gaStyle = gaStylesFromLiterals(singleTypeStyle);
+    olStyle = gaStyle.getFeatureStyle();
+    expect(olStyle).to.be.an(ol.style.Style);
+    expect(olStyle.getStroke()).to.be.an(ol.style.Stroke);
+    expect(olStyle.getStroke().getColor()).to.equal('#GG1GG1');
+    expect(olStyle.getStroke().getWidth()).to.equal(5);
+    expect(olStyle.getFill()).to.be.an(ol.style.Fill);
+    expect(olStyle.getFill().getColor()).to.equal('#FF2FF2');
   });
 
   it('supports simple unique type style assignment', function() {
@@ -88,10 +131,10 @@ describe('ga_stylesfromliterals_service', function() {
     );
     olStyle = gaStyle.getFeatureStyle(olFeature);
     olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
     expect(olImage.getStroke().getWidth()).to.equal(3);
 
@@ -110,10 +153,10 @@ describe('ga_stylesfromliterals_service', function() {
     );
     olStyle = gaStyle.getFeatureStyle(olFeature);
     olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF2222');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#F55555');
     expect(olImage.getStroke().getWidth()).to.equal(2);
   });
@@ -189,28 +232,28 @@ describe('ga_stylesfromliterals_service', function() {
     );
     var olStyle = gaStyle.getFeatureStyle(olFeature, 5);
     var olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
     expect(olImage.getStroke().getWidth()).to.equal(3);
 
     olStyle = gaStyle.getFeatureStyle(olFeature, 750);
     olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#C03199');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#C03199');
     expect(olImage.getStroke().getWidth()).to.equal(1);
 
     olStyle = gaStyle.getFeatureStyle(olFeature, 2000);
     olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#C03199');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#C03199');
     expect(olImage.getStroke().getWidth()).to.equal(1);
 
@@ -229,10 +272,10 @@ describe('ga_stylesfromliterals_service', function() {
     );
     olStyle = gaStyle.getFeatureStyle(olFeature, 2000);
     olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF2222');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#F55555');
     expect(olImage.getStroke().getWidth()).to.equal(2);
   });
@@ -290,10 +333,10 @@ describe('ga_stylesfromliterals_service', function() {
     );
     olStyle = gaStyle.getFeatureStyle(olFeature);
     olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
     expect(olImage.getStroke().getWidth()).to.equal(3);
 
@@ -312,10 +355,10 @@ describe('ga_stylesfromliterals_service', function() {
     );
     var olStyle = gaStyle.getFeatureStyle(olFeature);
     var olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF2222');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#F55555');
     expect(olImage.getStroke().getWidth()).to.equal(2);
   });
@@ -390,19 +433,19 @@ describe('ga_stylesfromliterals_service', function() {
     );
     var olStyle = gaStyle.getFeatureStyle(olFeature, 10);
     var olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
     expect(olImage.getStroke().getWidth()).to.equal(3);
 
     olStyle = gaStyle.getFeatureStyle(olFeature, 1000);
     olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#GGGGGG');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#AAAAAA');
     expect(olImage.getStroke().getWidth()).to.equal(1);
 
@@ -421,10 +464,10 @@ describe('ga_stylesfromliterals_service', function() {
     );
     olStyle = gaStyle.getFeatureStyle(olFeature, 2000);
     olImage = olStyle.getImage();
-    expect(olStyle.getImage() instanceof ol.style.Image).to.be(true);
-    expect(olImage.getFill() instanceof ol.style.Fill).to.be(true);
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF2222');
-    expect(olImage.getStroke() instanceof ol.style.Stroke).to.be(true);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#F55555');
     expect(olImage.getStroke().getWidth()).to.equal(2);
   });

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -33,6 +33,7 @@ describe('ga_stylesfromliterals_service', function() {
     expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
     expect(olImage.getStroke().getWidth()).to.equal(2);
+    expect(olImage.getRadius()).to.equal(8);
 
     singleTypeStyle = {
       type: 'single',
@@ -139,6 +140,7 @@ describe('ga_stylesfromliterals_service', function() {
     expect(olImage.getStroke().getWidth()).to.equal(3);
     expect(olImage.getFill()).to.be.an(ol.style.Fill);
     expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
+    expect(olImage.getRadius()).to.equal(8);
     expect(olText.getText()).to.equal('bar');
     expect(olText.getFill()).to.be.an(ol.style.Fill);
     expect(olText.getStroke()).to.an(ol.style.Stroke);
@@ -460,6 +462,54 @@ describe('ga_stylesfromliterals_service', function() {
     expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
     expect(olImage.getStroke().getColor()).to.equal('#F55555');
     expect(olImage.getStroke().getWidth()).to.equal(2);
+
+    // Resolution only
+    uniqueTypeStyleWithRes = {
+      type: 'unique',
+      values: [
+        {
+          geomType: 'point',
+          minResolution: 1.5,
+          maxResolution: 750,
+          vectorOptions: {
+            type: 'circle',
+            radius: 8,
+            fill: {
+              color: '#FF1FF1'
+            },
+            stroke: {
+              color: '#FFFFFF',
+              width: 3
+            }
+          }
+        }, {
+          geomType: 'point',
+          minResolution: 750,
+          vectorOptions: {
+            type: 'circle',
+            radius: 3,
+            fill: {
+              color: '#C03199'
+            },
+            stroke: {
+              color: '#C03199',
+              width: 1
+            }
+          }
+        }
+      ]
+    };
+
+    gaStyle = gaStylesFromLiterals(uniqueTypeStyleWithRes);
+    olStyle = gaStyle.getFeatureStyle(olFeature, 2000);
+    olImage = olStyle.getImage();
+    expect(olStyle.getImage()).to.be.an(ol.style.Image);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
+    expect(olImage.getFill().getColor()).to.equal('#C03199');
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
+    expect(olImage.getStroke().getColor()).to.equal('#C03199');
+    expect(olImage.getStroke().getWidth()).to.equal(1);
+    expect(olImage.getRadius()).to.equal(3);
   });
 
   it('supports range type style assignment', function() {

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -78,6 +78,188 @@ describe('ga_stylesfromliterals_service', function() {
     expect(olStyle.getFill().getColor()).to.equal('#FF2FF2');
   });
 
+  it('supports label for single type style assignment', function() {
+    var singleTypeStyle = {
+      type: 'single',
+      geomType: 'point',
+      vectorOptions: {
+        type: 'circle',
+        radius: 8,
+        fill: {
+          color: '#FF1FF1'
+        },
+        stroke: {
+          color: '#FFFFFF',
+          width: 3
+        },
+        label: {
+          property: 'foo',
+          text: {
+            textAlign: 'center',
+            textBaseline: 'middle',
+            font: 'bold 10px Helvetica',
+            scale: 1.5,
+            offsetX: 0,
+            offsetY: 0,
+            stroke: {
+              color: 'rgba(255, 255, 255, 0.7)',
+              width: 4
+            },
+            fill: {
+              color: 'rgba(52, 52, 52, 0.95)',
+            }
+          }
+        }
+      }
+    };
+    var geoJsonFormat = new ol.format.GeoJSON();
+    var olFeature = geoJsonFormat.readFeature(
+      '{"type": "Feature",' +
+        '"geometry": {' +
+          '"coordinates": [' +
+            '10000,' +
+            '20000' +
+          '],' +
+          '"type": "Point"' +
+        '},' +
+        '"properties": {' +
+          '"foo": "bar"' +
+        '}}'
+    );
+    var gaStyle = gaStylesFromLiterals(singleTypeStyle);
+    var olStyle = gaStyle.getFeatureStyle(olFeature);
+    var olImage = olStyle.getImage();
+    var olText = olStyle.getText();
+    expect(olStyle).to.be.an(ol.style.Style);
+    expect(olImage).to.be.an(ol.style.Image);
+    expect(olImage).to.be.an(ol.style.Circle);
+    expect(olText).to.be.an(ol.style.Text);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
+    expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
+    expect(olImage.getStroke().getWidth()).to.equal(3);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
+    expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
+    expect(olText.getText()).to.equal('bar');
+    expect(olText.getFill()).to.be.an(ol.style.Fill);
+    expect(olText.getStroke()).to.an(ol.style.Stroke);
+    expect(olText.getScale()).to.equal(1.5);
+    expect(olText.getOffsetX()).to.equal(0);
+    expect(olText.getOffsetY()).to.equal(0);
+    expect(olText.getTextAlign()).to.equal('center');
+    expect(olText.getTextBaseline()).to.equal('middle');
+  });
+
+  it('supports label for unique type style assignment', function() {
+    var uniqueTypeStyle = {
+      type: 'unique',
+      property: 'foo',
+      values: [
+        {
+          geomType: 'line',
+          value: 'bar',
+          vectorOptions: {
+            stroke: {
+              color: '#FFFFFF',
+              width: 3
+            },
+            label: {
+              property: 'oraison',
+              text: {
+                textAlign: 'center',
+                textBaseline: 'middle',
+                font: 'bold 10px Helvetica',
+                scale: 1.1,
+                offsetX: 1,
+                offsetY: 2,
+                stroke: {
+                  color: 'rgba(22, 22, 22, 0.4)',
+                  width: 4
+                },
+                fill: {
+                  color: 'rgba(52, 52, 52, 0.3)',
+                }
+              }
+            }
+          }
+        }, {
+          geomType: 'point',
+          value: 'toto',
+          vectorOptions: {
+            type: 'circle',
+            radius: 2,
+            fill: {
+              color: '#FF2222'
+            },
+            stroke: {
+              color: '#F55555',
+              width: 3
+            }
+          }
+        }
+      ]
+    };
+    var geoJsonFormat = new ol.format.GeoJSON();
+    var olFeature = geoJsonFormat.readFeature(
+      '{"type": "Feature",' +
+        '"geometry": {' +
+          '"coordinates": [' +
+            '10000,' +
+            '20000' +
+          '],' +
+          '"type": "Point"' +
+        '},' +
+        '"properties": {' +
+          '"foo": "toto",' +
+          '"oraison": "mylord"' +
+        '}}'
+    );
+    var gaStyle = gaStylesFromLiterals(uniqueTypeStyle);
+    var olStyle = gaStyle.getFeatureStyle(olFeature);
+    var olImage = olStyle.getImage();
+    var olText = olStyle.getText();
+    expect(olStyle).to.be.an(ol.style.Style);
+    expect(olImage).to.be.an(ol.style.Image);
+    expect(olImage).to.be.an(ol.style.Circle);
+    expect(olText).to.equal(null);
+    expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
+    expect(olImage.getFill()).to.be.an(ol.style.Fill);
+    expect(olImage.getStroke().getColor()).to.equal('#F55555');
+    expect(olImage.getFill().getColor()).to.equal('#FF2222');
+
+    olFeature = geoJsonFormat.readFeature(
+      '{"type": "Feature",' +
+        '"geometry": {' +
+          '"coordinates": [' +
+            '[10000,' +
+             '20000],' +
+            '[12000,' +
+             '21000]' +
+          '],' +
+          '"type": "LineString"' +
+        '},' +
+        '"properties": {' +
+          '"foo": "bar",' +
+          '"oraison": "mylady"' +
+        '}}'
+    );
+    olStyle = gaStyle.getFeatureStyle(olFeature);
+    olImage = olStyle.getImage();
+    olText = olStyle.getText();
+    expect(olStyle).to.be.an(ol.style.Style);
+    expect(olImage).not.to.be.an(ol.style.Image);
+    expect(olText).to.be.an(ol.style.Text);
+    expect(olStyle.getStroke()).to.be.an(ol.style.Stroke);
+    expect(olStyle.getStroke().getColor()).to.equal('#FFFFFF');
+    expect(olStyle.getStroke().getWidth()).to.equal(3);
+    expect(olText.getText()).to.equal('mylady');
+    expect(olText.getStroke()).to.an(ol.style.Stroke);
+    expect(olText.getScale()).to.equal(1.1);
+    expect(olText.getOffsetX()).to.equal(1);
+    expect(olText.getOffsetY()).to.equal(2);
+    expect(olText.getTextAlign()).to.equal('center');
+    expect(olText.getTextBaseline()).to.equal('middle');
+  });
+
   it('supports simple unique type style assignment', function() {
     var uniqueTypeStyle = {
       type: 'unique',


### PR DESCRIPTION
This PR adds:
* labels support to Vector Layers (points, lines and polygons) via JSON config files.
* additional tests
* a specification document to configure vector layers

I provide a couple of test links/show cases tomorrow.