### PR TITLE
KML fixes

### DIFF
--- a/src/components/ExportKmlService.js
+++ b/src/components/ExportKmlService.js
@@ -4,6 +4,7 @@ goog.require('ga_browsersniffer_service');
 
   var module = angular.module('ga_exportkml_service', [
     'ga_browsersniffer_service',
+    'ga_kml_service',
     'pascalprecht.translate'
   ]);
 
@@ -13,7 +14,7 @@ goog.require('ga_browsersniffer_service');
    */
   module.provider('gaExportKml', function() {
     this.$get = function($translate, $window, $document, $http,
-        gaBrowserSniffer) {
+        gaBrowserSniffer, gaKml) {
 
       var downloadUrl = this.downloadKmlUrl;
 
@@ -90,7 +91,7 @@ goog.require('ga_browsersniffer_service');
               //force the add of a <Document> node
               exportFeatures.push(new ol.Feature());
             }
-            kmlString = new ol.format.KML().writeFeatures(exportFeatures);
+            kmlString = gaKml.getFormat().writeFeatures(exportFeatures);
             // Remove no image hack
             kmlString = kmlString.
                 replace(/<Icon>\s*<href>noimage<\/href>\s*<\/Icon>/g, '');

--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -36,6 +36,12 @@ goog.require('ga_urlutils_service');
       // Create the parser/writer KML
       var setKmlFormat = function() {
         if (!kmlFormat) {
+          // TO FIX
+          // Hack for #3531: Should be fix with next version of ol >3.18.2
+          // We create an empty format first to create the default style variables.
+          // https://github.com/openlayers/ol3/blob/master/src/ol/format/kml.js#L143
+          ol.format.KML();
+
           kmlFormat = new ol.format.KML({
             extractStyles: true,
             defaultStyle: [gaStyleFactory.getStyle('kml')]
@@ -68,13 +74,6 @@ goog.require('ga_urlutils_service');
         kml = kml.replace(
           /<href>https?:\/\/[a-z\d\.\-]*(bgdi|geo.admin)\.ch[a-zA-Z\d\-_\/]*img\/maki\/([a-z]*-24@2x\.png)/g,
           '<href>' + gaGlobalOptions.apiUrl + '/color/255,0,0/$2'
-        );
-
-        // Fix #3531: Should be fix with next version of ol >3.18.2
-        // We set a default href otherwise the KML parsing is broken.
-        kml = kml.replace(
-          /<IconStyle><scale>0<\/scale><\/IconStyle>/g,
-          '<IconStyle><Icon><href>https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href><\/Icon><scale>0</scale></IconStyle>'
         );
 
         // Create the parser

--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -33,6 +33,16 @@ goog.require('ga_urlutils_service');
       // Store the parser.
       var kmlFormat;
 
+      // Create the parser/writer KML
+      var setKmlFormat = function() {
+        if (!kmlFormat) {
+          kmlFormat = new ol.format.KML({
+            extractStyles: true,
+            defaultStyle: [gaStyleFactory.getStyle('kml')]
+          });
+        }
+      };
+
       // Read a kml string then return a list of features.
       var readFeatures = function(kml) {
         // Replace all hrefs to prevent errors if image doesn't have
@@ -67,14 +77,8 @@ goog.require('ga_urlutils_service');
           '<IconStyle><Icon><href>https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href><\/Icon><scale>0</scale></IconStyle>'
         );
 
-        // Load the parser only when needed.
-        // WARNING: it's needed to initialize it here for test.
-        if (!kmlFormat) {
-          kmlFormat = new ol.format.KML({
-            extractStyles: true,
-            defaultStyle: [gaStyleFactory.getStyle('kml')]
-          });
-        }
+        // Create the parser
+        setKmlFormat();
 
         // Manage networkLink tags
         var all = [];
@@ -364,6 +368,12 @@ goog.require('ga_urlutils_service');
             return false;
           }
           return true;
+        };
+
+        // Returns the unique KML format used by the application
+        this.getFormat = function() {
+          setKmlFormat();
+          return kmlFormat;
         };
       };
       return new Kml();

--- a/test/saucelabs/checker_test.py
+++ b/test/saucelabs/checker_test.py
@@ -1,70 +1,5 @@
 # -*- coding: utf-8 -*
 
-import time
-from helpers import bCheckIfUrlHasChanged
-
-# Search testing using saucelabs
-DEFAULT_WAIT = 6
-SHORTEN_LAYER = "ch.swisstopo.lubis-bildstreifen"
-SHORTEN_CODE = "20cc812c90"
-URL_API_DEV = "https://mf-chsdi3.dev.bgdi.ch/"
-URL_API_INT = "https://mf-chsdi3.int.bgdi.ch/"
-URL_API_CI = "https://mf-chsdi3.ci.bgdi.ch/"
-URL_API_PROD = "https://api3.geo.admin.ch/"
-URL_SHORTEN = 'shorten.json?url=https://mf-geoadmin3.int.bgdi.ch/' + \
-    '%3FX%3D164565.22%26Y%3D620538.74%26zoom%3D2%26lang%3Den%26topic%3Dlubis%26bgLayer%3D' + \
-    'ch.swisstopo.pixelkarte-grau%26catalogNodes%3D1179,1180,1184,1186%26layers%3D' + \
-    'ch.swisstopo.lubis-bildstreifen'
-
-
-def runCheckerTest(driver, url, is_top_browser):
-    print 'Checker tests starts!'
-
-    try:
-        assert "dev" in url
-        url_4_api = URL_API_DEV
-    except Exception as e:
-        try:
-            assert "int" in url
-            url_4_api = URL_API_INT
-        except Exception as e:
-            try:
-                assert "ci" in url
-                url_4_api = URL_API_CI
-            except Exception as e:
-                url_4_api = URL_API_PROD
-                print '-----------'
-                print str(e)
-                print "Current url: " + url
-
-    for ckFunc in checkerFunctions:
-        ckFunc(driver, url, url_4_api, is_top_browser)
-
-    print 'Checker tests completed'
-
-
-def wait_url_changed(driver, old_url, timeout=DEFAULT_WAIT):
-    UrlHasChanged = False
-    t0 = time.time()
-    while not UrlHasChanged:
-        new_url = driver.current_url
-        if old_url != new_url:
-            UrlHasChanged = True
-        t1 = time.time()
-        if t1 - t0 > timeout:
-            break
-        continue
-    if not UrlHasChanged:
-        raise Exception(
-            "Url not changed until end of timeout (" + str(timeout) + ")")
-    return bool(not UrlHasChanged)
-
-
-def ApiPage(driver, url, url_4_api, is_top_browser):
-    print "  Test API (search words Welcome)"
-    driver.get(url_4_api)
-    assert "Welcome" in driver.page_source
-
 
 def CheckerGeoAdmin(driver, url, url_4_api, is_top_browser):
     if is_top_browser == 1:
@@ -72,30 +7,5 @@ def CheckerGeoAdmin(driver, url, url_4_api, is_top_browser):
         driver.get(url + '/' + 'checker')
         assert "OK" in driver.page_source
 
-
-def ShortenUrl(driver, url, url_4_api, is_top_browser):
-    print "  Test Shorten URL"
-    driver.get(url_4_api + URL_SHORTEN)
-    assert "shorturl" in driver.page_source
-    assert SHORTEN_CODE in driver.page_source
-    # Test url shorten
-    if bCheckIfUrlHasChanged(driver):
-        driver.get(url_4_api + 'shorten/' + SHORTEN_CODE)
-        current_url = driver.current_url
-        try:
-            # print "search in url directly"
-            assert SHORTEN_LAYER in current_url
-        except Exception as e:
-            try:
-                wait_url_changed(driver, current_url)
-            except Exception as e:
-                print '-----------'
-                print str(e)
-                print "Current url: " + current_url
-                raise Exception(SHORTEN_LAYER + " not exist on url")
-
-
 checkerFunctions = [
-    ApiPage,
-    CheckerGeoAdmin,
-    ShortenUrl]
+    CheckerGeoAdmin]

--- a/test/saucelabs/test.py
+++ b/test/saucelabs/test.py
@@ -59,20 +59,18 @@ if __name__ == '__main__':
     desired_cap_list = [
         # Chrome
         {'platform': "Windows 7", 'browserName': "chrome",
-            'version': "48.0", 'screenResolution': "1280x1024"},
-        {'platform': "Windows 7", 'browserName': "chrome",
-            'version': "47.0", 'screenResolution': "1280x1024"},
+            'version': "53.0", 'screenResolution': "1280x1024"},
         {'platform': "Windows 8.1", 'browserName': "chrome",
-            'version': "48.0", 'screenResolution': "1280x1024"},
+            'version': "53.0", 'screenResolution': "1280x1024"},
         {'platform': "Windows 10", 'browserName': "chrome",
-            'version': "48.0", 'screenResolution': "1280x1024"},
+            'version': "53.0", 'screenResolution': "1280x1024"},
         # FireFox
         {'platform': "Windows 7", 'browserName': "firefox",
-            'version': "43.0", 'screenResolution': "1280x1024"},
+            'version': "49.0", 'screenResolution': "1280x1024"},
         {'platform': "Windows 8.1", 'browserName': "firefox",
-            'version': "44.0", 'screenResolution': "1280x1024"},
+            'version': "49.0", 'screenResolution': "1280x1024"},
         {'platform': "Windows 10", 'browserName': "firefox",
-            'version': "44.0", 'screenResolution': "1280x1024"},
+            'version': "49.0", 'screenResolution': "1280x1024"},
         # Internet Exeplorer
         {'platform': "Windows 7", 'browserName': "internet explorer",
             'version': "9.0", 'screenResolution': "1280x1024"},

