### PR TITLE
Allow spaces in URL path and query

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -11,8 +11,11 @@ goog.provide('ga_urlutils_service');
 
         // from Angular
         // https://github.com/angular/angular.js/blob/v1.4.8/src/ng/directive/input.js#L15
-        var URL_REGEXP =
-        /^(ftp|http|https):\/\/(?:\w+(?::\w+)?@)?[^\s/]+(?::\d+)?(?:\/[\w#!:.?+=&%@\-/[\]$'()*,;~]*)?$/;
+        var URL_REGEXP = new RegExp('^(ftp|http|https):\\/\\/' +
+                                    '(?:\\w+(?::\\w+)?@)?' +
+                                    '[^\\s/]+(?::\\d+)?' +
+                                    '(?:\\/[\\w#!:.?+=&%@\\- /' +
+                                    '[\\]$\'()*,;~]*)?$');
 
         // Test validity of a URL
         this.isValid = function(url) {

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -23,6 +23,9 @@ describe('ga_urlutils_service', function() {
         expect(gaUrlUtils.isValid('http://admin.ch')).to.be(true);
         expect(gaUrlUtils.isValid('https://admin.ch')).to.be(true);
         expect(gaUrlUtils.isValid('ftp://admin.ch')).to.be(true);
+        expect(gaUrlUtils.isValid('https://admin.ch/?mit space im query')).to.be(true);
+        expect(gaUrlUtils.isValid('https://admin.ch/space in URLtrue?query')).to.be(true);
+        expect(gaUrlUtils.isValid('https://domain admin.ch/space in URLfalse?query')).to.be(false);
       });
     });
 


### PR DESCRIPTION
This is a fix for https://github.com/geoadmin/mf-geoadmin3/issues/3512

Because I added a space, the line was too long so I had to use the RegExp constructor. It simply adds a space as a possibility in the query part of an URL.

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_fix3512/index.html?topic=emapis&layers=WMS%7C%7CHochbau%20(Query)%7C%7Chttps:%2F%2Fwms-bgdi.int.bgdi.ch%2F%3Fequery%3D(typ_code%3D47%20AND%20geschaeftsnummer%3D%270200002782%27)%7C%7Cch.blw.emapis-hochbau)

Ping @p1d1d1 