### PR TITLE
Fix resolution definition

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -19,10 +19,16 @@ goog.require('ga_urlutils_service');
 
   module.provider('gaTileGrid', function() {
     var origin = [420000, 350000];
-    var defaultResolutions = [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250,
-        2000, 1750, 1500, 1250, 1000, 750, 650, 500, 250, 100, 50, 20, 10, 5,
-        2.5, 2, 1.5, 1, 0.5];
-    var wmsResolutions = defaultResolutions.concat([0.25, 0.1]);
+
+    function getDefaultResolutions() {
+        return [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250,
+                2000, 1750, 1500, 1250, 1000, 750, 650, 500, 250,
+                100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5];
+    }
+
+    function getWmsResolutions() {
+        return getDefaultResolutions().concat([0.25, 0.1]);
+    }
 
     function createTileGrid(resolutions, type) {
       if (type === 'wms') {
@@ -43,7 +49,8 @@ goog.require('ga_urlutils_service');
       return {
         get: function(resolutions, minResolution, type) {
           if (!resolutions) {
-            resolutions = (type == 'wms') ? wmsResolutions : defaultResolutions;
+            resolutions = (type == 'wms') ? getWmsResolutions() :
+                getDefaultResolutions();
           }
           if (minResolution) { // we remove useless resolutions
             for (var i = 0, ii = resolutions.length; i < ii; i++) {
@@ -380,7 +387,7 @@ goog.require('ga_urlutils_service');
     this.$get = function($http, $q, $rootScope, $translate, $window,
         gaBrowserSniffer, gaDefinePropertiesForLayer, gaMapUtils,
         gaNetworkStatus, gaStorage, gaTileGrid, gaUrlUtils,
-        gaStylesFromLiterals, gaGlobalOptions, gaPermalink, 
+        gaStylesFromLiterals, gaGlobalOptions, gaPermalink,
         gaLang, gaTime) {
 
       var Layers = function(dfltWmsSubdomains,

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -181,6 +181,11 @@ describe('ga_map_service', function() {
         expect(tg.getTileSize()).to.be(512);
         expect(tg.getOrigin()).to.eql(orig);
         expect(tg.getResolutions()).to.eql(res);
+
+        tg = gaTileGrid.get(undefined, undefined, 'wms');
+        expect(tg.getTileSize()).to.be(512);
+        expect(tg.getOrigin()).to.eql(orig);
+        expect(tg.getResolutions()).to.eql(wmsRes);
       });
     });
   });


### PR DESCRIPTION
FIx for https://github.com/geoadmin/mf-geoadmin3/issues/3514

Bug introduced in
https://github.com/geoadmin/mf-geoadmin3/commit/1820eb9e6febc578ec284e6bf8d2c1d4c70aaccc

I have a hard time believing we had this bug for so long. It's pretty incredible.
I think it explains a lot of bugs we never understood.

So basically we would change the resolution list forever whenever we had a layer with minResolution added. :x:  
