### PR TITLE
[WIP] Add image page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /src/index.html
 /src/mobile.html
 /src/embed.html
+/src/img.html
 /src/TemplateCacheModule.js
 /prd
 /.build-artefacts

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ DEFAULT_TOPIC_ID ?= ech
 TRANSLATION_FALLBACK_CODE ?= de
 LANGUAGES ?= '[\"de\", \"fr\", \"it\", \"en\", \"rm\"]'
 LANGS ?= de fr it rm en
-HTMLFILES ?= index mobile embed
+HTMLFILES ?= index mobile embed img
 TRANSLATE_GSPREAD_KEYS ?= 1F3R46w4PODfsbJq7jd79sapy3B7TXhQcYM7SEaccOA0
 TRANSLATE_CSV_FILES ?= "https://docs.google.com/spreadsheets/d/1F3R46w4PODfsbJq7jd79sapy3B7TXhQcYM7SEaccOA0/export?format=csv&gid=0"
 TRANSLATE_EMPTY_JSON ?= src/locales/empty.json
@@ -184,6 +184,7 @@ release: .build-artefacts/devlibs \
 	prd/index.html \
 	prd/mobile.html \
 	prd/embed.html \
+	prd/img.html \
 	prd/img/ \
 	prd/style/font-awesome-4.5.0/font/ \
 	prd/locales/ \
@@ -194,7 +195,7 @@ release: .build-artefacts/devlibs \
 	prd/robots_prod.txt
 
 .PHONY: debug
-debug: .build-artefacts/devlibs src/deps.js src/style/app.css src/index.html src/mobile.html src/embed.html
+debug: .build-artefacts/devlibs src/deps.js src/style/app.css src/index.html src/mobile.html src/embed.html src/img.html
 
 .PHONY: lint
 lint: .build-artefacts/devlibs .build-artefacts/lint.timestamp
@@ -581,6 +582,20 @@ prd/embed.html: src/index.mako.html \
 	$(call buildpage,embed,prod,$(VERSION),$(VERSION)/,$(S3_BASE_PATH))
 	${PYTHON_CMD} ${HTMLMIN_CMD} --remove-comments --keep-optional-attribute-quotes $@ $@
 
