### PR TITLE
Put back keyboard nav on Catalog and Layertree

### DIFF
--- a/src/components/catalogtree/style/catalogtree.less
+++ b/src/components/catalogtree/style/catalogtree.less
@@ -2,6 +2,12 @@
 
   .ga-catalogitem-node {
 
+    button {
+      &:focus {
+        box-shadow: 0 0 3px 0px rgb(77, 144, 254);
+      }
+    }
+
     a {
       color: black;
       display: block;
@@ -60,8 +66,7 @@
       margin: 0;
     }
     input[type=checkbox] {
-      margin-left: .5em;
-      margin-right: .5em;
+      margin-top: .7em;
     }
   }
 
@@ -69,7 +74,7 @@
     margin-top: 0px;
     margin-bottom: 0px;
     padding-left: 0px;
-    
+
     &:not(.ga-catalogitem-selected) label:hover {
       color: #666;
     }

--- a/src/components/layermanager/style/layermanager.less
+++ b/src/components/layermanager/style/layermanager.less
@@ -28,7 +28,7 @@
     width: 5.5em;
     padding: 0;
   }
- 
+
   .ga-layer-infos label, input, select, options {
     cursor: pointer;
 
@@ -55,13 +55,13 @@
     padding: 0px;
     height: 14px;
     vertical-align: middle;
- 
+
     &::-ms-track {
       height: 4px;
       color: transparent;
       background: linear-gradient(to right, rgba(0,0,0,0.65) 0%,rgba(0,0,0,0) 100%);
     }
- 
+
     &::-ms-fill-lower, &::-ms-fill-upper {
       background: none;
     }
@@ -71,9 +71,9 @@
       border-radius: 5px;
       height: 12px;
       background: linear-gradient(to bottom, #eeeeee 0%,#cccccc 100%);
-    } 
+    }
   }
- 
+
   .ga-layer-infos {
     width: 100%;
     z-index: 1;
@@ -81,6 +81,9 @@
 
     button {
       position: absolute;
+      &:focus {
+        box-shadow: 0 0 3px 0px rgb(77, 144, 254);
+      }
     }
 
     label {
@@ -120,7 +123,7 @@
         opacity: 0;
       }
     }
-    
+
     .fa-user {
       display: none;
       color: red;
@@ -132,7 +135,7 @@
       display: block;
       right: 34px;
     }
-    
+
     .ga-layer-infos label {
       padding-right: 5.1em;
     }
@@ -160,13 +163,13 @@
       }
     }
   }
