### PR TITLE
Fixes pegman and arrows for 3d

### DIFF
--- a/src/components/controls3d/Controls3dDirective.js
+++ b/src/components/controls3d/Controls3dDirective.js
@@ -42,6 +42,13 @@ goog.require('ga_map_service');
 
         var moving = false;
 
+        var setTiltDisabled = function(angleDeg) {
+          var angle = Cesium.Math.toRadians(Math.abs(angleDeg));
+          scope.tiltUpDisabled = camera.pitch + angle >= 0;
+          scope.tiltDownDisabled = camera.pitch - angle <=
+              -Cesium.Math.PI_OVER_TWO;
+        };
+
         camera.moveStart.addEventListener(function() {
           moving = true;
         });
@@ -108,6 +115,7 @@ goog.require('ga_map_service');
             var tiltOnGlobe = olcs.core.computeSignedTiltAngleOnGlobe(scene);
             cssRotate(tiltIndicator, -tiltOnGlobe - Cesium.Math.PI_OVER_TWO);
             cssRotate(rotateIndicator, -camera.heading);
+            setTiltDisabled(5);
           }
         });
 
@@ -126,12 +134,13 @@ goog.require('ga_map_service');
           }
         };
 
-        scope.tilt = function(angle) {
-          angle = Cesium.Math.toRadians(angle);
-          var finalAngle = camera.pitch + angle;
-          if (finalAngle > 0 || finalAngle < -Cesium.Math.PI_OVER_TWO) {
+        scope.tilt = function(angleDeg) {
+          setTiltDisabled(angleDeg);
+          if ((angleDeg >= 0 && scope.tiltUpDisabled) ||
+              (angleDeg < 0 && scope.tiltDownDisabled)) {
             return;
           }
+          var angle = Cesium.Math.toRadians(angleDeg);
           var pivot = olcs.core.pickBottomPoint(scene);
           if (pivot) {
             var transform = Cesium.Matrix4.fromTranslation(pivot);

--- a/src/components/controls3d/partials/controls3d.html
+++ b/src/components/controls3d/partials/controls3d.html
@@ -4,11 +4,11 @@
     <i class="fa fa-ga-tilt"></i>
     <i class="fa fa-ga-tilt-indicator"></i>
   </button>
-  <button class="ga-btn ga-inc" ng-click="tilt(+5)">
-    <i class="fa fa-ga-left-arrow"></i>  
+  <button class="ga-btn ga-inc fa fa-ga-left-arrow" ng-click="tilt(+5)"
+          ng-disabled="tiltUpDisabled">
   </button>
-  <button class="ga-btn ga-dec" ng-click="tilt(-5)">
-    <i class="fa fa-ga-right-arrow"></i>
+  <button class="ga-btn ga-dec fa fa-ga-right-arrow" ng-click="tilt(-5)"
+          ng-disabled="tiltDownDisabled">
   </button>
 </div>
 <div class="ga-pegman" ng-show="pegman" ng-class="{'ga-fly-mode': fps.flyMode, 'ga-jet-mode': fps.jetMode}" ng-mousedown="startDraggingPegman()"></div>
@@ -18,12 +18,8 @@
     <i class="fa fa-ga-northarrow"></i>
     <i class="fa fa-ga-indicator-northarrow"></i>
   </button>
-  <button class="ga-btn ga-inc" ng-click="rotate(-15)">
-    <i class="fa fa-ga-left-arrow"></i>
-  </button>
-  <button class="ga-btn ga-dec" ng-click="rotate(+15)">
-    <i class="fa fa-ga-right-arrow"></i>
-  </button>
+  <button class="ga-btn ga-inc fa fa-ga-left-arrow" ng-click="rotate(-15)"></button>
+  <button class="ga-btn ga-dec fa fa-ga-right-arrow" ng-click="rotate(+15)"></button>
 </div>
 <div class="ga-pegman-help" ng-show="fps.active">
   pegman help text here.

--- a/src/components/controls3d/style/controls3d.less
+++ b/src/components/controls3d/style/controls3d.less
@@ -24,6 +24,11 @@
     background: transparent;
     padding: 0;
     margin: 0;
+
+    &[disabled] {
+      color: #ccc;
+      text-shadow: none;
+    }
   }
 
   .ga-tilt, .ga-rotate {
@@ -81,13 +86,13 @@
     text-shadow: 0px 1px 3px #020202;
     margin: 2px;
 
-    .fa-ga-right-arrow, .fa-ga-left-arrow {
-      color: #ed1c24
-    }
-
     @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
       display: none;
     }
+  }
+
+  .fa-ga-right-arrow, .fa-ga-left-arrow {
+    color: #ed1c24
   }
 
   .ga-pegman-help {

--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -137,7 +137,8 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions,
     }
     // Set the minimumZoomDistance according to the camera height
     var minimumZoomDistance = pos.height > 1800 ? 400 : 200;
-    this.screenSpaceCameraController.minimumZoomDistance = minimumZoomDistance;
+    this.screenSpaceCameraController.minimumZoomDistance =
+        gaGlobalOptions.pegman ? 2 : minimumZoomDistance;
   };
 
   var enableOl3d = function(ol3d, enable) {


### PR DESCRIPTION
With pegman we can now go to 2 meters from the ground : [Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fixes/?pegman=true&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&lon=7.44017&lat=46.94723&elevation=545&heading=326.366&pitch=-78.458)

Arrow tilt up is grey when we can tilt up further: [test](https://mf-geoadmin3.dev.bgdi.ch/teo_fixes/?pegman=true&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&lon=7.44373&lat=46.90670&elevation=677&heading=356.847&pitch=7.956)


Arrow tilt down is grey when we can tilt down further: [test](https://mf-geoadmin3.dev.bgdi.ch/teo_fixes/?pegman=true&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&lon=7.44291&lat=46.91166&elevation=2841&heading=341.635&pitch=-89.583)


Fix #2870
Fix #2665 