### PR TITLE
Remove need for ogcproxy on public.geo resources

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -33,7 +33,6 @@ goog.provide('ga_urlutils_service');
         // Test if URL represents resource that needs to pass via ogcProxy
         this.needsProxy = function(url) {
           return (!this.isHttps(url) ||
-                  this.isPublicValid(url) ||
                   !this.isAdminValid(url) ||
                   /.*kmz$/.test(url));
         };

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -51,14 +51,14 @@ describe('ga_urlutils_service', function() {
 
   it('verifies proxy needs', function() {
     expect(gaUrlUtils.needsProxy('http://public.geo.admin.ch')).to.be(true);
-    expect(gaUrlUtils.needsProxy('https://public.geo.admin.ch/')).to.be(true);
+    expect(gaUrlUtils.needsProxy('https://public.geo.admin.ch/')).to.be(false);
     expect(gaUrlUtils.needsProxy('http://data.geo.admin.ch')).to.be(true);
     expect(gaUrlUtils.needsProxy('https://data.geo.admin.ch')).to.be(false);
     expect(gaUrlUtils.needsProxy('https://google.com')).to.be(true);
     expect(gaUrlUtils.needsProxy('https://admin.ch')).to.be(true);
     expect(gaUrlUtils.needsProxy('ftp://geo.admin.ch')).to.be(true);
     expect(gaUrlUtils.needsProxy('https://some.geo.admin.ch')).to.be(false);
-    expect(gaUrlUtils.needsProxy('https://public.geo.admin.ch/test.kml')).to.be(true);
+    expect(gaUrlUtils.needsProxy('https://public.geo.admin.ch/test.kml')).to.be(false);
     expect(gaUrlUtils.needsProxy('https://data.geo.admin.ch/test.kml')).to.be(false);
     expect(gaUrlUtils.needsProxy('https://public.geo.admin.ch/test.kmz')).to.be(true);
   });


### PR DESCRIPTION
As CORS has been enabled on all levels now, this should be save. I'll deploy this after tests.