### PR TITLE
Fix #3484: Allow the display a tooltips of measure feature from a loc…

### DIFF
--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -278,7 +278,8 @@ goog.require('ga_urlutils_service');
 
               // If the layer can contain measure features, we register some
               // events to add/remove correctly the overlays
-              if (gaMapUtils.isStoredKmlLayer(olLayer)) {
+              if (gaMapUtils.isStoredKmlLayer(olLayer) ||
+                  gaMapUtils.isLocalKmlLayer(olLayer)) {
                 if (olLayer.getVisible()) {
                   angular.forEach(olLayer.getSource().getFeatures(),
                       function(feature) {

--- a/src/components/measure/MeasureService.js
+++ b/src/components/measure/MeasureService.js
@@ -246,7 +246,6 @@ goog.require('ga_measure_filter');
                 this.removeOverlays(features[i]);
                 features[i].set('overlays', undefined);
               }
-
             }
           }, this);
           layer.getSource().on('removefeature', function(evt) {

--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -742,7 +742,7 @@ describe('ga_kml_service', function() {
         var kml = '<kml><Document>' +
             createValidPlkPoint('measure_bbbb') +
           '</Document></kml>';
-        var isMeasFeat = gaMapUtilsMock.expects('isMeasureFeature').once().returns(true);
+        var isMeasFeat = gaMapUtilsMock.expects('isMeasureFeature').twice().returns(true);
         var getStyle = gaStyleFactoryMock.expects('getFeatureStyleFunction').once()
              .withArgs('measure').returns(new ol.style.Style());
 
@@ -803,7 +803,7 @@ describe('ga_kml_service', function() {
         $rootScope.$digest();
       });
 
-      it('adds Overlays for measure feature', function() {
+      it('adds Overlays for measure feature from a public.geo.admin.ch KML', function() {
         var addOverlays, registerOverlaysEvents, kml = '<kml><Document>' +
             createValidPlkLineString('measure_bbbb') +
           '</Document></kml>';
@@ -811,6 +811,20 @@ describe('ga_kml_service', function() {
         var regOverlays = gaMeasureMock.expects('registerOverlaysEvents').once();
         gaKml.addKmlToMap(map, kml, {
            url: 'http://public.geo.admin.ch/nciusdhfjsbnduvishfjknl'
+        });
+        $rootScope.$digest();
+        addOverlays.verify();
+        regOverlays.verify();
+      });
+
+      it('adds Overlays for measure feature from a local KML', function() {
+        var addOverlays, registerOverlaysEvents, kml = '<kml><Document>' +
+            createValidPlkLineString('measure_bbbb') +
+          '</Document></kml>';
+        var addOverlays = gaMeasureMock.expects('addOverlays').once();
+        var regOverlays = gaMeasureMock.expects('registerOverlaysEvents').once();
+        gaKml.addKmlToMap(map, kml, {
+           url: 'foo/kml.kml'
         });
         $rootScope.$digest();
         addOverlays.verify();


### PR DESCRIPTION
…al KML

Fix #3484 

[Test](//mf-geoadmin3.int.bgdi.ch/teo_fixes_2/index.html)

Creates a KML with a measure.
Export it.
Reload the page
Add the exported KML via DragnDrop

Before:
  You don't see the measure tooltips

Now:
  You see the measure tooltips.