### PR TITLE
Fix #3360: Use the default behavior for the favicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,6 +512,7 @@ prd/embed.html: src/index.mako.html \
 prd/img/: src/img/*
 	mkdir -p $@
 	cp -R $^ $@
+	cp -f $@/favicon.ico $@/../
 
 prd/style/font-awesome-4.5.0/font/: src/style/font-awesome-4.5.0/font/*
 	mkdir -p $@

--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -220,7 +220,7 @@ def upload(bucket_name, base_dir, deploy_target):
     upload_directories = ['prd', 'src']
     exclude_filename_patterns = ['.less', '.gitignore', '.mako.']
     root_files = ('index.html', 'mobile.html', 'embed.html',
-                  'robots.txt', 'robots_prod.txt',
+                  'robots.txt', 'robots_prod.txt', 'favicon.ico',
                   'checker', 'geoadmin.%s.appcache' % version)
 
     for directory in upload_directories:
@@ -383,7 +383,7 @@ def activate_version(s3_path, bucket_name, deploy_target):
         files = list(bucket.objects.filter(Prefix='{}/geoadmin.'.format(s3_path)).all())
         if len(files) > 0:
             appcache = os.path.basename(sorted(files)[-1].key)
-        for j in ('robots.txt', 'checker', appcache):
+        for j in ('robots.txt', 'checker', 'favicon.ico', appcache):
             # In prod move robots prod
             src_file_name = 'robots_prod.txt' if j == 'robots.txt' and deploy_target == 'prod' else j
             src_key_name = '{}/{}'.format(s3_path, src_file_name)

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -90,9 +90,7 @@ itemscope itemtype="http://schema.org/WebApplication"
       })();
     </script>
     <link href="${s3basepath}${versionslashed}style/app.css" rel="stylesheet"/>
-    <link rel="shortcut icon" type="image/x-icon" href="${s3basepath}${versionslashed}img/favicon.ico"/>
   </head>
-
   <body class="{{topicId}} {{langId}}" 
         ng-class="{
           'search-focused': globals.searchFocused,


### PR DESCRIPTION
Fix #3360 

It seems the problem comes from the `.replaceState` use in gaPermalink service, [see this link](http://stackoverflow.com/questions/24185506/using-history-pushstate-in-firefox-make-my-favicon-disappear) .

Putting the favicon in the root directory is the only way I found to fix this bug. 