### PR TITLE
Make sure the layer exists

### DIFF
--- a/src/components/draw/DrawDirective.js
+++ b/src/components/draw/DrawDirective.js
@@ -700,7 +700,11 @@ goog.require('ga_styles_service');
         // create/update the file on s3
         ////////////////////////////////////
         var save = function(evt) {
-          if (layer && layer.getSource().getFeatures().length == 0) {
+          if (!layer {
+            // Do nothing if the layer does not exist
+            return;
+          }
+          if (layer.getSource().getFeatures().length == 0) {
             //if no features to save, delete the file
             if (layer.adminId) {
               scope.statusMsgId = '';

--- a/src/components/draw/DrawDirective.js
+++ b/src/components/draw/DrawDirective.js
@@ -700,7 +700,7 @@ goog.require('ga_styles_service');
         // create/update the file on s3
         ////////////////////////////////////
         var save = function(evt) {
-          if (layer.getSource().getFeatures().length == 0) {
+          if (layer && layer.getSource().getFeatures().length == 0) {
             //if no features to save, delete the file
             if (layer.adminId) {
               scope.statusMsgId = '';


### PR DESCRIPTION
This PR fixes an unreported JS error.

Step to reproduce:

Open https://map.geo.admin.ch
Click Draw tool
Draw a line
Delete all features
Click back button

Result:
Error -> getSource of null (because layer is set to null)

Expected Result:
No JS error