+prd/img.html: src/index.mako.html \
+	    ${MAKO_CMD} \
+	    ${HTMLMIN_CMD} \
+	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-mapproxy-url \
+	    .build-artefacts/last-shop-url \
+	    .build-artefacts/last-wms-url \
+	    .build-artefacts/last-public-url \
+	    .build-artefacts/last-apache-base-path \
+	    .build-artefacts/last-version
+	mkdir -p $(dir $@)
+	$(call buildpage,img,prod,$(VERSION),$(VERSION)/,$(S3_BASE_PATH))
+	${PYTHON_CMD} ${HTMLMIN_CMD} --remove-comments --keep-optional-attribute-quotes $@ $@
+
 prd/img/: src/img/*
 	mkdir -p $@
 	cp -R $^ $@
@@ -643,6 +658,16 @@ src/embed.html: src/index.mako.html \
 	    .build-artefacts/last-print-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,embed,,,,$(S3_SRC_BASE_PATH))
+
+src/img.html: src/index.mako.html \
+	    ${MAKO_CMD} \
+	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-mapproxy-url \
+	    .build-artefacts/last-shop-url \
+	    .build-artefacts/last-wms-url \
+	    .build-artefacts/last-public-url \
+	    .build-artefacts/last-apache-base-path
+	$(call buildpage,img,,,,$(S3_SRC_BASE_PATH))
 
 src/TemplateCacheModule.js: src/TemplateCacheModule.mako.js \
 	    ${SRC_COMPONENTS_PARTIALS_FILES} \
@@ -854,4 +879,5 @@ clean:
 	rm -f src/index.html
 	rm -f src/mobile.html
 	rm -f src/embed.html
+	rm -f src/img.html
 	rm -rf prd

--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -61,7 +61,7 @@ RewriteRule ^${apache_base_path}/[0-9]+/(img|lib|style|locales)(.*) ${apache_bas
 # Assure main pages are not cached with headers set according to
 # http://stackoverflow.com/questions/49547/making-sure-a-web-page-is-not-cached-across-all-browser
 # and http://tools.ietf.org/html/rfc2616
-<LocationMatch ^${apache_base_path}/(index.html|mobile.html|embed.html|geoadmin.${version}.appcache)$>
+<LocationMatch ^${apache_base_path}/(index.html|mobile.html|embed.html|img.html|geoadmin.${version}.appcache)$>
     Header unset Age
     Header unset Vary
     Header unset Cache-Control

--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -221,7 +221,7 @@ def upload(bucket_name, base_dir, deploy_target, named_branch):
     print('%s' % s3_dir_path)
     upload_directories = ['prd', 'src']
     exclude_filename_patterns = ['.less', '.gitignore', '.mako.']
-    root_files = ('index.html', 'mobile.html', 'embed.html',
+    root_files = ('index.html', 'mobile.html', 'embed.html', 'img.html',
                   'robots.txt', 'robots_prod.txt', 'favicon.ico',
                   'checker', 'geoadmin.%s.appcache' % version)
 
@@ -357,7 +357,7 @@ def activate_version(s3_path, bucket_name, deploy_target):
     msg = raw_input('Are you sure you want to activate version <%s>?\n' % s3_path)
     if msg.lower() in ('y', 'yes'):
         # Prod files
-        for n in ('index', 'embed', 'mobile'):
+        for n in ('index', 'embed', 'mobile', 'img'):
             src_key_name = '{}/{}.html'.format(s3_path, n)
             print('{} --> {}.html'.format(src_key_name, n))
             s3client.copy_object(

--- a/src/components/BrowserSnifferService.js
+++ b/src/components/BrowserSnifferService.js
@@ -54,8 +54,9 @@ goog.require('ga_permalink');
           (('msMaxTouchPoints' in navigator) && navigator.msMaxTouchPoints > 1);
       var mobile = touchDevice && testSize(768);
       var embed = /\/embed\.html$/.test($window.location.pathname);
+      var img = /\/img\.html$/.test($window.location.pathname);
       var p = gaPermalink.getParams();
-      mobile = !embed && ((mobile && p.mobile != 'false') ||
+      mobile = !embed && !img && ((mobile && p.mobile != 'false') ||
           p.mobile == 'true');
 
       if (msie > 9) {
@@ -121,6 +122,7 @@ goog.require('ga_permalink');
         phone: mobile && testSize(480),
         events: eventsKeys,
         embed: embed,
+        img: img,
         isInFrame: ($window.location != $window.parent.location),
         webgl: !(typeof WebGLRenderingContext === 'undefined'),
         animation: (!msie || msie > 9),

--- a/src/components/attribution/style/attribution.less
+++ b/src/components/attribution/style/attribution.less
@@ -11,7 +11,7 @@
   }
 }
 
-.embed {
+.embed, .img {
   [ga-attribution], [ga-attribution-warning] {
     bottom: 0;
   }

--- a/src/components/backgroundselector/BackgroundSelectorDirective.js
+++ b/src/components/backgroundselector/BackgroundSelectorDirective.js
@@ -25,7 +25,8 @@ goog.require('ga_topic_service');
         link: function(scope, elt, attrs) {
           scope.isBackgroundSelectorClosed = true;
           var mobile = gaBrowserSniffer.mobile;
-          scope.desktop = !gaBrowserSniffer.embed && !mobile;
+          scope.desktop = !gaBrowserSniffer.embed && !gaBrowserSniffer.img &&
+                          !mobile;
           scope.backgroundLayers = [];
 
           if (mobile) {

--- a/src/components/map/MapDirective.js
+++ b/src/components/map/MapDirective.js
@@ -202,7 +202,7 @@ goog.require('ga_styles_service');
         // Often when we use embed map the size of the map is fixed, so we
         // don't need to resize the map for printing (use case: print an
         // embed map in a tooltip.
-        if (!gaBrowserSniffer.embed) {
+        if (!gaBrowserSniffer.embed && !gaBrowserSniffer.img) {
           // IE + Firefox
           // We can't call a map.updateSize() for these browsers(because
           // it's applied after the printing) so we resize

--- a/src/components/permalink/PermalinkService.js
+++ b/src/components/permalink/PermalinkService.js
@@ -55,6 +55,27 @@ goog.require('ga_urlutils_service');
           var base = b;
           var params = p;
 
+          var getHrefFor = function(p, page) {
+            var pageHtml = page + '.html';
+            var pageRegex = new RegExp(page + '\\.html$');
+            var newParams = angular.extend({}, params);
+            if (angular.isDefined(p)) {
+              angular.extend(newParams, p);
+            }
+            if (angular.isDefined(newParams.mobile)) {
+              delete newParams.mobile;
+            }
+            var basePage = base.replace(/^http:/, 'https:').
+                replace(/(index|mobile)\.html$/, pageHtml);
+            if (!pageRegex.test(basePage)) {
+              if (!/\/$/.test(basePage)) {
+                basePage += '/';
+              }
+              basePage += pageHtml;
+            }
+            return basePage + '?' + gaUrlUtils.toKeyValue(newParams);
+          };
+
           this.getHref = function(p) {
             var newParams = angular.extend({}, params);
             if (angular.isDefined(p)) {
@@ -64,22 +85,11 @@ goog.require('ga_urlutils_service');
           };
 
           this.getEmbedHref = function(p) {
-            var newParams = angular.extend({}, params);
-            if (angular.isDefined(p)) {
-              angular.extend(newParams, p);
-            }
-            if (angular.isDefined(newParams.mobile)) {
-              delete newParams.mobile;
-            }
-            var baseEmbed = base.replace(/^http:/, 'https:').
-                replace(/(index|mobile)\.html$/, 'embed.html');
-            if (!/embed\.html$/.test(baseEmbed)) {
-              if (!/\/$/.test(baseEmbed)) {
-                baseEmbed += '/';
-              }
-              baseEmbed += 'embed.html';
-            }
-            return baseEmbed + '?' + gaUrlUtils.toKeyValue(newParams);
+            return getHrefFor(p, 'embed');
+          };
+
+          this.getImgHref = function(p) {
+            return getHrefFor(p, 'img');
           };
 
           // The main href is the embed permalink but without the name of

--- a/src/components/timestampcontrol/style/timestampcontrol.less
+++ b/src/components/timestampcontrol/style/timestampcontrol.less
@@ -16,6 +16,9 @@
   border-radius: 3px;
 }
 
-.embed .ga-timestamp-control {
-  bottom: 22px;
+.embed, .img {
+  .ga-timestamp-control {
+    bottom: 22px;
+  }
 }
+

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -101,6 +101,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           'offline': globals.offline,
           'online': !globals.offline,
           'embed': globals.embed,
+          'img': globals.img,
           'ga-draw-active': globals.isDrawActive,
           'ga-3d-active': globals.is3dActive
         }">
@@ -139,7 +140,7 @@ itemscope itemtype="http://schema.org/WebApplication"
     <div ng-controller="GaSeoController">
       <div ga-seo ga-seo-options="options" ga-seo-map="map"></div>
     </div>
-% if device != 'embed':
+% if device != 'embed' and device != 'img':
     <div ng-cloak translate-cloak id="header" class="navbar navbar-fixed-top" ng-class="{'host-not-prod': !globals.hostIsProd}">
       <a href="?topic={{topicId}}&lang={{langId}}">
         <div id="logo" class="pull-left ga-logo">
@@ -205,6 +206,37 @@ itemscope itemtype="http://schema.org/WebApplication"
       <div ga-scale-line ga-scale-line-map="map" ng-show="!globals.is3dActive"></div>
   % endif
 
+  % if device == 'img':
+      <form id="img-settings" class="form">
+       <!-- <label>Page size </label> -->
+        <select id="format">
+          <option value="a0">A0 (slow)</option>
+          <option value="a1">A1</option>
+          <option value="a2">A2</option>
+          <option value="a3">A3</option>
+          <option value="a4" selected>A4</option>
+          <option value="a5">A5 (fast)</option>
+        </select>
+      <!-- <label>Resolution </label> -->
+        <select id="resolution">
+          <option value="75">75 dpi (fast)</option>
+          <option value="150">150 dpi</option>
+          <option value="300">300 dpi (slow)</option>
+        </select>
+        <button id="apply-rendering">Apply</button>
+      </form>
+      <!-- search is needed for img page so swisssearch parameter is working
+           even though search is not displayed -->
+      <div id="search-container" ng-controller="GaSearchController">
+        <div ga-search ga-search-map="map" ga-search-options="options" ga-search-ol3d="::ol3d"></div>
+      </div>
+
+      <div ga-scale-line ga-scale-line-map="map" ng-show="!globals.is3dActive"></div>
+  % endif
+
+
+
+% if device != 'img':
       <div id='buttonGroup' ng-cloak translate-cloak>
   % if device != 'embed':
         <div ga-geolocation ga-geolocation-map="::map" ga-geolocation-ol3d="::ol3d"></div>
@@ -226,6 +258,7 @@ itemscope itemtype="http://schema.org/WebApplication"
            ga-background-selector-ol3d="::ol3d">
       </div>
   % endif
+% endif
       <div ga-swipe
            ga-swipe-map="map"
            ga-swipe-active="globals.isSwipeActive"
@@ -253,7 +286,7 @@ itemscope itemtype="http://schema.org/WebApplication"
          ga-attribution-warning-ol3d="::ol3d">
       <span translate>3d_overlay_warning</span>
     </div>
-% if device != 'embed':
+% if device != 'embed' and device != 'img':
     <div ng-cloak translate-cloak id="footer" class="navbar navbar-fixed-bottom">
       <div  class="pull-left" ga-scale-line ga-scale-line-map="::map" ng-show="!globals.is3dActive"></div>
 
@@ -291,7 +324,7 @@ itemscope itemtype="http://schema.org/WebApplication"
 
     <div ga-timestamp-control ga-timestamp-control-map="map"></div>
 
-% if device != 'embed':
+% if device != 'embed' and device != 'img':
     <div ng-controller="GaTimeSelectorController">
       <div ga-time-selector
            ga-time-selector-map="::map"
@@ -313,7 +346,7 @@ itemscope itemtype="http://schema.org/WebApplication"
       </div>
     </div>
 
-% if device != 'embed':
+% if device != 'embed' and device != 'img':
     <div  id="pulldown" ng-cloak translate-cloak
           ng-class="{
             'selection-and-catalog-shown': (globals.catalogShown && globals.selectionShown),
@@ -665,6 +698,8 @@ itemscope itemtype="http://schema.org/WebApplication"
   % endif
 % endif
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/1.2.61/jspdf.min.js"></script>
+
 % if mode == 'prod':
 
     <script>
@@ -755,7 +790,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         var adminUrlRegexp = new RegExp('${admin_url_regexp}');
         var module = angular.module('geoadmin');
         var cacheAdd = '${version}' != '' ? '/' + '${version}' : '';
-        var pathname = location.pathname.replace(/(index|mobile|embed)\.html$/g, '');
+        var pathname = location.pathname.replace(/(index|mobile|embed|img)\.html$/g, '');
         var s3pathname = '${s3basepath}' == '' ? pathname : '${s3basepath}';
         var prtl = location.protocol;
         // Because s3 is hosted on infra
@@ -931,5 +966,39 @@ itemscope itemtype="http://schema.org/WebApplication"
       })();
 % endif
     </script>
+% if device == 'img':
+    <script>
+    var dims = {
+        a0: [1189, 841],
+        a1: [841, 594],
+        a2: [594, 420],
+        a3: [420, 297],
+        a4: [297, 210],
+        a5: [210, 148]
+      };
+
+      var renderButton = document.getElementById('apply-rendering');
+
+      renderButton.addEventListener('click', function() {
+        var map = angular.element(document.body).scope().map;
+
+        var format = document.getElementById('format').value;
+        var resolution = document.getElementById('resolution').value;
+        var dim = dims[format];
+        var width = Math.round(dim[0] * resolution / 25.4);
+        var height = Math.round(dim[1] * resolution / 25.4);
+        var size = /** @type {ol.Size} */ (map.getSize());
+        var extent = map.getView().calculateExtent(size);
+        var oldRes = map.getView().getResolution();
+
+        map.setSize([width, height]);
+        map.getView().fit(extent, /** @type {ol.Size} */ (map.getSize()));
+        var newRes = map.getView().getResolution();
+        map.render();
+
+      }, false);
+
+    </script>
+% endif
   </body>
 </html>

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -256,6 +256,7 @@ goog.require('ga_topic_service');
       animation: gaBrowserSniffer.animation,
       offline: gaNetworkStatus.offline,
       embed: gaBrowserSniffer.embed,
