### PR TITLE
Add support for default EPSG other than 21781

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ RESOLUTIONS ?= '[650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0, 2.5, 2.0, 1.
 LEVEL_OF_DETAILS ?= '[6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 16, 17, 18, 18]' #lods corresponding to resolutions
 DEFAULT_EPSG ?= EPSG:21781
 DEFAULT_EPSG_EXTEND ?= '[420000, 30000, 900000, 350000]'
+DEFAULT_EPSG_CONTEXT_POPUP_TITLE ?= CH1903 / LV03
+DEFAULT_TO_SECONDARY_EPSG_URL ?= https://geodesy.geo.admin.ch/reframe/lv03tolv95
+SECONDARY_EPSG ?= EPSG:2056
+SECONDARY_EPSG_EXTENT ?= '[2485071.58, 1075346.31, 2828515.82, 1299941.79]'
+SECONDARY_EPSG_CONTEXT_POPUP_TITLE ?= CH1903+ / LV95
 DEFAULT_ELEVATION_MODEL ?= COMB
 DEFAULT_TERRAIN ?= ch.swisstopo.terrain.3d
 SAUCELABS_TESTS ?=
@@ -381,6 +386,11 @@ define buildpage
 		--var "public_url_regexp=$(PUBLIC_URL_REGEXP)" \
 		--var "default_epsg"="$(DEFAULT_EPSG)" \
 		--var "default_epsg_extend"="$(DEFAULT_EPSG_EXTEND)" \
+        --var "default_epsg_context_popup_title"="$(DEFAULT_EPSG_CONTEXT_POPUP_TITLE)" \
+        --var "default_to_secondary_epsg_url"="$(DEFAULT_TO_SECONDARY_EPSG_URL)" \
+        --var "secondary_epsg"="$(SECONDARY_EPSG)" \
+        --var "secondary_epsg_extent"="$(SECONDARY_EPSG_EXTENT)" \
+        --var "secondary_epsg_context_popup_title"="$(SECONDARY_EPSG_CONTEXT_POPUP_TITLE)" \
 		--var "staging"="$(DEPLOY_TARGET)" $< > $@
 endef
 

--- a/src/components/contextpopup/partials/contextpopup.html
+++ b/src/components/contextpopup/partials/contextpopup.html
@@ -8,13 +8,13 @@
       <table>
           <tbody>
           <tr>
-              <td>CH1903 / LV03</td>
+              <td>{{defaultEpsgContextPopupTitle}}</td>
               <td><a href="{{contextPermalink}}"
-                     target="_blank">{{coord21781}}</a></td>
+                     target="_blank">{{coordDefaultEpsg}}</a></td>
           </tr>
           <tr>
-              <td>CH1903+ / LV95</td>
-              <td>{{coord2056}}</td>
+              <td>{{secondaryEpsgContextPopupTitle}}</td>
+              <td>{{coordSecondaryEpsg}}</td>
           </tr>
           <tr>
               <td>WGS 84 (lat/lon)</td>