--- a/test/saucelabs/test.py
+++ b/test/saucelabs/test.py
@@ -11,7 +11,6 @@ from search_test import runSearchTest
 from print_test import runPrintTest
 from mobile_test import runMobileTest
 from wms_test import runWmsTest
-from checker_test import runCheckerTest
 from tooltip_test import runTooltipTest
 
 DEFAULT_WAIT_FOUND = 5
@@ -93,12 +92,12 @@ if __name__ == '__main__':
     ]
 
     config_test_list = {
-        "firefox": ['start', 'mobile', 'search', 'checker', 'wms', 'tooltip'],
-        "chrome": ['start', 'mobile', 'search', 'checker', 'wms', 'tooltip'],
+        "firefox": ['start', 'mobile', 'search', 'wms', 'tooltip'],
+        "chrome": ['start', 'mobile', 'search', 'wms', 'tooltip'],
         "internet explorer": ['start'],
         "opera": ['start'],
         "safari": ['start'],
-        "MicrosoftEdge": ['start', 'search', 'checker']
+        "MicrosoftEdge": ['start', 'search']
     }
 
     # okay we will start the script!
@@ -114,7 +113,6 @@ if __name__ == '__main__':
         'search': runSearchTest,
         'kml': runKmlTest,
         'print': runPrintTest,
