### PR TITLE
Don't change upload path for prd/img/favicon.ico

### DIFF
--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -234,7 +234,8 @@ def upload(bucket_name, base_dir, deploy_target):
                         local_file = os.path.join(file_base_path, file_name)
                         file_base_path = file_base_path.replace('cache', '')
                         if directory == 'prd':
-                            if file_name in root_files:
+                            # Take only files directly in prd/
+                            if file_name in root_files and file_base_path.endswith('prd'):
                                 file_base_path = file_base_path.replace('prd', '')
                             else:
                                 file_base_path = file_base_path.replace('prd', version)


### PR DESCRIPTION
Since https://github.com/geoadmin/mf-geoadmin3/issues/3360

Fixes the issue were the favicon in `prd/img/favicon.ico` was uploaded to  /img/favicon.ico. (resulting in an URL with a double slash which causes the s3listint)

We have a favicon in `prd/favicon.ico` and `prd/img/favicon.ico`

We were only checking that the filename was actually in the list of `root_files` which isn't enough, we also need to check that the `root file` is also directly in the prd folder.

This is to be merged before the deploy.

Now we have which is correct
`Uploading to gal_s3manage/28d8ca9/1472574236/favicon.ico - image/vnd.microsoft.icon, gzip: False, cache headers: True`

And then during activate:
`gal_s3manage/28d8ca9/1472574236/favicon.ico ---> favicon.ico`

which is correct as well.