### PR TITLE
Add map loading metricc in debug=true mode

### DIFF
--- a/src/components/MapLoadService.js
+++ b/src/components/MapLoadService.js
@@ -1,0 +1,130 @@
+goog.provide('ga_map_load_service');
+
+goog.require('ga_map_service');
+
+(function() {
+
+  var module = angular.module('ga_map_load_service', [
+    'ga_map_service'
+  ]);
+
+ /**
+   * This service can be used to inspect loading of the map.
+   * It times the loading of the map and emits messages about
+   * it
+   */
+  module.provider('gaMapLoad', function() {
+
+    this.$get = function($window, gaLayerFilters) {
+
+      var layersPending = 0;
+      var layersDone = 0;
+      var mapStartTime;
+
+      var updateMapLoading = function() {
+        if (layersPending == layersDone) {
+          var seconds = (new Date() - mapStartTime) / 1000;
+          mapStartTime = undefined;
+          $window.console.info('Map loaded in ' + seconds + 's');
+        }
+      };
+
+      var addLayerPending = function() {
+        if (mapStartTime == undefined) {
+          $window.console.info('Start loading map.');
+          mapStartTime = new Date();
+        }
+        layersPending++;
+        updateMapLoading();
+      };
+
+      var addLayerLoaded = function() {
+        layersDone++;
+        updateMapLoading();
+      };
+
+      var LayerProgress = function(layer) {
+        var src, startTime;
+        var loading = 0;
+        var loaded = 0;
+
+        var update = function() {
+          if (loading == loaded) {
+            var seconds = (new Date() - startTime) / 1000;
+            startTime = undefined;
+            $window.console.log('Layer ' + layer.id +
+                                ' finished loading in ' + seconds + 's.');
+            addLayerLoaded();
+          }
+        };
+
+        var addLoading = function() {
+          if (startTime == undefined) {
+            startTime = new Date();
+            addLayerPending();
+          }
+          loading++;
+          update();
+        };
+        var addLoaded = function() {
+          loaded++;
+          update();
+        };
+
+        if (layer instanceof ol.layer.Tile ||
+            layer instanceof ol.layer.Image) {
+          var start, error, end;
+          src = layer.getSource();
+          if (src instanceof ol.source.WMTS ||
+              src instanceof ol.source.TileWMS) {
+              start = 'tileloadstart';
+              error = 'tileloaderror';
+              end = 'tileloadend';
+          } else if (src instanceof ol.source.ImageWMS) {
+              start = 'imageloadstart';
+              error = 'imageloaderror';
+              end = 'imageloadend';
+          }
+          if (start) {
+            src.on(start, addLoading);
+            src.on([end, error], addLoaded);
+          }
+        }
+      };
+
+      var Mapload = function() {
+
+        var progs = {};
+
+        var createLayerProgress = function(layers) {
+          angular.forEach(layers, function(layer) {
+            if (layer.type == 'aggregate') {
+              createLayerProgress(layer.getLayers());
+            } else if (!progs[layer.id]) {
+              progs[layer.id] = new LayerProgress(layer);
+            }
+          });
+        };
+
+        this.init = function(scope) {
+          scope.maploadLayers = scope.map.getLayers().getArray();
+          scope.maploadFilter = function(l) {
+            return gaLayerFilters.selectedAndVisible(l) ||
+                   gaLayerFilters.background(l);
+          };
+
+          //React on adding/removing layers
+          scope.$watchCollection('maploadLayers | filter:maploadFilter',
+                                 function(layers) {
+            createLayerProgress(layers);
+          });
+
+        };
+      };
+
+      return new Mapload();
+
+    };
+  });
+})();
+

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -3,6 +3,7 @@ goog.provide('ga_main_controller');
 goog.require('ga_background_service');
 goog.require('ga_cesium');
 goog.require('ga_map');
+goog.require('ga_map_load_service');
 goog.require('ga_networkstatus_service');
 goog.require('ga_storage_service');
 goog.require('ga_topic_service');
