### PR TITLE
Use same staging level as app for WMS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ MAPPROXY_URL ?= //wmts{s}.dev.bgdi.ch
 LAST_MAPPROXY_URL := $(shell if [ -f .build-artefacts/last-mapproxy-url ]; then cat .build-artefacts/last-mapproxy-url 2> /dev/null; else echo '-none-'; fi)
 SHOP_URL ?= //shop-bgdi.dev.bgdi.ch
 LAST_SHOP_URL := $(shell if [ -f .build-artefacts/last-shop-url ]; then cat .build-artefacts/last-shop-url 2> /dev/null; else echo '-none-'; fi)
+WMS_URL ?= //wms-bgdi.dev.bgdi.ch
+LAST_WMS_URL := $(shell if [ -f .build-artefacts/last-wms-url ]; then cat .build-artefacts/last-wms-url 2> /dev/null; else echo '-none-'; fi)
 LESS_PARAMETERS ?= -ru
 KEEP_VERSION ?= 'false'
 LAST_VERSION := $(shell if [ -f .build-artefacts/last-version ]; then cat .build-artefacts/last-version 2> /dev/null; else echo '-none-'; fi)
@@ -107,6 +109,7 @@ help:
 	@echo "- API_URL Service URL         (build with: $(LAST_API_URL), current value: $(API_URL))"
 	@echo "- MAPPROXY_URL Service URL    (build with: $(LAST_MAPPROXY_URL), current value: $(MAPPROXY_URL))"
 	@echo "- SHOP_URL Service URL        (build with: $(LAST_SHOP_URL), current value: $(SHOP_URL))"
+	@echo "- WMS_URL Service URL         (build with  $(LAST_WMS_URL), current value: $(WMS_URL))"
 	@echo "- APACHE_BASE_PATH Base path  (build with: $(LAST_APACHE_BASE_PATH), current value: $(APACHE_BASE_PATH))"
 	@echo "- APACHE_BASE_DIRECTORY       (build with: $(LAST_APACHE_BASE_DIRECTORY), current value: $(APACHE_BASE_DIRECTORY))"
 
@@ -366,6 +369,7 @@ define buildpage
 		--var "application_url=$(APPLICATION_URL)" \
 		--var "mapproxy_url=$(MAPPROXY_URL)" \
 		--var "shop_url=$(SHOP_URL)" \
+		--var "wms_url=$(WMS_URL)" \
 		--var "default_topic_id=$(DEFAULT_TOPIC_ID)" \
 		--var "translation_fallback_code=$(TRANSLATION_FALLBACK_CODE)" \
 		--var "languages=$(LANGUAGES)" \
@@ -402,6 +406,7 @@ prd/index.html: src/index.mako.html \
 	    .build-artefacts/last-api-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-shop-url \
+	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
@@ -414,6 +419,7 @@ prd/mobile.html: src/index.mako.html \
 	    .build-artefacts/last-api-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-shop-url \
+	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
@@ -426,6 +432,7 @@ prd/embed.html: src/index.mako.html \
 	    .build-artefacts/last-api-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-shop-url \
+	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
@@ -462,6 +469,7 @@ src/index.html: src/index.mako.html \
 	    .build-artefacts/last-api-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-shop-url \
+	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,desktop,,,)
 
@@ -470,6 +478,7 @@ src/mobile.html: src/index.mako.html \
 	    .build-artefacts/last-api-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-shop-url \
+	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,mobile,,,)
 
@@ -478,6 +487,7 @@ src/embed.html: src/index.mako.html \
 	    .build-artefacts/last-api-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-shop-url \
+	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,embed,,,)
 
@@ -652,6 +662,10 @@ scripts/00-$(GIT_BRANCH).conf: scripts/00-branch.mako-dot-conf \
 .build-artefacts/last-shop-url::
 	mkdir -p $(dir $@)
 	test "$(SHOP_URL)" != "$(LAST_SHOP_URL)" && echo $(SHOP_URL) > .build-artefacts/last-shop-url || :
+
+.build-artefacts/last-wms-url::
+	mkdir -p $(dir $@)
+	test "$(WMS_URL)" != "$(LAST_WMS_URL)" && echo $(WMS_URL) > .build-artefacts/last-wms-url || :
 
 .build-artefacts/last-apache-base-path::
 	mkdir -p $(dir $@)

--- a/README.md
+++ b/README.md
@@ -204,3 +204,9 @@ You can flush varnish instances manually.
     ./scripts/flushvarnish.sh varnihs_host_ip api_host
 
 Where `varnish_host_ip` is the ip of the varnish server and api_host is the hostname of the url you want to flush. e.g. mf-chsdi3.dev.bgdi.ch for dev and api3.geo.admin.ch for prod.
+
+# Use a custom backend and WMS server via permalink parameters
+
+Add `api_url=theNameOfABranch` to use a custom backend.
+
+Add `wms_url=//theNameOfAWMSServer` to use a cutsom wms service.

--- a/rc_dev
+++ b/rc_dev
@@ -7,3 +7,4 @@ export APACHE_BASE_PATH=
 export VARNISH_HOSTS=(ip-10-220-4-250.eu-west-1.compute.internal)
 export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch
 export SHOP_URL=//shop-bgdi.dev.bgdi.ch
+export WMS_URL=//wms-bgdi.dev.bgdi.ch

