### PR TITLE
Fix #3413: Remove entirely the TIME property when its value is undefined

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -199,7 +199,12 @@ goog.require('ga_urlutils_service');
                   src.updateDimensions({'Time': val});
                 } else if (src instanceof ol.source.ImageWMS ||
                     src instanceof ol.source.TileWMS) {
-                  src.updateParams({'TIME': val});
+                  if (angular.isDefined(val)) {
+                    src.updateParams({'TIME': val});
+                  } else {
+                    delete src.getParams().TIME;
+                    src.updateParams();
+                  }
                 }
                 this.set('time', val);
               }

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -391,8 +391,15 @@ describe('ga_map_service', function() {
         var spy = sinon.spy(layer.getSource(), 'updateParams');
         layer[prop] = 'test3';
         expect(spy.callCount).to.be(0);
+
+        // Verifies the TIME parameter is correctly deleted from the object when
+        // it is set to undefined.
+        layer[prop] = undefined;
+        expect(layer.getSource().getParams().hasOwnProperty('TIME')).to.be(false);
+        expect(spy.callCount).to.be(1);
         spy.restore();
       });
+
 
       // LayerGroup
       layer = new ol.layer.Group({});


### PR DESCRIPTION
Fix #3413

[Test](https://mf-geoadmin3.dev.bgdi.ch/teo_fixes/?lang=fr&topic=luftbilder&bgLayer=voidLayer&dev3d=true&debug&catalogNodes=1179,1180,1186&layers=ch.swisstopo.lubis-luftbilder_schraegaufnahmen&layers_timestamp=1941&X=189500.00&Y=647000.00&zoom=1&time=1941)