### PR TITLE
[WIP] build once for dev/int/prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ API_URL ?= //mf-chsdi3.dev.bgdi.ch
 LAST_API_URL := $(shell if [ -f .build-artefacts/last-api-url ]; then cat .build-artefacts/last-api-url 2> /dev/null; else echo '-none-'; fi)
 PUBLIC_URL ?= //public.dev.bgdi.ch
 E2E_TARGETURL ?= https://mf-geoadmin3.dev.bgdi.ch
-APPLICATION_URL ?= $(E2E_TARGETURL)
 PUBLIC_URL_REGEXP ?= ^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*
 ADMIN_URL_REGEXP ?= ^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)
 MAPPROXY_URL ?= //wmts{s}.dev.bgdi.ch
@@ -364,12 +363,6 @@ define buildpage
 		--var "mode=$2" \
 		--var "version=$3" \
 		--var "versionslashed=$4" \
-		--var "apache_base_path=$(APACHE_BASE_PATH)" \
-		--var "api_url=$(API_URL)" \
-		--var "application_url=$(APPLICATION_URL)" \
-		--var "mapproxy_url=$(MAPPROXY_URL)" \
-		--var "shop_url=$(SHOP_URL)" \
-		--var "wms_url=$(WMS_URL)" \
 		--var "default_topic_id=$(DEFAULT_TOPIC_ID)" \
 		--var "translation_fallback_code=$(TRANSLATION_FALLBACK_CODE)" \
 		--var "languages=$(LANGUAGES)" \
@@ -378,14 +371,12 @@ define buildpage
 		--var "default_level_of_detail"="$(DEFAULT_LEVEL_OF_DETAIL)" \
 		--var "resolutions"="$(RESOLUTIONS)" \
 		--var "level_of_details"="$(LEVEL_OF_DETAILS)" \
-		--var "public_url=$(PUBLIC_URL)" \
 		--var "default_elevation_model=${DEFAULT_ELEVATION_MODEL}" \
 		--var "default_terrain=$(DEFAULT_TERRAIN)" \
 		--var "admin_url_regexp=$(ADMIN_URL_REGEXP)" \
 		--var "public_url_regexp=$(PUBLIC_URL_REGEXP)" \
 		--var "default_epsg"="$(DEFAULT_EPSG)" \
-		--var "default_epsg_extend"="$(DEFAULT_EPSG_EXTEND)" \
-		--var "staging"="$(DEPLOY_TARGET)" $< > $@
+		--var "default_epsg_extend"="$(DEFAULT_EPSG_EXTEND)" $< > $@
 endef
 
 define applypatches
@@ -403,11 +394,6 @@ endef
 prd/index.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    ${HTMLMIN_CMD} \
-	    .build-artefacts/last-api-url \
-	    .build-artefacts/last-mapproxy-url \
-	    .build-artefacts/last-shop-url \
-	    .build-artefacts/last-wms-url \
-	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	$(call buildpage,desktop,prod,$(VERSION),$(VERSION)/)
@@ -416,11 +402,6 @@ prd/index.html: src/index.mako.html \
 prd/mobile.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    ${HTMLMIN_CMD} \
-	    .build-artefacts/last-api-url \
-	    .build-artefacts/last-mapproxy-url \
-	    .build-artefacts/last-shop-url \
-	    .build-artefacts/last-wms-url \
-	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	$(call buildpage,mobile,prod,$(VERSION),$(VERSION)/)
@@ -429,11 +410,6 @@ prd/mobile.html: src/index.mako.html \
 prd/embed.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    ${HTMLMIN_CMD} \
-	    .build-artefacts/last-api-url \
-	    .build-artefacts/last-mapproxy-url \
-	    .build-artefacts/last-shop-url \
-	    .build-artefacts/last-wms-url \
-	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	$(call buildpage,embed,prod,$(VERSION),$(VERSION)/)
@@ -465,30 +441,15 @@ src/style/app.css: $(SRC_LESS_FILES)
 	node_modules/.bin/lessc $(LESS_PARAMETERS) src/style/app.less $@
 
 src/index.html: src/index.mako.html \
-	    ${MAKO_CMD} \
-	    .build-artefacts/last-api-url \
-	    .build-artefacts/last-mapproxy-url \
-	    .build-artefacts/last-shop-url \
-	    .build-artefacts/last-wms-url \
-	    .build-artefacts/last-apache-base-path
+	    ${MAKO_CMD}
 	$(call buildpage,desktop,,,)
 
 src/mobile.html: src/index.mako.html \
-	    ${MAKO_CMD} \
-	    .build-artefacts/last-api-url \
-	    .build-artefacts/last-mapproxy-url \
-	    .build-artefacts/last-shop-url \
-	    .build-artefacts/last-wms-url \
-	    .build-artefacts/last-apache-base-path
+	    ${MAKO_CMD}
 	$(call buildpage,mobile,,,)
 
 src/embed.html: src/index.mako.html \
