### PR TITLE
Allow multiple apostrophes in search coordinate

### DIFF
--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -87,14 +87,14 @@ goog.provide('ga_search_service');
 
         var match = query.match(regexpCoordinate);
         if (match && !valid) {
-          var left = parseFloat(match[1].replace('\'', ''));
-          var right = parseFloat(match[2].replace('\'', ''));
+          var left = parseFloat(match[1].replace(/\'/g, ''));
+          var right = parseFloat(match[2].replace(/\'/g, ''));
           //Old school entries like '600 000 200 000'
           if (match[3] != null) {
-            left = parseFloat(match[1].replace('\'', '') +
-                              match[2].replace('\'', ''));
-            right = parseFloat(match[4].replace('\'', '') +
-                               match[5].replace('\'', ''));
+            left = parseFloat(match[1].replace(/\'/g, '') +
+                              match[2].replace(/\'/g, ''));
+            right = parseFloat(match[4].replace(/\'/g, '') +
+                               match[5].replace(/\'/g, ''));
           }
 
           position =


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3553

The problem was that 1 apostrophe per coordinate was supported, but not multiple. Now it is.

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_lv95search/index.html)

[Direct Testlink with Swissearch](https://mf-geoadmin3.int.bgdi.ch/gjn_lv95search/index.html?swisssearch=2'500'157.08, 1'121'682.60)