--- a/src/components/map/MapDirective.js
+++ b/src/components/map/MapDirective.js
@@ -42,7 +42,7 @@ goog.require('ga_styles_service');
 
   module.directive('gaMap', function($window, $rootScope, $timeout, gaPermalink,
       gaStyleFactory, gaBrowserSniffer, gaLayers, gaDebounce, gaOffline,
-      gaMapUtils) {
+      gaMapUtils, gaGlobalOptions) {
     return {
       restrict: 'A',
       scope: {
@@ -61,9 +61,9 @@ goog.require('ga_styles_service');
           if (isFinite(easting) && isFinite(northing)) {
             var position = [easting, northing];
             if (ol.extent.containsCoordinate(
-                [2420000, 1030000, 2900000, 1350000], position)) {
+                gaGlobalOptions.secondaryEpsgExtent, position)) {
               position = ol.proj.transform([easting, northing],
-                'EPSG:2056', 'EPSG:21781');
+                gaGlobalOptions.secondaryEpsg, gaGlobalOptions.defaultEpsg);
             }
             view.setCenter(position);
           }

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -701,8 +701,11 @@ goog.require('ga_urlutils_service');
           var olSource = (layer.timeEnabled) ? null : layer.olSource;
           if (layer.type == 'wmts') {
             if (!olSource) {
+              var tileMatrixSet = layer.epsg ?
+                  layer.epsg : gaGlobalOptions.defaultEpsg;
+              tileMatrixSet = tileMatrixSet.replace('EPSG:', '');
               var wmtsTplUrl = getWmtsGetTileTpl(layer.serverLayerName, null,
-                  '21781', layer.format, true)
+                  tileMatrixSet, layer.format, true)
                   .replace('{z}', '{TileMatrix}')
                   .replace('{x}', '{TileCol}')
                   .replace('{y}', '{TileRow}');
@@ -714,7 +717,7 @@ goog.require('ga_urlutils_service');
                 // Temporary until https://github.com/openlayers/ol3/pull/4964
                 // is merged upstream
                 cacheSize: 2048 * 3,
-                projection: gaGlobalOptions.defaultEpsg,
+                projection: layer.epsg || gaGlobalOptions.defaultEpsg,
                 requestEncoding: 'REST',
                 tileGrid: gaTileGrid.get(layer.resolutions,
                     layer.minResolution),

--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -24,7 +24,7 @@ goog.provide('ga_search_service');
     '([\\s,]+([\\d\\.\']+)[\\s,]+([\\d\\.\']+))?');
 
   module.provider('gaSearchGetCoordinate', function() {
-    this.$get = function() {
+    this.$get = function(gaGlobalOptions) {
       return function(extent, query) {
         var position;
         var valid = false;
@@ -61,7 +61,7 @@ goog.provide('ga_search_service');
             .replace('\'\'' , '').replace('′′' , '')
             .replace('″' , '')) / 3600;
           position = ol.proj.transform([easting, northing],
-                'EPSG:4326', 'EPSG:21781');
+                'EPSG:4326', gaGlobalOptions.defaultEpsg);
           if (ol.extent.containsCoordinate(
             extent, position)) {
               valid = true;
@@ -88,7 +88,7 @@ goog.provide('ga_search_service');
             valid = true;
           } else {
             position = ol.proj.transform(position,
-              'EPSG:2056', 'EPSG:21781');
+              gaGlobalOptions.secondaryEpsg, gaGlobalOptions.defaultEpsg);
             if (ol.extent.containsCoordinate(
                 extent, position)) {
               valid = true;
@@ -97,7 +97,7 @@ goog.provide('ga_search_service');
                 [left < right ? left : right,
                   right > left ? right : left];
               position = ol.proj.transform(position,
-                'EPSG:4326', 'EPSG:21781');
+                'EPSG:4326', gaGlobalOptions.defaultEpsg);
               if (ol.extent.containsCoordinate(
                 extent, position)) {
                 valid = true;

--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -25,12 +25,12 @@ goog.require('ga_urlutils_service');
     return $.map(extent, parseFloat);
   };
 
-  var addOverlay = function(gaOverlay, map, res) {
+  var addOverlay = function(gaOverlay, map, res, destinationEpsg) {
     var visible = originToZoomLevel.hasOwnProperty(res.attrs.origin);
     var center = [res.attrs.y, res.attrs.x];
     if (!res.attrs.y || !res.attrs.x) {
       center = ol.proj.transform([res.attrs.lon, res.attrs.lat],
-          'EPSG:4326', 'EPSG:21781');
+          'EPSG:4326', destinationEpsg);
     }
     gaOverlay.add(map,
                   center,
@@ -190,7 +190,7 @@ goog.require('ga_urlutils_service');
 
   module.controller('GaSearchTypesController',
     function($scope, $http, $q, $sce, gaUrlUtils, gaSearchLabels,
-             gaBrowserSniffer, gaMarkerOverlay, gaDebounce) {
+             gaBrowserSniffer, gaMarkerOverlay, gaDebounce, gaGlobalOptions) {
 
       // This value is used to block blur/mouseleave event, when a value
       // is selected. See #2284. It's reinitialized when a new search is
@@ -278,7 +278,8 @@ goog.require('ga_urlutils_service');
         if (gaBrowserSniffer.mobile) {
           return;
         }
-        addOverlay(gaMarkerOverlay, $scope.map, res);
+        addOverlay(
+            gaMarkerOverlay, $scope.map, res, gaGlobalOptions.defaultEpsg);
       };
 
       $scope.removePreview = function() {
@@ -314,7 +315,8 @@ goog.require('ga_urlutils_service');
 
   module.directive('gaSearchLocations',
       function($http, $q, $sce, $translate, gaUrlUtils, gaBrowserSniffer,
-               gaMarkerOverlay, gaSearchLabels, gaMapUtils, gaDebounce) {
+               gaMarkerOverlay, gaSearchLabels, gaMapUtils, gaDebounce,
+               gaGlobalOptions) {
         return {
           restrict: 'A',
           templateUrl: 'components/search/partials/searchtypes.html',
@@ -352,7 +354,8 @@ goog.require('ga_urlutils_service');
               } else {
                 gaMapUtils.zoomToExtent($scope.map, $scope.ol3d, e);
               }
-              addOverlay(gaMarkerOverlay, $scope.map, res);
+              addOverlay(
+                gaMarkerOverlay, $scope.map, res, gaGlobalOptions.defaultEpsg);
               $scope.options.valueSelected(
                   gaSearchLabels.cleanLabel(res.attrs.label));
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -805,6 +805,11 @@ itemscope itemtype="http://schema.org/WebApplication"
           defaultEpsg: '${default_epsg}',
           defaultEpsgExtent: JSON.parse(${default_epsg_extend}),
           defaultElevationModel: '${default_elevation_model}',
+          defaultEpsgContextPopupTitle: '${default_epsg_context_popup_title}',
+          defaultToSecondaryEpsgUrl: '${default_to_secondary_epsg_url}',
+          secondaryEpsg: '${secondary_epsg}',
+          secondaryEpsgExtent: JSON.parse(${secondary_epsg_extent}),
+          secondaryEpsgContextPopupTitle: '${secondary_epsg_context_popup_title}',
           defaultTerrain: '${default_terrain}',
           languages: JSON.parse(${languages})
         });

--- a/src/js/ContextPopupController.js
+++ b/src/js/ContextPopupController.js
@@ -8,7 +8,7 @@ goog.provide('ga_contextpopup_controller');
         $scope.options = {
           heightUrl: gaGlobalOptions.apiUrl + '/rest/services/height',
           qrcodeUrl: gaGlobalOptions.apiUrl + '/qrcodegenerator',
-          lv03tolv95Url: 'https://geodesy.geo.admin.ch/reframe/lv03tolv95'
+          defaultToSecondaryEpsgUrl: gaGlobalOptions.defaultToSecondaryEpsgUrl
         };
 
       });

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -40,6 +40,9 @@ beforeEach(function() {
         'https://' + location.host + '/**'
       ],
       defaultEpsg: 'EPSG:21781',
+      secondaryEpsg: 'EPSG:2056',
+      defaultToSecondaryEpsgUrl: '//api.example.com/reframe/' +
+          'lv03tolv95?easting=661473&northing=188192',
       defaultTopicId: 'sometopic',
       translationFallbackCode: 'somelang',
       languages: ['de', 'fr', 'it', 'en', 'rm', 'somelang'],

--- a/test/specs/contextpopup/ContextPopupDirective.spec.js
+++ b/test/specs/contextpopup/ContextPopupDirective.spec.js
@@ -34,7 +34,7 @@ describe('ga_contextpopup_directive', function() {
       map = new ol.Map({});
       $rootScope.map = map;
       $rootScope.options = {
-        lv03tolv95Url: "//api.example.com/reframe/lv03tolv95",
+        defaultToSecondaryEpsgUrl: "//api.example.com/reframe/lv03tolv95",
         heightUrl: "//api.geo.admin.ch/height",
         qrcodeUrl: "//api.geo.admin.ch/qrcodegenerator"
       };


### PR DESCRIPTION
- Add suppport for secondary EPSG
- Use gaGlobalOptions.defaultEpsg instead of 'EPSG:21781'
- Use gaGlobalOptions.secondaryEpsg instead of 'EPSG:2056'
- Reframe by URL is done by gaGlobalOptions.defaultToSecondaryEpsgUrl
- Allow WMTS layers to be in a different projection than the default by
using an epsg attribute in layersConfig
- Convert permalink to default EPSG in it is contained in secondary EPSG
extent
- In context popop:
- display the coordinates in the default EPSG then in the secondary
EPSG
- use gaGlobalOptions.defaultEpsgContextPopupTitle and
gaGlobalOptions.secondaryEpsgContextPopupTitle to display the correct
projection title