### PR TITLE
Use ogcProxy for kml's stored under public.*

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -34,6 +34,7 @@ goog.provide('ga_urlutils_service');
         this.needsProxy = function(url) {
           return (!this.isHttps(url) ||
                   !this.isAdminValid(url) ||
+                  this.isPublicValid(url) ||
                   /.*kmz$/.test(url));
         };
 


### PR DESCRIPTION
If URL points to public.geo.admin.ch, continue to use ogcProxy as CORS headers are not set correctly.