- 
+
   .ga-layer-tools, .ga-layer-infos {
     height: 3em;
   }
 
   .ga-layer-time-enabled .ga-layer-tools {
- 
+
     @media (max-width: 335px) {
       label > div {
         font-size: 0.8em;
@@ -201,9 +204,11 @@
 
   .ga-layer-folded {
     height: 3em;
+    display: block;
 
     .ga-layer-tools {
       top: 0em;
+      display: none;
     }
 
     .fa-gear {
@@ -225,7 +230,7 @@
 /* The popover is outside the layermanager */
 .ga-layer-timestamps {
   width: 200px;
- 
+
   & div {
     width: 50px;
     height: 20px;
@@ -247,11 +252,11 @@
   border: 0;
   font-size: inherit;
   font-weight: normal;
- 
+
   &, &.ga-black, &.ga-black:hover {
     color: #000;
   }
- 
+
   &:not(.ga-black), &:not(.ga-black):hover {
     color: #f00;
   }

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -86,15 +86,15 @@ button, a, .ga-bg-layer, .ga-bg-layer-bt {
   touch-action: manipulation;
   -ms-touch-action: manipulation;
 }
- 
+
 .has-error {
-  
+
   input[type=url] {
     background-color: #f2dede!important;
   }
 
   .ga-message {
-    color: red; 
+    color: red;
   }
 }
 
@@ -188,7 +188,7 @@ button.ga-btn, .ol-control button {
     right: 0;
     color: #343434;
   }
-  
+
   .fa-ga-circle-bg {
     color: #fff;
   }
@@ -212,7 +212,7 @@ button.ga-btn, .ol-control button {
 
     .fa-ga-circle-bg {
       color: #fff;
-    }  
+    }
   }
 }
 
@@ -247,7 +247,7 @@ button.ga-icon, &.ga-btn-disabled {
   background-color: transparent;
   font-size: 1.3em;
   line-height: 1em; /* Critical css for alignment */
- 
+
   &[disabled] {
     color: #CCC;
     cursor: not-allowed;
@@ -294,7 +294,7 @@ button.ga-btn, .ol-control button {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  
+
   /* IE9+FontAwesome hack: https://github.com/FortAwesome/Font-Awesome/issues/1079*/
   &:before {
     content: "";
@@ -310,7 +310,7 @@ button.ga-btn, .ol-control button {
 }
 
 .ga-full-screen {
-  
+
   #header {
     background-color: transparent;
     box-shadow: none;
@@ -331,15 +331,15 @@ button.ga-btn, .ol-control button {
       padding: 1px 6px;
     }
   }
-  
-  &.ga-full-screen-no-inputs #search-container, 
+
+  &.ga-full-screen-no-inputs #search-container,
   #logo, #toptools, #pulldown, #footer {
     display: none;
   }
 }
 
 .ga-draw-active {
-  
+
   #header {
     top: unit(-@header-height, px);
   }
@@ -413,9 +413,9 @@ input[type=text][readonly] {
   cursor: default;
 }
 
-// ***** TABS 
+// ***** TABS
 .nav-tabs {
-  
+
   .active {
     cursor: default;
   }
@@ -548,7 +548,7 @@ input[type=text][readonly] {
     left: 44px;
     position: absolute;
   }
-  
+
   @media (max-width: @screen-phone) {
     right: 50px;
     width: auto;
@@ -576,7 +576,7 @@ input[type=text][readonly] {
     .fa-remove-sign {
       margin-right: 2%;
     }
-      
+
     .ga-search-dropdown {
       top: 37px !important;
       border-width: 1px 0;
@@ -698,10 +698,10 @@ input[type=text][readonly] {
   vertical-align: middle;
   padding: 6px 12px;
   background-color: #e6e6e6;
- 
+
   .btn-primary {
     margin-top: 1px;
-  } 
+  }
   .btn-primary .fa-arrow-left{
     vertical-align: middle;
   }
@@ -754,21 +754,21 @@ input[type=text][readonly] {
     line-height: unit(@footer-height, px);
     margin-right: 1em;
   }
-  
+
   [ga-scale-line] {
     line-height: 1.5em;
     height: 1.5em;
-    margin-top: .4em;  
+    margin-top: .4em;
   }
 
   @media (max-width: @screen-tablet) {
     background: transparent;
     padding-left: 2px;
-    
+
     & > div {
       display: none;
     }
-      
+
     [ga-scale-line] {
       display: inline-block;
       position: absolute;
@@ -777,7 +777,7 @@ input[type=text][readonly] {
       height: auto;
       line-height: 1.4em;
       margin: 0;
-      
+
       .ol-scale-line-inner {
         background: rgba(255,255,255,.7);
         outline: 2px solid rgba(255,255,255,.7);
@@ -852,8 +852,8 @@ a .ga-icon-separator {
     vertical-align: -2px;
   }
 
-  .collapsed .fa-caret-down {   
-    .rotate(-90deg);   
+  .collapsed .fa-caret-down {
+    .rotate(-90deg);
   }
 
   .panel {
@@ -949,7 +949,7 @@ a .ga-icon-separator {
       display: none;
     }
 
-    #share { 
+    #share {
       display: block!important;
       visibility: visible!important;
       height: auto!important;
@@ -1031,7 +1031,7 @@ a .ga-icon-separator {
     vertical-align: middle;
     .transition-transform(.2s ease);
   }
-  
+
   .ga-hidden-collapsed, .ga-visible-mobile {
     display: none;
   }
@@ -1059,7 +1059,7 @@ a .ga-icon-separator {
 
   .fa-caret-down {
     .rotate(-180deg);
-  } 
+  }
 
   .ga-visible-collapsed {
     display: none;
@@ -1118,7 +1118,7 @@ a .ga-icon-separator {
 
 // ****** SELECTION
 #selection {
-  
+
   .panel-body {
     padding: 0px 4px;
   }
@@ -1155,7 +1155,7 @@ a .ga-icon-separator {
   display: block;
   top: unit(@header-height, px);
   left: 2%;
-  right: 2%; 
+  right: 2%;
   margin: auto;
   max-width: 600px;
   max-height: none;
@@ -1168,9 +1168,9 @@ a .ga-icon-separator {
 
 .modal-header {
   .border-top-radius(6px);
-  
+
   @media (max-width: @screen-phone) {
-    padding: 5px 15px; 
+    padding: 5px 15px;
   }
 }
 .modal-body {
@@ -1178,7 +1178,7 @@ a .ga-icon-separator {
   overflow-y: auto;
 
   @media (max-width: @screen-phone) {
-    padding: 10px; 
+    padding: 10px;
     max-height: 340px;
   }
 }
@@ -1187,7 +1187,7 @@ a .ga-icon-separator {
 #import-wms-popup {
   width: 770px;  /* Fix resize from tablet to desktop */
   max-width: 770px;
- 
+
   @media (max-width: @screen-tablet) {
     max-width: 480px;
   }
@@ -1200,7 +1200,7 @@ a .ga-icon-separator {
 
 #featuretree-popup {
   width: 320px;
- 
+
   .ga-popup-content {
     padding: 5px 9px 5px 5px;
 
@@ -1230,7 +1230,7 @@ a .ga-icon-separator {
 }
 
 #profile-popup {
-  .popover-content { 
+  .popover-content {
     overflow: visible;
   }
 }
@@ -1239,10 +1239,10 @@ a .ga-icon-separator {
   width: 320px;
   margin: 18px 0 0 -160px;
   overflow: visible !important;
-  
+
   @media (max-width: @screen-phone) {
     margin: 0;
-  }  
+  }
 }
 
 
@@ -1296,7 +1296,7 @@ a.panel-heading {
   display: block;
 }
 
-// ***** POPOVER and MODAL (ga-popup and bs popover) 
+// ***** POPOVER and MODAL (ga-popup and bs popover)
 .popover {
   z-index: 3000;
 }
@@ -1378,11 +1378,11 @@ ul.panel-body-wide {
   padding: .7em .7em 0;
   display: table;
   width: 100%;
-  
+
   select, span {
     display: table-cell;
   }
-  
+
   span {
     font-size: 13px;
     font-weight: normal;
@@ -1506,7 +1506,7 @@ ul.panel-body-wide {
 // Only IE9
 .no-animation.online.ga-wait-cursor {
   cursor: wait;
- 
+
   #loader {
     display: none;
   }
@@ -1574,7 +1574,7 @@ input[type=range] {
 .ga-checkbox {
   cursor: pointer;
   -webkit-touch-callout: none;
-  
+
   input[type=checkbox] {
     cursor: inherit;
     display: inline;
@@ -1582,10 +1582,11 @@ input[type=range] {
 }
 
 .no-webkit .ga-checkbox {
-    
+
   input[type=checkbox] {
-    display: none;
-  
+    position: absolute;
+    opacity: 0;
+
     & + span:before {
       font-family: "FontAwesome";
       font-size: 14px;
@@ -1593,17 +1594,21 @@ input[type=range] {
       letter-spacing: 4px;
       vertical-align: -0.1em;
     }
-    
+
     &:checked + span:before {
       content: "\f046";
       color: #000;
       letter-spacing: 2px;
     }
   }
+
+  input[type=checkbox]:focus + span {
+    box-shadow: 0 0 3px 0px rgb(255, 0, 0);
+  }
 }
 
 .webkit .ga-checkbox {
-    
+
   input[type=checkbox] {
     -webkit-appearance: none;
     -moz-appearance: none;
@@ -1611,14 +1616,14 @@ input[type=range] {
     border: 0;
     background: white;
     vertical-align: -3px;
-    
+
     &:after {
       font-size: 14px;
       content: "\f096";
       font-family: FontAwesome;
       letter-spacing: 2px;
     }
-    
+
     &:checked:after {
       content: "\f046";
       letter-spacing: 0px;
@@ -1680,7 +1685,7 @@ input[type=range] {
     height: unit(@control-btn-size, px);
     pointer-events: auto;
   }
- 
+
   button {
     padding: 0;
     background-color: transparent;
@@ -1688,7 +1693,7 @@ input[type=range] {
     width: unit(@control-btn-size, px);
     height: unit(@control-btn-size, px);
   }
-   
+
   [ga-offline-bt] {
     .bt-bottom-mixin();
   }
@@ -1719,7 +1724,7 @@ body:not(.embed) {
     @media (min-width: @screen-tablet) and (max-height: unit((@screen-height-step-1), px)),
            (max-width: @screen-tablet) and (max-height: unit((@screen-sm-height-step-1), px)) {
       right: @bt-right-col-1;
-    }  
+    }
 
     @media (min-width: @screen-tablet) and (max-height: @screen-height-step-2),
            (max-width: @screen-tablet) and (max-height: @screen-sm-height-step-2) {
@@ -1731,11 +1736,11 @@ body:not(.embed) {
       right: @bt-right-col-3;
     }
   }
-  
+
   /* When only 2 optional buttons are displayed */
   .ga-time-selector-enabled + .ga-rotate-enabled,
   .ga-time-selector-enabled ~ [ga-offline-bt],
-  .ga-rotate-enabled + [ga-offline-bt] { 
+  .ga-rotate-enabled + [ga-offline-bt] {
 
     @media (min-width: @screen-tablet) and (max-height: @screen-height-step-2),
            (max-width: @screen-tablet) and (max-height: @screen-sm-height-step-2) {
@@ -1748,7 +1753,7 @@ body:not(.embed) {
       right: @bt-right-col-2;
     }
   }
-  
+
   /* When only 1 optional button is displayed */
   .ga-time-selector-enabled,
   .ga-rotate-enabled,
@@ -1800,7 +1805,7 @@ body:not(.embed) {
       }
     }
   }
-  
+
   #buttonGroup {
     top: 0px;
     right: 5px;
@@ -1819,11 +1824,11 @@ body:not(.embed) {
     bottom: 0;
     z-index: 1000;
   }
-  
+
   #copyrightsdata {
     max-width: ~"calc(100% - 160px)";
   }
-  
+
   [ga-scale-line] {
     bottom: 2px;
     left: 2px;
@@ -1831,8 +1836,8 @@ body:not(.embed) {
     height: 15px;
     margin: 0;
     font-size: 11px;
-  }  
-  
+  }
+
   .ol-scale-line-inner {
     background: rgba(255,255,255,.7);
   }


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3487

[Test Link](https://mf-geoadmin3.int.bgdi.ch/gal_keyboardnav/index.html)

Fixes Keyboard nav on FF and IE.
Focused elements are now more obvious as well.

Keyboard nav is impossible when display property is set to None. Therefore I had to adapt a few things.
I decided to manually apply chrome default focus style to all other browsers so that we have the same look and feel across browsers.

ping @oterral for the review.