+      img: gaBrowserSniffer.img,
       pulldownShown: !(gaBrowserSniffer.mobile || win.width() <= 1024),
       printShown: false,
       catalogShown: false,

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -1655,7 +1655,7 @@ input[type=range] {
 @screen-sm-height-step-2: unit((@screen-sm-height-step-1 - @control-btn-size), px);
 @screen-sm-height-step-3: unit((@screen-sm-height-step-1 - @control-btn-size * 2), px);
 
-body:not(.embed) {
+body:not(.embed, .img) {
   /* Map rotated with device heading has its own rotation button */
   .ga-geolocation-northarrow ~ .ga-rotate-enabled {
     display: none;
@@ -1711,17 +1711,57 @@ body:not(.embed) {
 }
 
 
-.embed, .ga-full-screen {
+.embed, .img, .ga-full-screen {
   #buttonGroup {
     top: 0px;
   }
 }
 
-.embed {
+.embed, .img {
 
   #search-container {
     display: none;
   }
+
+  [ga-time-selector] {
+    display: none!important;
+  }
+
+  [ga-scale-line], #copyrightsdata {
+    position: absolute;
+    bottom: 0;
+    z-index: 1000;
+  }
+  
+  #copyrightsdata {
+    max-width: ~"calc(100% - 160px)";
+  }
+  
+  [ga-scale-line] {
+    bottom: 2px;
+    left: 2px;
+    width: auto;
+    height: 15px;
+    margin: 0;
+    font-size: 11px;
+  }  
+  
+  .ol-scale-line-inner {
+    background: rgba(255,255,255,.7);
+  }
+
+}
+
+.img {
+  #img-settings {
+    position: absolute;
+    z-index: 1000;
+    top: 5px;
+    left: 5px;
+  }
+}
+
+.embed {
 
   #bigMapLink {
     position: absolute;
@@ -1791,6 +1831,7 @@ body:not(.embed) {
     }
   }
 }
