### PR TITLE
Set no cache for time enabled layers WMTS (use cloudfront instead...)

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -718,9 +718,10 @@ goog.require('ga_urlutils_service');
                 dimensions: {
                   'Time': timestamp
                 },
-                // Temporary until https://github.com/openlayers/ol3/pull/4964
-                // is merged upstream
-                cacheSize: 2048 * 3,
+                // Workaround: Set a cache size of zero when layer is
+                // timeEnabled see:
+                // https://github.com/geoadmin/mf-geoadmin3/issues/3491
+                cacheSize: layer.timeEnabled ? 0 : 2048,
                 projection: gaGlobalOptions.defaultEpsg,
                 requestEncoding: 'REST',
                 tileGrid: gaTileGrid.get(layer.resolutions,


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3491

There is no way to tell ol3 to clear the cache manually. (which is not a huge hack)
Also I did not find a way to disable the animation.

The other work around this bug would be to remove and re-add the layer. But I think this may be really bad.

We can also probably use the default cache size again as
https://github.com/openlayers/ol3/pull/4964
is now merged.

[Test Link](http://mf-geoadmin3.int.bgdi.ch/gal_nocahe_timeenabled/index.html)