### PR TITLE
Fix #3416: Put the map and its content under everything

### DIFF
--- a/src/components/map/style/map.less
+++ b/src/components/map/style/map.less
@@ -2,6 +2,7 @@
   position: relative;
   width: 100%;
   height: 100%;
+  z-index: 0;
 
   .ol-viewport .ol-unselectable {
     .ga-user-select(none);


### PR DESCRIPTION
fix #3416 

[Test](https://mf-geoadmin3.dev.bgdi.ch/fix_3416/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,true,false&layers_timestamp=18641231,,,&swipe_ratio=0.50)