-	    ${MAKO_CMD} \
-	    .build-artefacts/last-api-url \
-	    .build-artefacts/last-mapproxy-url \
-	    .build-artefacts/last-shop-url \
-	    .build-artefacts/last-wms-url \
-	    .build-artefacts/last-apache-base-path
+	    ${MAKO_CMD}
 	$(call buildpage,embed,,,)
 
 src/TemplateCacheModule.js: src/TemplateCacheModule.mako.js \

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -34,7 +34,7 @@ itemscope itemtype="http://schema.org/WebApplication"
     <meta name="msapplication-square70x70logo" content="${versionslashed}img/touch-icon-bund-70x70.png"/>
     <meta name="msapplication-square150x150logo" content="${versionslashed}img/touch-icon-bund-150x150.png"/>
     <meta name="msapplication-square310x310logo" content="${versionslashed}img/touch-icon-bund-310x310.png"/>
-    <link rel="dns-prefetch" href="${api_url}"/>
+    <link rel="dns-prefetch" href="https://api3.geo.admin.ch"/>
 
     <link rel="apple-touch-icon" sizes="76x76" href="${versionslashed}img/touch-icon-bund-76x76.png"/>
     <link rel="apple-touch-icon" sizes="120x120" href="${versionslashed}img/touch-icon-bund-120x120.png"/>
@@ -50,8 +50,9 @@ itemscope itemtype="http://schema.org/WebApplication"
     <meta property="og:title" content="Swiss Geoportal"/>
     <meta property="og:description" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
     <meta property="og:type" content="WebApplication"/>
-    <meta property="og:url" content="${application_url}"/>
-    <meta property="og:image" content="${application_url}/${versionslashed}img/logo_geoportal.png"/>
+    <meta property="og:url" content=https://map.geo.admin.ch"/>
+    <!-- TODO: assure the logo is there withou version numbers -->
+    <meta property="og:image" content="https://map.geo.admin.ch/img/logo_geoportal.png"/>
 
     <!-- Twitter Card Infos -->
     <meta name="twitter:card" content="summary"/>
@@ -59,15 +60,15 @@ itemscope itemtype="http://schema.org/WebApplication"
     <meta name="twitter:creator" content="@swiss_geoportal"/>
     <meta name="twitter:title" content="geo.admin.ch"/>
     <meta name="twitter:description" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
-    <meta name="twitter:image" content="${application_url}/${versionslashed}img/logo_geoportal.png"/>
-    <meta name="twitter:url" content="${application_url}"/>
+    <meta name="twitter:image" content="https://map.geo.admin.ch/img/logo_geoportal.png"/>
+    <meta name="twitter:url" content="https://map.geo.admin.ch"/>
 
     <!-- Facebook Specific fb:admins and fb.appid -->
 
     <!-- Google+ Specific Tags -->
     <meta itemprop="name" content="geo.admin.ch"/>
     <meta itemprop="description" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
