### PR TITLE
IE9: Fix time selector

### DIFF
--- a/src/components/layermanager/LayermanagerDirective.js
+++ b/src/components/layermanager/LayermanagerDirective.js
@@ -84,7 +84,8 @@ goog.require('ga_urlutils_service');
         placement: 'auto right',
         title: $translate.instant('time_select_year') +
             '<button class="ga-icon ga-btn fa fa-remove"></button>',
-        trigger: 'focus'
+        trigger: 'focus',
+        delay: 150 // For IE9 let it time to capture the click event
       }).popover('show');
       element.on('scroll', callback);
       win.on('resize', callback);


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3472

On IE9 there is a timing issue  where the blur event is triggered before the click event in the tooltip.
Therefore we add a small timeout for IE to register and trigger the time change.

[Test Link](https://mf-geoadmin3.int.bgdi.ch/gal_ie9_time/index.html)