+
 
 /* Corner ribbons, from http://codepen.io/eode9/pen/twkKm */
 .corner-ribbon{

--- a/src/style/print.less
+++ b/src/style/print.less
@@ -43,11 +43,14 @@
     border: 1px solid lightgray;
   }
 
-  .embed [ga-map] {
-    width: initial !important;
-    top: initial !important;
-    height: initial !important;
+  .embed, img {
+    [ga-map] {
+      width: initial !important;
+      top: initial !important;
+      height: initial !important;
+    }
   }
+
 
   // ****** PRINT PROFILE SETTINGS
   [ga-profile] {


### PR DESCRIPTION
This PR adds an img page that _could_ serve as basis for map.geo rendered map images (jpg/png) using different sizes and resolutions (dpi)

We have use cases where we need a rendered map, outside of the actual application, as an image:
- print
- non-javascript version of map.geo
- twitter cards
- etc

Print currently uses it's own map rendering engine, which means we need to translate the map.geo map into something that the print server understands - and the print service needs to recompose the map gain.  And to have real Wysiwig, the print rendering engine needs to support the same things as the application itself - something that might not be there when we introduce vector tiles. So I thought: why not use map.geo to create the rendered image?

Anyhow, there are some challenges. As you can see in the testlink, rendering for A0 and 300dpi is extremely slow. Also
- [ ] we would need to extend current solution to store the image somewhere (on S3?) to be consumed with other things.
- [ ] parametrisation (specify dpi and image size) should be possible with permalink parameters.
- [ ] Assure map is loaded before image is created/uploaded
- [ ] Many other things

[In the demo](https://mf-geoadmin3.int.bgdi.ch/gjn_img/4781147/1472819635/img.html?topic=ech&lang=en&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.astra.unfaelle-personenschaeden_alle,ch.bazl.luftfahrthindernis&layers_timestamp=,&X=192243.00&Y=661224.96&zoom=4), you can define some parameters and apply them. To safe the image, just right-click on the map.

Inspiration: http://openlayers.org/en/latest/examples/export-pdf.html
Some other refs:
https://github.com/niklasvh/html2canvas
http://stackoverflow.com/questions/10721884/render-html-to-an-image
https://github.com/tsayen/dom-to-image
http://stackoverflow.com/questions/35480112/canvas-todataurl-download-size-limit#35480643
http://www.html5canvastutorials.com/advanced/html5-canvas-get-image-data-url/
https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob
