### PR TITLE
Handle highlightable markers/features

### DIFF
--- a/src/components/MarkerOverlayService.js
+++ b/src/components/MarkerOverlayService.js
@@ -35,6 +35,7 @@ goog.require('ga_styles_service');
         isAlwaysVisible = visible;
         setVisibility(map.getView().getZoom());
         layer.getSource().addFeature(new ol.Feature({
+          label: 'query_search',
           geometry: new ol.geom.Point(center)
         }));
       }

--- a/src/components/geolocation/GeolocationDirective.js
+++ b/src/components/geolocation/GeolocationDirective.js
@@ -35,7 +35,9 @@ goog.require('ga_throttle_service');
         var userTakesControl = false;
         var map = scope.map;
         var view = map.getView();
-        var accuracyFeature = new ol.Feature();
+        var accuracyFeature = new ol.Feature({
+          unselectable: true
+        });
         var positionFeature = new ol.Feature({
           geometry: new ol.geom.Point([0, 0]),
           label: 'Geolocation' // TODO to be translated

--- a/src/components/geolocation/GeolocationDirective.js
+++ b/src/components/geolocation/GeolocationDirective.js
@@ -36,7 +36,10 @@ goog.require('ga_throttle_service');
         var map = scope.map;
         var view = map.getView();
         var accuracyFeature = new ol.Feature();
-        var positionFeature = new ol.Feature(new ol.geom.Point([0, 0]));
+        var positionFeature = new ol.Feature({
+          geometry: new ol.geom.Point([0, 0]),
+          label: 'Geolocation' // TODO to be translated
+        });
         var featuresOverlay = gaMapUtils.getFeatureOverlay(
           [accuracyFeature, positionFeature],
           gaStyleFactory.getStyleFunction('geolocation')

--- a/src/components/geolocation/GeolocationDirective.js
+++ b/src/components/geolocation/GeolocationDirective.js
@@ -40,7 +40,7 @@ goog.require('ga_throttle_service');
         });
         var positionFeature = new ol.Feature({
           geometry: new ol.geom.Point([0, 0]),
-          label: 'Geolocation' // TODO to be translated
+          label: $translate.instant('geolocation')
         });
         var featuresOverlay = gaMapUtils.getFeatureOverlay(
           [accuracyFeature, positionFeature],

--- a/src/components/map/MapDirective.js
+++ b/src/components/map/MapDirective.js
@@ -73,7 +73,10 @@ goog.require('ga_styles_service');
         }
 
         if (queryParams.crosshair !== undefined) {
-          var crosshair = new ol.Feature(new ol.geom.Point(view.getCenter()));
+          var crosshair = new ol.Feature({
+            label: 'link_bowl_crosshair',
+            geometry: new ol.geom.Point(view.getCenter())
+          });
           var style = gaStyleFactory.getStyle(queryParams.crosshair);
           if (!style) {
             style = gaStyleFactory.getStyle('marker');

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -44,7 +44,7 @@ goog.require('ga_topic_service');
             '<div ng-bind-html="html.snippet"></div>' +
             '<div ng-if="::html.showVectorInfos" class="ga-vector-tools">' +
               '<div ga-measure="::html.feature"></div>' +
-              '<div ng-if="::!html.mobile" ' +
+              '<div ng-if="::!html.showProfile" ' +
                    'ga-profile-bt="::html.feature"></div>' +
             '</div>' +
             '<div ga-shop ' +
@@ -699,7 +699,8 @@ goog.require('ga_topic_service');
                 showVectorInfos: (value instanceof ol.Feature),
                 clickGeometry: new ol.geom.Point(scope.clickCoordinate),
                 snippet: $sce.trustAsHtml(html),
-                mobile: gaBrowserSniffer.mobile
+                showProfile: !gaBrowserSniffer.mobile ||
+                    (value instanceof ol.Feature && value.getGeometry())
               });
             };
           }

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -570,10 +570,12 @@ goog.require('ga_topic_service');
 
             // Create the html popup for a feature then display it.
             var showVectorFeature = function(feature, layer) {
+              var label = layer.label ||
+                  $translate.instant(feature.getProperties().label);
               var htmlpopup =
                 '<div id="{{id}}" class="htmlpopup-container">' +
                   '<div class="htmlpopup-header">' +
-                    '<span>' + layer.label + ' &nbsp;</span>' +
+                    '<span>' + label + ' &nbsp;</span>' +
                     '{{name}}' +
                   '</div>' +
                   '<div class="htmlpopup-content">' +

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -44,7 +44,8 @@ goog.require('ga_topic_service');
             '<div ng-bind-html="html.snippet"></div>' +
             '<div ng-if="::html.showVectorInfos" class="ga-vector-tools">' +
               '<div ga-measure="::html.feature"></div>' +
-              '<div ga-profile-bt="::html.feature"></div>' +
+              '<div ng-if="::!html.mobile" ' +
+                   'ga-profile-bt="::html.feature"></div>' +
             '</div>' +
             '<div ga-shop ' +
                  'ga-shop-map="::html.map" ' +
@@ -695,7 +696,8 @@ goog.require('ga_topic_service');
                 feature: value,
                 showVectorInfos: (value instanceof ol.Feature),
                 clickGeometry: new ol.geom.Point(scope.clickCoordinate),
-                snippet: $sce.trustAsHtml(html)
+                snippet: $sce.trustAsHtml(html),
+                mobile: gaBrowserSniffer.mobile
               });
             };
           }

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -98,8 +98,8 @@ goog.require('ga_topic_service');
           var featureFound;
           map.forEachFeatureAtPixel(pixel, function(feature, layer) {
             // vectorLayer is defined when a feature is clicked.
-            // onclick
-            if (layer) {
+            // onclick, geolocation circle is unselectable
+            if (layer && !feature.getProperties().unselectable) {
               if (!vectorLayer || vectorLayer == layer) {
                 if (!featureFound) {
                   featureFound = feature;

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -172,6 +172,7 @@
 "geoloc_pos_unavailable": "Die Positionsbestimmung ist nicht möglich. Fehlermeldung Gerät (WiFi, GPS). Prüfen sie die Einstellungen",
 "geoloc_time_out": "Ein timeout ihres Gerätes bei der Bestimmung der Position wurde erreicht. Bitte versuchen Sie es später",
 "geoloc_unknown": "Aufgrund eine unbekannten Fehlers war die Positionsbestimmung nicht erflogreich. Prüfen sie die Einstellungen für Lokalisierung, Privatsphäre und Firewall ihres Gerätes.",
+"geolocation": "Geolocation",
 "geothermie": "Geothermie (BETA)",
 "geothermie_service_link_href": "http://www.geologieportal.ch/internet/geologieportal/de/home/topics/energy/geothermalenergy/shortdesc.html",
 "geothermie_service_link_label": "Weitere Informationen",

--- a/src/locales/empty.json
+++ b/src/locales/empty.json
@@ -432,5 +432,6 @@
   "profile_poi_down": "",
   "profile_distance": "",
   "profile_slope_distance": "",
-  "profile_hike_time": ""
+  "profile_hike_time": "",
+  "geolocation": ""
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -172,6 +172,7 @@
 "geoloc_pos_unavailable": "The acquisition of the geolocation failed because at least one internal source of your device of position (Wifi, GPS) returned an internal error.",
 "geoloc_time_out": "The time allowed to acquire the geolocation was reached before the information was obtained.Try later.",
 "geoloc_unknown": "Sorry, for an unknow reason the geolocation service doesn't work. Check your device location, privacy and firewalls settings",
+"geolocation": "Geolocation",
 "geothermie": "Geoth. energy BETA",
 "geothermie_service_link_href": "http://www.geologieportal.ch/internet/geologieportal/en/home/topics/energy/geothermalenergy/shortdesc.html",
 "geothermie_service_link_label": "More information",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -172,6 +172,7 @@
 "geoloc_pos_unavailable": "L'acquisition de la position a échoué parce qu'au moins une source interne de positionnement de votre mobile (WiFi, GPS) a retourné une erreur interne.",
 "geoloc_time_out": "La durée maximale d'acquisition de la position a été dépassé avant d'avoir reçu l'information. Réessayez plus tard.",
 "geoloc_unknown": "Désolé, pour une raison inconnue la service de géolocalisation ne fonctionne pas. Vérifiez les paramètres de ce  service, du mode privé et du firewall.",
+"geolocation": "Géolocalisation",
 "geothermie": "Géothermie (BETA)",
 "geothermie_service_link_href": "http://www.geologieportal.ch/internet/geologieportal/fr/home/topics/energy/geothermalenergy/shortdesc.html",
 "geothermie_service_link_label": "Lire la suite",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -172,6 +172,7 @@
 "geoloc_pos_unavailable": "L'acquisizione della posizione è fallita perchè almeno un sistema di posizionamento del vostro apparecchio (WiFi, GPS) ha dato un errore.",
 "geoloc_time_out": "Il tentativo di geolocalizzazione ha raggiunto il limite di tempo. Provate più tardi.",
 "geoloc_unknown": "Spiacente, per una ragione sconosciuta il servizio di geolocalizzazione non funziona. Controllate le impostazioni del dispositivo per la geolocalizzazione, la privacy ed il firewall.",
+"geolocation": "Geolocalizzazione",
 "geothermie": "Geotermia (BETA)",
 "geothermie_service_link_href": "http://www.geologieportal.ch/internet/geologieportal/it/home/topics/energy/geothermalenergy/shortdesc.html",
 "geothermie_service_link_label": "Ulteriori informazioni",

--- a/src/locales/rm.json
+++ b/src/locales/rm.json
@@ -172,6 +172,7 @@
 "geoloc_pos_unavailable": "La posiziun na po betg vegnir fixada. Messadi da sbagl da l'apparat (WiFi, GPS) Controllai la configuraziun.",
 "geoloc_time_out": "n timeout da Voss apparat tar la fixaziun da la posiziun è vegnì cuntanschì. Empruvai per plaschair pli tard.",
 "geoloc_unknown": "Pervia d'in sbagl nunenconuschent n'ha la posiziun betg pudì vegnir fixada cun success. Controllai la configuraziun per la localisaziun, la sfera privata ed il firewall da Voss apparat.",
+"geolocation": "Geolocation",
 "geothermie": "Geotermia (BETA)",
 "geothermie_service_link_href": "http://www.geologieportal.ch/internet/geologieportal/de/home/topics/energy/geothermalenergy/shortdesc.html",
 "geothermie_service_link_label": "Ulteriuras infurmaziuns",


### PR DESCRIPTION
Fix all the issues described in https://github.com/geoadmin/mf-geoadmin3/issues/3471

From now on:
- all markers must have a proper `label` if they are selectable
- if the marker is unselectable, one must add an `unselectable: true` when creating a new feature.

As discussed:
- profile link is disabled on mobile and from WMS info tooltip (as we don't have the geometry)
- markers have now a proper title (`search`, `crosshair`, `geolocation`)
- Geolocation circle is not selectable

[Test Link](https://mf-geoadmin3.int.bgdi.ch/gal_vector_markers/index.html)
 