### PR TITLE
Allow multiple results for Lubis layers

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -525,6 +525,19 @@ goog.require('ga_urlutils_service');
                 }
               });
 
+              // Test shop layers allowing multiple results in tooltip.
+              ids = [
+                'ch.swisstopo.lubis-luftbilder_farbe',
+                'ch.swisstopo.lubis-luftbilder_schwarzweiss',
+                'ch.swisstopo.lubis-luftbilder_infrarot',
+                'ch.swisstopo.lubis-bildstreifen'
+              ];
+              angular.forEach(ids, function(id) {
+                if (response.data[id]) {
+                  response.data[id].shopMulti = true;
+                }
+              });
+
               // Terrain
               var lang = gaLang.getNoRm();
               response.data['ch.swisstopo.terrain.3d'] = {

--- a/src/components/shop/ShopDirective.js
+++ b/src/components/shop/ShopDirective.js
@@ -56,11 +56,16 @@ goog.require('ga_price_filter');
         var layerConfig = gaLayers.getLayer(layerBodId);
 
         // Remove the element if no shop config available
-        if (!layerConfig || !layerConfig.shop ||
-            layerConfig.shop.length == 0 || (scope.feature.properties &&
-            !angular.isDefined(scope.feature.properties.available))) {
+        if (!layerConfig.shop || layerConfig.shop.length == 0) {
           elt.remove();
           return;
+        }
+
+        // We consider a shopable feature as available by default if not
+        // explicitly defined.
+        if (scope.feature.properties &&
+            !angular.isDefined(scope.feature.properties.available)) {
+          scope.feature.properties.available = true;
         }
 
         // The feature is not available in the shop so we display a message

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -423,10 +423,12 @@ goog.require('ga_topic_service');
                 var geometry = new ol.geom.Point(coordinate);
                 var returnGeometry = !!gaLayers.getLayerProperty(
                     layerToQuery.bodId, 'highlightable');
-                var shopLayer = gaLayers.getLayerProperty(layerToQuery.bodId,
-                                                          'shop');
+                var shopLayer = (gaLayers.getLayerProperty(
+                    layerToQuery.bodId, 'shop') && !gaLayers.getLayerProperty(
+                    layerToQuery.bodId, 'shopMulti'));
+
                 var limit = shopLayer ? 1 : null;
-                var order = shopLayer ? 'distance' : null;
+                var order = (limit == 1) ? 'distance' : null;
                 all.push(gaIdentify.get(map, [layerToQuery], geometry, tol,
                     returnGeometry, canceler.promise, limit, order).then(
                   function(response) {

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -419,16 +419,19 @@ goog.require('ga_topic_service');
               // Go through all queryable bod layers.
               // Launch identify requests.
               layersToQuery.bodLayers.forEach(function(layerToQuery) {
-                var tol = scope.options.tolerance;
                 var geometry = new ol.geom.Point(coordinate);
                 var returnGeometry = !!gaLayers.getLayerProperty(
                     layerToQuery.bodId, 'highlightable');
                 var shopLayer = (gaLayers.getLayerProperty(
                     layerToQuery.bodId, 'shop') && !gaLayers.getLayerProperty(
                     layerToQuery.bodId, 'shopMulti'));
+                var shopMultiLayer = gaLayers.getLayerProperty(
+                    layerToQuery.bodId, 'shopMulti');
 
-                var limit = shopLayer ? 1 : null;
-                var order = (limit == 1) ? 'distance' : null;
+                var limit = shopMultiLayer ? 10 : null;
+                var order = limit ? 'distance' : null;
+                var tol = shopLayer ? 0 : scope.options.tolerance;
+
                 all.push(gaIdentify.get(map, [layerToQuery], geometry, tol,
                     returnGeometry, canceler.promise, limit, order).then(
                   function(response) {


### PR DESCRIPTION
A shopable layer of type 'mapsheet' allows to display only one result in the tooltip.

This PR creates an exception for lubis layers.

[Test](https://mf-geoadmin3.int.bgdi.ch/teo_shop/index.html?lang=fr&api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fteo_lubis&topic=luftbilder&bgLayer=ch.swisstopo.pixelkarte-grau&X=190000.00&Y=660000.00&zoom=1&dev3d=true&debug&layers=ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe,ch.swisstopo.skitourenkarte-50.metadata&layers_timestamp=99991231,99991231,&catalogNodes=1179,1180,1186&layers_visibility=false,true,true)

Work with https://github.com/geoadmin/mf-chsdi3/pull/2187