@@ -12,6 +13,7 @@ goog.require('ga_topic_service');
   var module = angular.module('ga_main_controller', [
     'pascalprecht.translate',
     'ga_map',
+    'ga_map_load_service',
     'ga_networkstatus_service',
     'ga_storage_service',
     'ga_background_service',
@@ -26,7 +28,7 @@ goog.require('ga_topic_service');
       gaPermalinkFeaturesManager, gaPermalinkLayersManager, gaMapUtils,
       gaRealtimeLayersManager, gaNetworkStatus, gaPermalink, gaStorage,
       gaGlobalOptions, gaBackground, gaTime, gaLayers, gaTopic,
-      gaOpaqueLayersManager) {
+      gaOpaqueLayersManager, gaMapLoad) {
 
     var createMap = function() {
       var toolbar = $('#zoomButtons')[0];
@@ -92,6 +94,10 @@ goog.require('ga_topic_service');
     // The main controller creates the OpenLayers map object. The map object
     // is central, as most directives/components need a reference to it.
     $scope.map = createMap();
+    // Only active if debug=true is specified
+    if (gaPermalink.getParams().debug == 'true') {
+      gaMapLoad.init($scope);
+    }
 
     // Set up 3D
     var startWith3D = false;

--- a/test/specs/MapLoadService.spec.js
+++ b/test/specs/MapLoadService.spec.js
@@ -1,0 +1,61 @@
+describe.only('ga_mapload_service', function() {
+
+  describe('gaMapLoad', function() {
+    var map, $window, gaLayerFilters, $rootScope;
+
+    var getBg = function(bodId) {
+      var layer = new ol.layer.Tile({
+        source: new ol.source.WMTS({})
+      });
+      layer.id = bodId;
+      layer.bodId = bodId;
+      layer.displayInLayerManager = true;
+      layer.visible = true;
+      layer.background = true;
+      return layer;
+    };
+
+    beforeEach(function() {
+
+      module(function($provide) {
+        $provide.value('gaTopic', {
+          get: function() {}
+        });
+        $provide.value('gaLayers', {
+          get: function() {}
+        });
+
+      });
+
+      inject(function($injector) {
+        gaMapLoad = $injector.get('gaMapLoad');
+        $window = $injector.get('$window');
+        gaLayerFilters = $injector.get('gaLayerFilters');
+        $rootScope = $injector.get('$rootScope');
+      });
+
+      map = new ol.Map({});
+      $rootScope.map = map;
+
+    });
+
+
+    describe('#init()', function() {
+
+      it('displays a console messages when a background WMTS source is added', function() {
+        gaMapLoad.init($rootScope);
+        var spyInfo = sinon.spy($window.console, 'info');
+        var spyLog = sinon.spy($window.console, 'log');
+        var layer = getBg('id');
+        var source = layer.getSource();
+        map.addLayer(layer);
+        $rootScope.$digest();
+        source.dispatchEvent('tileloadstart');
+        source.dispatchEvent('tileloadend');
+
+        expect(spyInfo.callCount).to.be(2);
+        expect(spyLog.callCount).to.be(1);
+      });
+    });
+  });
+});

--- a/test/specs/MapLoadService.spec.js
+++ b/test/specs/MapLoadService.spec.js
@@ -1,11 +1,13 @@
-describe.only('ga_mapload_service', function() {
+describe('ga_mapload_service', function() {
 
   describe('gaMapLoad', function() {
     var map, $window, gaLayerFilters, $rootScope;
+    var spyInfo, spyLog;
 
-    var getBg = function(bodId) {
+    var getLayer = function(bodId, sourceClass) {
+      var source = new sourceClass({});
       var layer = new ol.layer.Tile({
-        source: new ol.source.WMTS({})
+        source: source
       });
       layer.id = bodId;
       layer.bodId = bodId;
@@ -34,9 +36,18 @@ describe.only('ga_mapload_service', function() {
         $rootScope = $injector.get('$rootScope');
       });
 
+      spyInfo = sinon.spy($window.console, 'info');
+      spyLog = sinon.spy($window.console, 'log');
+
+
       map = new ol.Map({});
       $rootScope.map = map;
 
+    });
+
+    afterEach(function() {
+      $window.console.info.restore();
+      $window.console.log.restore();
     });
 
 
@@ -44,18 +55,74 @@ describe.only('ga_mapload_service', function() {
 
       it('displays a console messages when a background WMTS source is added', function() {
         gaMapLoad.init($rootScope);
-        var spyInfo = sinon.spy($window.console, 'info');
-        var spyLog = sinon.spy($window.console, 'log');
-        var layer = getBg('id');
+        var layer = getLayer('first test', ol.source.WMTS);
         var source = layer.getSource();
         map.addLayer(layer);
         $rootScope.$digest();
         source.dispatchEvent('tileloadstart');
+        expect(spyInfo.callCount).to.be(1);
+        expect(spyLog.callCount).to.be(0);
         source.dispatchEvent('tileloadend');
-
         expect(spyInfo.callCount).to.be(2);
         expect(spyLog.callCount).to.be(1);
       });
+    });
+    
+    describe('all', function() {
+
+      it('waits for last loaded tile until all messages are displayed', function() {
+        gaMapLoad.init($rootScope);
+        var layer = getLayer('id', ol.source.TileWMS);
+        var source = layer.getSource();
+        map.addLayer(layer);
+        $rootScope.$digest();
+        source.dispatchEvent('tileloadstart');
+        source.dispatchEvent('tileloadstart');
+        source.dispatchEvent('tileloadstart');
+        expect(spyInfo.callCount).to.be(1);
+        expect(spyLog.callCount).to.be(0);
+        source.dispatchEvent('tileloadend');
+        expect(spyInfo.callCount).to.be(1);
+        expect(spyLog.callCount).to.be(0);
+        source.dispatchEvent('tileloadend');
+        source.dispatchEvent('tileloadend');
+        expect(spyInfo.callCount).to.be(2);
+        expect(spyLog.callCount).to.be(1);
+      });
+    });
+    
+    describe('2 layers', function() {
+
+      it('waits for all layers loaded', function() {
+        gaMapLoad.init($rootScope);
+        var l1 = getLayer('id1', ol.source.WMTS);
+        var l2 = getLayer('id2', ol.source.ImageWMS);
+        var s1 = l1.getSource();
+        var s2 = l2.getSource();
+        map.addLayer(l1);
+        map.addLayer(l2);
+        $rootScope.$digest();
+        s1.dispatchEvent('tileloadstart');
+        s1.dispatchEvent('tileloadstart');
+        s2.dispatchEvent('imageloadstart');
+        s2.dispatchEvent('imageloadstart');
+        s2.dispatchEvent('imageloadstart');
+        expect(spyInfo.callCount).to.be(1);
+        expect(spyLog.callCount).to.be(0);
+        s2.dispatchEvent('imageloadend');
+        s2.dispatchEvent('imageloadend');
+        s1.dispatchEvent('tileloadend');
+        expect(spyInfo.callCount).to.be(1);
+        expect(spyLog.callCount).to.be(0);
+        s2.dispatchEvent('imageloadend');
+        expect(spyInfo.callCount).to.be(1);
+        expect(spyLog.callCount).to.be(1);
+        s1.dispatchEvent('tileloadend');
+        expect(spyInfo.callCount).to.be(2);
+        expect(spyLog.callCount).to.be(2);
+      });
+
+
     });
   });
 });


### PR DESCRIPTION
This PR adds a new service that surveys the loading of the map. It emits messages in the console that shows timings for map loading events. This can be helpful for debugging purposes and analysing map loading in a little more detail.

Currently, this only works with the `debug=true` parameter in the permalink.

The basic functionality might be used in the future. In general, we might trigger a `maploadstart` and `maploadend` event that could be used for other components.

Go to the [Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_load/index.html?debug=true&layers=ch.swisstopo.swisstlm3d-wanderwege,ch.bazl.luftfahrthindernis,ch.astra.unfaelle-personenschaeden_alle) and open the console. Then browser around the map (pan/zoom).
