### PR TITLE
Deploy named branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use `make help` to know about the possible `make` targets and the currently set 
     $ make help
 
 Use `make translate` to import directly translations from the Google spreadsheet. Don't forget to set up first these 2 following environment parameter:
-    
+
     export DRIVE_USER=your_login
     export DRIVE_PWD=your_password
 
@@ -39,7 +39,7 @@ should source the corresponding `rc` file.
 On mf0t, create an Apache configuration file for your environment. Ex:
 
     $ cat /var/www/vhosts/mf-geoadmin3/conf/00-elemoine.conf
-    Include /home/elemoine/mf-geoadmin3/apache/*.conf 
+    Include /home/elemoine/mf-geoadmin3/apache/*.conf
 
 ## Dependencies
 
@@ -50,8 +50,8 @@ setup your own web server with correct configurations), you should still
 be able to build the project on a different, Linux based infrastructure. For
 this to work, you need to make sure to install the following dependencies:
 
-    sudo apt-get install python-software-properties 
-    sudo add-apt-repository ppa:chris-lea/node.js 
+    sudo apt-get install python-software-properties
+    sudo add-apt-repository ppa:chris-lea/node.js
     sudo apt-get update
     sudo apt-get install make gcc+ git unzip openjdk-6-jre openjdk-6-jdk g++ npm python-virtualenv
 
@@ -60,7 +60,7 @@ this to work, you need to make sure to install the following dependencies:
 You might get an error similar to:
     /usr/bin/env: node: No such file or directory
 This can be fixed by running:
-    sudo ln -s /usr/bin/nodejs /usr/bin/node 
+    sudo ln -s /usr/bin/nodejs /usr/bin/node
     #see https://github.com/joyent/node/issues/3911
 
 ### Update to the last OpenLayers/Cesium/OL3-Cesium Version
@@ -107,12 +107,12 @@ the following command
 
 ## Cross-browser end-to-end tests with browserstack.com
 
-To run the e2e browserstack tests, a few things need to be set up in your 
-environment. You need to have the BROWSERSTACK_USER and BROWSERSTACK_KEY 
-variables set. As they are sensitive, they should not be accessible in public 
-(don't add them to github). Recommended way is via a protected file on your 
+To run the e2e browserstack tests, a few things need to be set up in your
+environment. You need to have the BROWSERSTACK_USER and BROWSERSTACK_KEY
+variables set. As they are sensitive, they should not be accessible in public
+(don't add them to github). Recommended way is via a protected file on your
 system (readable only by you):
-    
+
     echo "export BROWSERSTACK_USER=***" >> ~/.browserstack
     echo "export BROWSERSTACK_KEY=***" >> ~/.browserstack
     chmod 600 ~/.browserstack
@@ -140,9 +140,28 @@ These tests are not part of the normal build. They need to be launched manually.
 
 ## Building and deploying to AWS S3
 
-To build a branch of mf-geoadmin3 and upload the result to AWS S3 int,
+To build the current branch and upload it to AWS S3 int, use:
 
-    make s3deploybranch DEPLOY_GIT_BRANCH=my_branch
+    make s3deploybranch
+
+Branches are stored in the user environments under:
+
+   ~/tmp/branches/{branch_name}
+
+To upload a different branch, use:
+
+    make s3deploybranch DEPLOY_GIT_BRANCH=<BRANCH_NAME>
+
+After the first clone, dev dependencies are not removed when uploading a branch
+to S3. If you want to also remove the dev depedencies, use:
+
+    make s3deploybranch DEEP_CLEAN=true
+
+Per default, branches are overwritten on S3 when deployed on integration.
+If you want to change this behaviour and create a new version of the deployed branch,
+use the following command:
+
+    make s3deploybranch NAMED_BRANCH=false
 
 If the project builds and the tests are passing, then, files will be uploaded to a directory:
 
@@ -151,9 +170,9 @@ If the project builds and the tests are passing, then, files will be uploaded to
 For instance:
 
     mom_layersconfig_lang/75098c2/1468688399/index.html
-    
+
 and for source:
-    
+
     mom_layersconfig_lang/75098c2/1468688399/src/index.html
 
 Metadata to a build are available next to the index.html, as info.json
@@ -194,6 +213,10 @@ To get more information about a build:
 
 To delete a given build:
 `make s3deleteint S3_VERSION_PATH=<DEPLOY_GIT_BRANCH>/<DEPLOY_GIT_HASH>/<EPOCH_BUILD>`
+
+To delete a named branch:
+
+`make s3deleteint S3_VERSION_PATH=<DEPLOY_GIT_BRANCH>`
 
 ### Get correct link the API
 

--- a/scripts/clonebuild.sh
+++ b/scripts/clonebuild.sh
@@ -1,46 +1,67 @@
 #!/bin/bash
 
-#bail out on any error
+# bail out on any error
 set -o errexit
 
-# set some variables and default
+get_s3_basepath () {
+  SHA=$(git rev-parse HEAD | cut -c1-7)
+  VERSION=$(cat .build-artefacts/last-version)
+  echo "/$1/$SHA/$VERSION/"
+}
 
-GIT_CLONE_OPTS=""
-SNAPSHOTDIR=${@:$OPTIND:1}
-DEPLOY_GIT_BRANCH=${@:$OPTIND+1:1}
-DEPLOY_GIT_BRANCH=${DEPLOY_GIT_BRANCH:-master}
-DEPLOY_TARGET=${@:$OPTIND+2:1}
+create_snapshot_dir () {
+  if [ ! -d "${CLONEDIR}" ]; then
+    mkdir -p "${CLONEDIR}"
+  fi
+}
 
-if [ ! -d "${SNAPSHOTDIR}" ]; then
-    mkdir -p "${SNAPSHOTDIR}"
-fi
+update_and_reset_git_project () {
+  echo "Reseting repository to HEAD for branch=${DEPLOY_GIT_BRANCH}"
+  git fetch
+  git checkout $DEPLOY_GIT_BRANCH
+  git reset --hard origin/$DEPLOY_GIT_BRANCH
+}
 
-echo "Cloning branch=${DEPLOY_GIT_BRANCH}, into directory=${SNAPSHOTDIR}"
-cd ${SNAPSHOTDIR}
+# set some variables and defaults
+CLONEDIR=${@:$OPTIND:1}
+DEPLOY_TARGET=${@:$OPTIND+1:1}
+DEPLOY_GIT_BRANCH=${@:$OPTIND+2:1}
+DEEP_CLEAN=${@:$OPTIND+3:1}
+NAMED_BRANCH=${@:$OPTIND+4:1}
+
+create_snapshot_dir
+cd ${CLONEDIR}
 
 if [ ! -d mf-geoadmin3 ]; then
-    git clone ${GIT_CLONE_OPTS} -b ${DEPLOY_GIT_BRANCH}  https://github.com/geoadmin/mf-geoadmin3.git
-    cd mf-geoadmin3
+  echo "Cloning branch=${DEPLOY_GIT_BRANCH}, into directory=${CLONEDIR}"
+  git clone -b ${DEPLOY_GIT_BRANCH}  https://github.com/geoadmin/mf-geoadmin3.git
+  cd mf-geoadmin3
 else
-    cd mf-geoadmin3
+  cd mf-geoadmin3
+  if [ "$DEEP_CLEAN" = "true" ]; then
     make cleanall
-    echo "Reseting repository to HEAD for branch=${DEPLOY_GIT_BRANCH}"
-    git fetch
-    git checkout $DEPLOY_GIT_BRANCH
-    git reset --hard origin/$DEPLOY_GIT_BRANCH
+  else
+    make clean
+  fi
+  update_and_reset_git_project
 fi
 
-make .build-artefacts/last-version
-SHA=$(git rev-parse HEAD | cut -c1-7)
-VERSION=$(cat .build-artefacts/last-version)
-S3_BASE_PATH=/$DEPLOY_GIT_BRANCH/$SHA/$VERSION
-export S3_SRC_BASE_PATH=$S3_BASE_PATH/src/
-export S3_BASE_PATH=$S3_BASE_PATH/
+if [ "$NAMED_BRANCH" = "true" ]; then
+  export KEEP_VERSION="true"
+  S3_BASE_PATH=/$DEPLOY_GIT_BRANCH/
+else
+  export KEEEP_VERSION="false"
+  make .build-artefacts/last-version
+  S3_BASE_PATH=$(get_s3_basepath $DEPLOY_GIT_BRANCH)
+fi
+S3_SRC_BASE_PATH=$S3_BASE_PATH"src/"
 
-echo "S3_BASE_PATH="
+echo "S3_BASE_PATH:"
 echo $S3_BASE_PATH
-echo "S3_SRC_BASE_PATH="
+echo "S3_SRC_BASE_PATH:"
 echo $S3_SRC_BASE_PATH
 
 echo "Building the project"
+export S3_BASE_PATH=$S3_BASE_PATH
+export S3_SRC_BASE_PATH=$S3_SRC_BASE_PATH
 source rc_$DEPLOY_TARGET && make all


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3463

With this PR:

* `s3deploybranch` now only deploys using a branch name (overrides the previous branch in S3 if the version is kept), path are now `<branchName>/index.html` and `<branchName>/src/index.html`
* Named branch cannot be activated but they can be deleted.
* `s3deploybranch` simply performs a clean after a first deploy branch cmd, `DEEP_CLEAN=true` can be used to perform a cleanall operation before redeploying.
* One can deploy a full version like before using `NAMED_BRANCH=false`
* Improved version display in s3list(int|prod)
* Minor cleanups