### PR TITLE
Use level 18 for imagery layers

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -394,7 +394,7 @@ goog.require('ga_urlutils_service');
           dfltWmtsNativeSubdomains, dfltWmtsMapProxySubdomains,
           wmsUrlTemplate, wmtsGetTileUrlTemplate,
           wmtsMapProxyGetTileUrlTemplate, terrainTileUrlTemplate,
-          layersConfigUrlTemplate, legendUrlTemplate) {
+          layersConfigUrlTemplate, legendUrlTemplate, imageryMetadataUrl) {
         var layers;
 
         // Returns a unique WMS template url (e.g. //wms{s}.geo.admin.ch)
@@ -659,14 +659,11 @@ goog.require('ga_urlutils_service');
                 window.minimumRetrievingLevel;
             var maxRetLod = gaMapUtils.getLodFromRes(config3d.minResolution);
             // Set maxLod as undefined deactivate client zoom.
-            var maxLod = (maxRetLod) ? undefined : 17;
+            var maxLod = (maxRetLod) ? undefined : 18;
             if (maxLod && config3d.resolutions) {
               maxLod = gaMapUtils.getLodFromRes(
                   config3d.resolutions[config3d.resolutions.length - 1]);
             }
-
-            var terrainTimestamp = this.getLayerTimestampFromYear(
-                gaGlobalOptions.defaultTerrain, gaTime.get());
             provider = new Cesium.UrlTemplateImageryProvider({
               url: params.url,
               subdomains: params.subdomains,
@@ -680,9 +677,9 @@ goog.require('ga_urlutils_service');
               tileHeight: params.tileSize,
               hasAlphaChannel: (format == 'png'),
               availableLevels: window.imageryAvailableLevels,
-              // Experimental: restrict all rasters to terrain availability
-              metadataUrl: getTerrainTileUrl(
-                  gaGlobalOptions.defaultTerrain, terrainTimestamp) + '/'
+              // Experimental: restrict all rasters from 0 - 17 to terrain
+              // availability and 18 to Swiss bbox
+              metadataUrl: imageryMetadataUrl
             });
           }
           if (provider) {
@@ -987,11 +984,11 @@ goog.require('ga_urlutils_service');
         };
       };
 
-      return new Layers(this.dfltWmsSubdomains,
-          this.dfltWmtsNativeSubdomains, this.dfltWmtsMapProxySubdomains,
-          this.wmsUrlTemplate, this.wmtsGetTileUrlTemplate,
-          this.wmtsMapProxyGetTileUrlTemplate, this.terrainTileUrlTemplate,
-          this.layersConfigUrlTemplate, this.legendUrlTemplate);
+      return new Layers(this.dfltWmsSubdomains, this.dfltWmtsNativeSubdomains,
+          this.dfltWmtsMapProxySubdomains, this.wmsUrlTemplate,
+          this.wmtsGetTileUrlTemplate, this.wmtsMapProxyGetTileUrlTemplate,
+          this.terrainTileUrlTemplate, this.layersConfigUrlTemplate,
+          this.legendUrlTemplate, this.imageryMetadataUrl);
     };
 
   });

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -532,10 +532,10 @@ itemscope itemtype="http://schema.org/WebApplication"
 
     <!-- Modal: draw share -->
     <div ng-cloak translate-cloak ga-share-draw></div>
-    
+
     <!-- Modal: embed share -->
     <div ng-cloak translate-cloak ga-share-embed></div>
- 
+
     <!-- Popup: Feedback -->
     <div ga-popup="globals.feedbackPopupShown"
          ga-popup-options="{title:'problem_announcement', help:'70'}"
@@ -588,8 +588,8 @@ itemscope itemtype="http://schema.org/WebApplication"
           <div ng-if="toggle"
                ga-profile="feature"
                ga-profile-map="::map"
-               ga-profile-layer="layer" 
-               ga-profile-options="options"> 
+               ga-profile-layer="layer"
+               ga-profile-options="options">
           </div>
         </div>
       </div>
@@ -857,6 +857,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
           gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =  gaGlobalOptions.mapproxyUrl + '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
           gaLayersProvider.terrainTileUrlTemplate = '//terrain100.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
+          gaLayersProvider.imageryMetadataUrl = '//3d.geo.admin.ch/imagery/';
           if (apiOverwrite) {
             gaLayersProvider.layersConfigUrlTemplate = apiUrl + '/rest/services/all/MapServer/layersConfig?lang={Lang}';
           } else {

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -76,6 +76,7 @@ beforeEach(function() {
     gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
     gaLayersProvider.layersConfigUrlTemplate = 'https://example.com/all?lang={Lang}';
     gaLayersProvider.legendUrlTemplate = 'https://legendservice.com/all/{Layer}?lang={Lang}';
+    gaLayersProvider.imageryMetadataUrl = '//3d.geo.admin.ch/imagery/';
   });
 
   module(function(gaTopicProvider, gaGlobalOptions) {

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -809,13 +809,13 @@ describe('ga_map_service', function() {
         expect(params.minimumRetrievingLevel).to.eql(window.minimumRetrievingLevel);
         expect(params.maximumRetrievingLevel).to.eql(window.maximumRetrievingLevel);
         expect(params.minimumLevel).to.eql(undefined);
-        expect(params.maximumLevel).to.eql(17);
+        expect(params.maximumLevel).to.eql(18);
         expect(params.tilingScheme).to.be.an(Cesium.GeographicTilingScheme);
         expect(params.tileWidth).to.eql(256);
         expect(params.tileHeight).to.eql(256);
         expect(params.hasAlphaChannel).to.eql(true);
         expect(params.availableLevels).to.be(window.imagerAvailableLevels);
-        expect(params.metadataUrl).to.eql(expectTerrainUrl('ch.dummy.terrain.3d', '20180101') + '/');
+        expect(params.metadataUrl).to.eql('//3d.geo.admin.ch/imagery/');
         expect(prov.bodId).to.be('wmts3d');
         spy.restore();
       });


### PR DESCRIPTION
So I uploaded a custom layer.json for raster layers where I added an extra zoom level (18).

See: https://3d.geo.admin.ch/imagery/layer.json

Related to https://github.com/geoadmin/mf-geoadmin3/issues/3124 and 

[Test Link After](https://mf-geoadmin3.int.bgdi.ch/gal_3d_imagery/index.html?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false&lon=7.70164&lat=46.68020&elevation=815&heading=360.000&pitch=-69.536)
[Test Link Before](https://map.geo.admin.ch/?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false&lon=7.70164&lat=46.68020&elevation=815&heading=360.000&pitch=-69.536)

https://github.com/geoadmin/mf-geoadmin3/issues/3424