-    <meta itemprop="image" content="${application_url}/${versionslashed}img/logo_geoportal.png"/>
+    <meta itemprop="image" content="https://map.geo.admin.ch/img/logo_geoportal.png"/>
 
     <script>
       (function(){
@@ -721,62 +722,46 @@ itemscope itemtype="http://schema.org/WebApplication"
 
     <script>
       (function() {
-        // Make sure ajax is using cached requests
-        $.ajaxSetup({
-          cache: true
-        });
-
-        var module = angular.module('geoadmin');
-        var cacheAdd = '${version}' != '' ? '/' + '${version}' : '';
-        var pathname = location.pathname.replace(/(index|mobile|embed)\.html$/g, '');
-
         function getParam(name){
           return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
         }
 
+
+        // Make sure ajax is using cached requests
+        $.ajaxSetup({
+          cache: true
+        });
+ 
         var adminUrlRegexp = new RegExp('${admin_url_regexp}');
-        var wmsUrl = location.protocol + getParam('wms_url');
-        wmsUrl = adminUrlRegexp.test(wmsUrl) ? wmsUrl : null;
+        var module = angular.module('geoadmin');
+        var cacheAdd = '${version}' != '' ? '/' + '${version}' : '';
+        var pathname = location.pathname.replace(/(index|mobile|embed)\.html$/g, '');
+        var staging = 'prod';
+        var testres = /^mf-geoadmin3\.([a-z]+)\.bgdi.ch$/.exec(location.hostname);
+        if (testres && testres.length == 2) {
+          staging = testres[1];
+        }
+        var hasOverWrite = false;
 
-        var apiParam = getParam('api_url');
-        var apiEnv = getParam('api_env');
-        var apiUrlBase = '${api_url}';
-
-        if (apiEnv){
-          if (apiEnv == 'prod'){
-            host = '//api3.geo.admin.ch';
-          } else {
-            host = '//mf-chsdi3.' + apiEnv + '.bgdi.ch';
+        function setBackend(prodUrl, techUrl, overWriteParam) {
+          hasOverWrite = false;
+          var url = prodUrl;
+          if (staging != 'prod') {
+            url = techUrl + staging + '.bgdi.ch';
           }
-        } else {
-          host = '${api_url}';
+          var overWrite = 'https://' + getParam(overWriteParam);
+          hasOverWrite = adminUrlRegexp.test(overWrite);
+          url = hasOverWrite ? overWrite : url;
+          return url;
         }
 
-        if (host.slice(-1) == '/'){
-          host = host.slice(0, -1);
-        }
-
-        if (apiParam){
-          apiUrl = host + '/' + apiParam;
-        } else {
-          apiUrl = host;
-        }
-
-        var shopUrl = getParam('shop_url');
-        var shopUrlBase = '${shop_url}';
-
-        if (shopUrl){
-          shopUrl = shopUrl;
-          if (shopUrl == 'dev' || shopUrl == 'int'){
-            shopUrl = '//shop-bgdi.'+ shopUrl + '.bgdi.ch';
-          } else if (shopUrl == 'prod'){
-              shopUrl = '//beta.shop.swisstopo.ch';
-          } else if (shopUrl == 'puzzle'){
-              shopUrl = '//shop-shopbgdi.openshift.puzzle.ch';
-          }
-        } else {
-          shopUrl = shopUrlBase;
-        }
+        // Setting backends
+        var apiUrl = setBackend('https://api3.geo.admin.ch', 'https://mf-chsdi3.', 'api_url');
+        var apiOverwrite = hasOverWrite;
+        var mapproxyUrl = setBackend('https://wmts{s}.geo.admin.ch', 'https://wmts{s}.', 'mapproxy_url');
+        var wmsUrl = setBackend('https://wms.geo.admin.ch', 'https://wms-bgdi.', 'wms_url');
+        var shopUrl = setBackend('https://shop.swisstopo.admin.ch', 'https://shop-bgdi.', 'shop_url');
+        var publicUrl = setBackend('https://publich.geo.admin.ch', 'https://public.', 'public_url');
 
         module.constant('gaGlobalOptions', {
           //dev3d to be removed once 3d goes live
@@ -784,17 +769,17 @@ itemscope itemtype="http://schema.org/WebApplication"
           buildMode: '${mode}',
           version: '${version}',
           pegman: !!window.location.search.match(/(pegman=true)/),
-          mapUrl : location.origin + '${apache_base_path}',
-          apiUrl : location.protocol + apiUrl,
-          mapproxyUrl : location.protocol + '${mapproxy_url}',
+          mapUrl : location.origin + pathname,
+          apiUrl : apiUrl,
+          mapproxyUrl : mapproxyUrl,
           shopUrl : location.protocol + shopUrl,
-          publicUrl : location.protocol + '${public_url}',
+          publicUrl : publicUrl,
           publicUrlRegexp: new RegExp('${public_url_regexp}'),
           adminUrlRegexp: adminUrlRegexp,
-          cachedApiUrl: location.protocol + apiUrl + cacheAdd,
+          cachedApiUrl: apiUrl + cacheAdd,
           resourceUrl: location.origin + pathname + '${versionslashed}',
-          ogcproxyUrl : location.protocol + apiUrl + '/ogcproxy?url=',
-          wmsUrl: wmsUrl ? wmsUrl : location.protocol + '${wms_url}',
+          ogcproxyUrl : apiUrl + '/ogcproxy?url=',
+          wmsUrl: wmsUrl,
           w3wUrl : 'https://api.what3words.com',
           w3wApiKey : 'OM48J50Y',
           whitelist: [
@@ -834,7 +819,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
           gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =  gaGlobalOptions.mapproxyUrl + '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
           gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
-          if (apiEnv || apiParam){
+          if (apiOverwrite){
             gaLayersProvider.layersConfigUrlTemplate = apiUrl + '/rest/services/all/MapServer/layersConfig?lang={Lang}';
           } else{
             gaLayersProvider.layersConfigUrlTemplate = gaGlobalOptions.resourceUrl + 'layersConfig?lang={Lang}';
@@ -842,7 +827,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           gaLayersProvider.legendUrlTemplate = gaGlobalOptions.apiUrl + '/rest/services/all/MapServer/{Layer}/legend?lang={Lang}';
         });
         module.config(function(gaTopicProvider, gaGlobalOptions) {
-          if (apiEnv || apiParam){
+          if (apiOverwrite){
             gaTopicProvider.topicsUrl = apiUrl + '/rest/services';
           } else {
             gaTopicProvider.topicsUrl = gaGlobalOptions.resourceUrl + 'services';


### PR DESCRIPTION
As discussed in https://github.com/geoadmin/mf-geoadmin3/pull/3142, this PR tries to configure the project and the index.html so that only one build is required for dev/int/prod. It moves the application configuration (definition of back-ends mainly) from build time to run-time.

This is unfinished work but the basic idea is working: the information in the rc_* files is not needed anymore for the application build. Backend definitions happen on load and depend on the URL under which the appliation is served. Most backends can be overwritten by a parameters for flexibility.

There are a few things missing:
- appcache adaptions (I think they are needed)
- robots.txt needs adaptions as well
- maybe we need to add canonical name in html for SEO
- not all backends have `ci` environment. this needs to be treated.
- during dev, api should not only be staging dependant, but also point to user specific api (ltjeg points to ltjeg api)
- ....others