--- a/rc_int
+++ b/rc_int
@@ -7,3 +7,4 @@ export PUBLIC_URL=//public.int.bgdi.ch
 export APACHE_BASE_PATH=
 export VARNISH_HOSTS=(ip-10-220-6-234.eu-west-1.compute.internal ip-10-220-4-93.eu-west-1.compute.internal)
 export E2E_TARGETURL=https://mf-geoadmin3.int.bgdi.ch
+export WMS_URL=//wms-bgdi.int.bgdi.ch

--- a/rc_prod
+++ b/rc_prod
@@ -7,3 +7,4 @@ export PUBLIC_URL=//public.geo.admin.ch
 export APACHE_BASE_PATH=
 export VARNISH_HOSTS=(ip-10-220-5-71.eu-west-1.compute.internal ip-10-220-6-245.eu-west-1.compute.internal)
 export E2E_TARGETURL=https://map.geo.admin.ch
+export WMS_URL=//wms.geo.admin.ch

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -632,7 +632,7 @@ goog.require('ga_urlutils_service');
               wmsParams.time = timestamp;
             }
             params = {
-              url: getWmsTpl(config3d.wmsUrl, wmsParams),
+              url: getWmsTpl(gaGlobalOptions.wmsUrl, wmsParams),
               tileSize: tileSize,
               subdomains: dfltWmsSubdomains
             };
@@ -745,7 +745,7 @@ goog.require('ga_urlutils_service');
             if (layer.singleTile === true) {
               if (!olSource) {
                 olSource = layer.olSource = new ol.source.ImageWMS({
-                  url: getImageryUrls(getWmsTpl(layer.wmsUrl))[0],
+                  url: getImageryUrls(getWmsTpl(gaGlobalOptions.wmsUrl))[0],
                   params: wmsParams,
                   crossOrigin: crossOrigin,
                   ratio: 1
@@ -762,7 +762,8 @@ goog.require('ga_urlutils_service');
               if (!olSource) {
                 var subdomains = dfltWmsSubdomains;
                 olSource = layer.olSource = new ol.source.TileWMS({
-                  urls: getImageryUrls(getWmsTpl(layer.wmsUrl), subdomains),
+                  urls: getImageryUrls(
+                      getWmsTpl(gaGlobalOptions.wmsUrl), subdomains),
                   // Temporary until https://github.com/openlayers/ol3/pull/4964
                   // is merged upstream
                   cacheSize: 2048 * 3,

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -734,7 +734,9 @@ itemscope itemtype="http://schema.org/WebApplication"
           return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
         }
 
-        var wmsUrl = getParam('wms_url');
+        var adminUrlRegexp = new RegExp('${admin_url_regexp}');
+        var wmsUrl = location.protocol + getParam('wms_url');
+        wmsUrl = adminUrlRegexp.test(wmsUrl) ? wmsUrl : null;
 
         var apiParam = getParam('api_url');
         var apiEnv = getParam('api_env');
@@ -788,11 +790,11 @@ itemscope itemtype="http://schema.org/WebApplication"
           shopUrl : location.protocol + shopUrl,
           publicUrl : location.protocol + '${public_url}',
           publicUrlRegexp: new RegExp('${public_url_regexp}'),
-          adminUrlRegexp: new RegExp('${admin_url_regexp}'),
+          adminUrlRegexp: adminUrlRegexp,
           cachedApiUrl: location.protocol + apiUrl + cacheAdd,
           resourceUrl: location.origin + pathname + '${versionslashed}',
           ogcproxyUrl : location.protocol + apiUrl + '/ogcproxy?url=',
-          wmsUrl: wmsUrl ? location.protocol + wmsUrl : location.protocol + '${wms_url}',
+          wmsUrl: wmsUrl ? wmsUrl : location.protocol + '${wms_url}',
           w3wUrl : 'https://api.what3words.com',
           w3wApiKey : 'OM48J50Y',
           whitelist: [

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -734,6 +734,8 @@ itemscope itemtype="http://schema.org/WebApplication"
           return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
         }
 
+        var wmsUrl = getParam('wms_url');
+
         var apiParam = getParam('api_url');
         var apiEnv = getParam('api_env');
         var apiUrlBase = '${api_url}';
@@ -790,6 +792,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           cachedApiUrl: location.protocol + apiUrl + cacheAdd,
           resourceUrl: location.origin + pathname + '${versionslashed}',
           ogcproxyUrl : location.protocol + apiUrl + '/ogcproxy?url=',
+          wmsUrl: wmsUrl ? location.protocol + wmsUrl : location.protocol + '${wms_url}',
           w3wUrl : 'https://api.what3words.com',
           w3wApiKey : 'OM48J50Y',
           whitelist: [


### PR DESCRIPTION
As discussed, the app now always uses per default the corresponding WMS staging level.
This behaviour can be overriden using `wms_url` parameter.

Further discussion can be found here:
https://github.com/geoadmin/mf-chsdi3/pull/2167

[Use WMS default host](https://mf-geoadmin3.dev.bgdi.ch/gal_wms/?lang=fr&topic=ech&bgLayer=voidLayer&layers=ch.bafu.gewaesserschutz-biologischer_zustand_diatomeen&layers_timestamp=)
[Override WMS default host](https://mf-geoadmin3.dev.bgdi.ch/gal_wms/?wms_url=%2F%2Fwms-bgdi.int.bgdi.ch&lang=fr&topic=ech&bgLayer=voidLayer&layers=ch.bafu.gewaesserschutz-biologischer_zustand_diatomeen&layers_timestamp=)

@gjn @oterral 
What shall we do for the JS API?