-        'checker': runCheckerTest,
         'tooltip': runTooltipTest
     }
 

--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -179,6 +179,30 @@ describe('ga_kml_service', function() {
       });
     });
 
+    describe('#getFormat()', function() {
+
+      it('returns an ol.format.KML object', function() {
+        var getStyle = gaStyleFactoryMock.expects('getStyle').once()
+            .withArgs('kml').returns(dfltStyle);
+        var spy = sinon.spy(ol.format, 'KML');
+        var f = gaKml.getFormat();
+        expect(f).to.be.a(ol.format.KML);
+        getStyle.verify();
+        expect(spy.calledOnce).to.be(true);
+        expect(spy.args[0][0].extractStyles).to.be(true);
+        expect(spy.args[0][0].defaultStyle[0]).to.be(dfltStyle);
+      });
+
+      it('returns the same object on 2nd call', function() {
+        var getStyle = gaStyleFactoryMock.expects('getStyle').once()
+            .withArgs('kml').returns(dfltStyle);
+        var f = gaKml.getFormat();
+        var f2 = gaKml.getFormat();
+        expect(f).to.be(f2);
+        getStyle.verify();
+      });
+    });
+
     describe('#addKmlToMap()', function() {
 
       it('doesn\'t add layer if kml string is not defined', function(done) {

--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -892,19 +892,35 @@ describe('ga_kml_service', function() {
         fit.verify();
       });
 
-      //it(' zoom to data extent if intersects with default extent', function() {
-      //  // We set an dflt extent in 3857
-      //  gaGlobalOptions.defaultExtent = [-20000000, -20000000, 20000000, 20000000];
-      //  var kml = '<kml><Document>' +
-      //      createValidPlkLineString() +
-      //    '</Document></kml>';
-      //  var fit = sinon.mock(map.getView()).expects('fit').once().withArgs([1013007.36621878961, 5844682.851056053, 1235646.3478053366, 5909489.863677091]);
-      //  gaKml.addKmlToMap(map, kml, {
-      //    zoomToExtent: true
-      //  });
-      //  $rootScope.$digest();
-      //  fit.verify();
-      //});
+      it('zooms to data extent if intersects with default extent (ol.source.Vector)', function() {
+        // We set an dflt extent in 3857
+        gaGlobalOptions.defaultExtent = [-20000000, -20000000, 20000000, 20000000];
+        var kml = '<kml><Document>' +
+            createValidPlkLineString() +
+          '</Document></kml>';
+        var fit = sinon.mock(map.getView()).expects('fit').once().withArgs([1013007.36621878961, 5844682.851056053, 1235646.3478053366, 5909489.863677091]);
+        gaKml.addKmlToMap(map, kml, {
+          zoomToExtent: true
+        });
+        $rootScope.$digest();
+        fit.verify();
+      });
+
+      it('zooms to data extent if intersects with default extent (ol.source.ImageVector)', function() {
+        // We set an dflt extent in 3857
+        gaGlobalOptions.defaultExtent = [-20000000, -20000000, 20000000, 20000000];
+        var kml = '<kml><Document>' +
+            createValidPlkLineString() +
+          '</Document></kml>';
+        sinon.stub(gaKml, 'useImageVector').returns(true);
+        var fit = sinon.mock(map.getView()).expects('fit').once().withArgs([1013007.36621878961, 5844682.851056053, 1235646.3478053366, 5909489.863677091]);
+        gaKml.addKmlToMap(map, kml, {
+          zoomToExtent: true,
+          useImageVector: true
+        });
+        $rootScope.$digest();
+        fit.verify();
+      });
     });
 
     describe('#addKmlToMapForUrl()', function() {

--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -188,9 +188,9 @@ describe('ga_kml_service', function() {
         var f = gaKml.getFormat();
         expect(f).to.be.a(ol.format.KML);
         getStyle.verify();
-        expect(spy.calledOnce).to.be(true);
-        expect(spy.args[0][0].extractStyles).to.be(true);
-        expect(spy.args[0][0].defaultStyle[0]).to.be(dfltStyle);
+        expect(spy.calledTwice).to.be(true);
+        expect(spy.args[1][0].extractStyles).to.be(true);
+        expect(spy.args[1][0].defaultStyle[0]).to.be(dfltStyle);
       });
 
       it('returns the same object on 2nd call', function() {


### PR DESCRIPTION
Improve the KML hacks using the old behavior (using default style values).

Fix #3544 .

[Test](https://mf-geoadmin3.int.bgdi.ch/teo_fixes/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&X=190370.14&Y=604667.85&zoom=7)