### PR TITLE
Allow multiple local KMLs to be loaded

### DIFF
--- a/src/components/importkml/ImportKmlDirective.js
+++ b/src/components/importkml/ImportKmlDirective.js
@@ -135,6 +135,7 @@ goog.require('ga_urlutils_service');
 
             // Read the file
             fileReader.readAsText($scope.file);
+            fileReader = null;
           }
           $scope.isDropped = false;
         };


### PR DESCRIPTION
Loading more than one local KML caused an exception to be thrown and
broke the KML import tool for both local and distant KMLs.

To reproduce: import a local KML from your hard drive and click on the
'Load KML' button twice or try to load another KML.

This seems to come from the fact that before this commit, once a local
KML was loaded, the fileReader reference was always truethy which means
in $scope.cancel we were trying to abort the upload of an uploaded
file. This caused the exception.