### PR TITLE
Fixes

### DIFF
--- a/src/components/draw/DrawDirective.js
+++ b/src/components/draw/DrawDirective.js
@@ -675,7 +675,11 @@ goog.require('ga_styles_service');
             $rootScope.$broadcast('gaProfileActive');
             $rootScope.$broadcast('gaDrawStyleActive');
             scope.$applyAsync();
-          } else if (gaMapUtils.isMeasureFeature(scope.feature)) {
+            return;
+          }
+          var geometry = scope.feature.getGeometry();
+          if (geometry instanceof ol.geom.LineString ||
+              geometry instanceof ol.geom.Polygon) {
             if (!clickCoord) {
               // Hide or show the Profile popup
               $rootScope.$broadcast('gaProfileActive', scope.feature, layer,
@@ -685,8 +689,8 @@ goog.require('ga_styles_service');
           } else {
             // Move the popup on the closest coordinate of the click event
             var coord = clickCoord ?
-                feature.getGeometry().getClosestPoint(clickCoord) :
-                feature.getGeometry().getLastCoordinate();
+                geometry.getClosestPoint(clickCoord) :
+                geometry.getLastCoordinate();
             var pixel = map.getPixelFromCoordinate(coord);
 
             $rootScope.$broadcast('gaDrawStyleActive', scope.feature, layer,

--- a/src/components/popup/PopupDirective.js
+++ b/src/components/popup/PopupDirective.js
@@ -11,12 +11,22 @@ goog.require('ga_print_service');
   ]);
 
   module.directive('gaPopup',
-    function($rootScope, $translate, $window, gaBrowserSniffer,
-        gaPrint) {
-      var zIndex = 2000;
+    function($rootScope, $translate, $window, gaBrowserSniffer, gaPrint) {
+      var zIndex;
+      var screenLimit = 0;
+      var screenTabletLimit = 768;
+      var screenMobileLimit = 480;
+
       var bringUpFront = function(el) {
-        zIndex += 1;
-        el.css('z-index', zIndex);
+        // We get the initial z-index css.
+        var currZIndex = parseInt(el.css('z-index'));
+        if (!zIndex) {
+          zIndex = 2500; // same as in popup.less
+          zIndex++;
+        }
+        if (!currZIndex || zIndex > currZIndex) {
+          el.css('z-index', ++zIndex);
+        }
         $rootScope.$emit('gaPopupFocused', el);
       };
       var updatePosition = function(scope, element, pixel) {
@@ -45,6 +55,15 @@ goog.require('ga_print_service');
           // Init css
           element.addClass('popover');
 
+          // Init some utilities variables.
+          var className = element[0].className;
+          if (/ga-popup-tablet/.test(className)) {
+            screenLimit = screenTabletLimit;
+          }
+          if (/ga-popup-mobile/.test(className)) {
+            screenLimit = screenMobileLimit;
+          }
+
           // Initialize the popup properties
           scope.toggle = scope.toggle || false;
           scope.options = scope.optionsFunc() || {title: ''};
@@ -67,8 +86,7 @@ goog.require('ga_print_service');
           }
           // Bring the popup to front on click on it.
           element.find('.popover-content').click(function(evt) {
-            if (!scope.options.isReduced && scope.toggle &&
-                element.css('z-index') != zIndex) {
+            if (!scope.options.isReduced && scope.toggle) {
               bringUpFront(element);
             }
           });
@@ -192,9 +210,8 @@ goog.require('ga_print_service');
             if (scope.options.isReduced) {
               return;
             }
-            var screenSmLimit = 768;
             var winWidth = win.width();
-            if (winWidth > screenSmLimit) {
+            if (winWidth > screenLimit) {
               var winHeight = win.height();
               var popupWidth = element.outerWidth();
               var popupHeight = element.outerHeight();

--- a/src/components/popup/style/popup.less
+++ b/src/components/popup/style/popup.less
@@ -2,6 +2,7 @@
 @ga-popup-reduced-height: 40px;
 @ga-popup-max-width: 620px;
 
+/* sticked to bottom */
 .ga-bottom-fixed() {
   max-width: none!important;
   width: auto!important;
@@ -16,6 +17,22 @@
     display: none;
   }
 }
+
+/* full screen */
+.ga-full() {
+  top: 2% !important;
+  left: 2% !important;
+  right: 2%;
+  bottom: 2%;
+  width: auto!important;
+  max-height: none;
+  max-width: none;
+  -webkit-overflow-scrolling: touch;
+
+  .popover-content {
+    max-height: none;
+  }
+}
  
 [ga-popup] {
   display: none;
@@ -24,7 +41,7 @@
   max-width: @ga-popup-max-width;
   min-height: 100px;
   max-height: @ga-popup-max-height;
-  z-index: 2000;
+  z-index: 2500; /* on top of the menu but under modals */
 
   .ga-popup-no-info {
     padding: 20px 14px;
@@ -108,6 +125,48 @@
     }
   }
 
+  /* POPUP display at the bottom */
+  &.ga-popup-bottom {
+    .ga-bottom-fixed();
+    bottom: 26px;
+  }
+
+  /* POPUP MOBILE display at the bottom */
+  &.ga-popup-bottom, &.ga-popup-mobile-bottom {
+    @media (max-width: @screen-phone) {
+      .ga-bottom-fixed();
+ 
+      > .popover-content {
+        max-height: 250px;
+      }
+    }
+  }
+
+  /* POPUP MOBILE & TABLET display in full screen (ex: metadata popup) */
+  &.ga-popup-tablet-full {
+
+    /* !important is used to override (and so deactivate) draggable styles
+    applied */
+    @media (max-width: @screen-tablet) {
+      .ga-full();
+    }
+
+    @media (max-width: @screen-phone) {
+      position: absolute;
+      overflow: hidden;
+    }
+  }
+
+  /* POPUP MOBILE display in full screen (ex: feedback popup) */
+  &.ga-popup-mobile-full {
+
+    @media (max-width: @screen-phone) {
+      position: absolute;
+      overflow: hidden;
+      .ga-full();
+    }
+  }
+
   /* REDUCED POPUP */
   /* !important is used to override (and so deactivate) draggable styles
   and specific popups styles */
@@ -154,54 +213,28 @@
       display: none;
     }
 
-    @medi (max-width: @screen-tablet) {
+    .fa-remove {
+      opacity: 0.8;
+    }
+
+    @media (max-width: @screen-tablet) {
       width: 160px!important;
       min-width: 160px!important;
       bottom: unit(@ga-popup-reduced-height + 14, px);
-    }
-  }
- 
-  /* POPUP display at the bottomi */
-  &.ga-popup-bottom {
-    .ga-bottom-fixed();
-    bottom: 26px;
-  }
-  
-  /* POPUP MOBILE display at the bottom */
-  &.ga-popup-bottom, &.ga-popup-mobile-bottom {
-    @media (max-width: @screen-phone) {
-      .ga-bottom-fixed();
-        
-      > .popover-content {
-        max-height: 250px;
-      }
-    }
-  }
- 
-  /* POPUP MOBILE & TABLET display in full screen (ex: metadata popup) */
-  &.ga-popup-tablet-full {
-    
-    /* !important is used to override (and so deactivate) draggable styles
-    applied */
-    @media (max-width: @screen-tablet) {
-      z-index: 1500;
-      top: 2% !important;
-      left: 2% !important;
-      right: 2%;
-      bottom: 2%;
-      width: auto!important;
-      max-height: none;
-      max-width: none;
-      -webkit-overflow-scrolling: touch;
       
-      .popover-content {
-        max-height: none;
-      }
+      /* Override ga-popup-tablet-full css */
+      top: initial!important;
+      left: initial!important;
+      top: auto!important; // for IE
+      left: auto!important; // for IE
     }
 
     @media (max-width: @screen-phone) {
-      position: absolute;
-      overflow: hidden;
+      /* Override ga-popup-mobile-full css */
+      top: initial!important;
+      left: initial!important;
+      top: auto!important; // for IE
+      left: auto!important; // for IE
     }
   }
 }

--- a/src/components/share/style/share-draw.less
+++ b/src/components/share/style/share-draw.less
@@ -1,0 +1,7 @@
+[ga-share-draw] {
+
+  .input-group {
+    width: 100%;
+  }
+}
+

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -699,8 +699,7 @@ goog.require('ga_topic_service');
                 showVectorInfos: (value instanceof ol.Feature),
                 clickGeometry: new ol.geom.Point(scope.clickCoordinate),
                 snippet: $sce.trustAsHtml(html),
-                showProfile: !gaBrowserSniffer.mobile &&
-                    value instanceof ol.Feature && value.getGeometry()
+                showProfile: value instanceof ol.Feature && value.getGeometry()
               });
             };
           }

--- a/src/components/tooltip/style/tooltip.less
+++ b/src/components/tooltip/style/tooltip.less
@@ -46,5 +46,9 @@
   @media (max-width: @screen-phone) {
     top: 50% !important;
     max-height: none;
+
+    &[style] {
+      z-index: 1800!important; /* under the menu*/
+    }
   }
 }

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -823,7 +823,7 @@ a .ga-icon-separator {
       position: absolute;
       width: 100%;
       height: 100%;
-      z-index: 2499;
+      z-index: 1999;
       top: 0;
       background: #000;
       opacity: 0;
@@ -936,7 +936,7 @@ a .ga-icon-separator {
   }
 
   @media (max-width: @screen-phone) {
-    z-index: 2500; /* top of popups but under modal */
+    z-index: 2000; /* under popups and  modal */
     top: 0;
     right: 0;
     width: 0;
@@ -1297,8 +1297,8 @@ a.panel-heading {
 }
 
 // ***** POPOVER and MODAL (ga-popup and bs popover)
-.popover {
-  z-index: 3000;
+.popover:not([ga-popup]) {
+  z-index: 3000; /* on top of menu but under modals */
 }
 
 .popover-content, .popover-content .btn, .popover-content .form-control {

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -9,6 +9,7 @@
 @import "../components/scaleline/style/scaleline.less";
 @import "../components/attribution/style/attribution.less";
 @import "../components/share/style/share.less";
+@import "../components/share/style/share-draw.less";
 @import "../components/share/style/share-embed.less";
 @import "../components/contextpopup/style/contextpopup.less";
 @import "../components/feedback/style/feedback.less";

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -1241,6 +1241,10 @@ a .ga-icon-separator {
   margin: 18px 0 0 -160px;
   overflow: visible !important;
 
+  &[style] {
+    z-index: 500 !important; /* under menu */
+  }
+
   @media (max-width: @screen-phone) {
     margin: 0;
   }


### PR DESCRIPTION
[Test](https://mf-geoadmin3.int.bgdi.ch/teo_fixes/index.html)

Fix #3539, test popups:

On desktop : All popups are under modals and the popup is put on front when it has the focus.

On mobile: All popups are on top of the menu except the tooltip popup which is under.




Fix #3482, test draw:

Draw a Line or a polygon then the profile is displayed automatically at the end of the draw.


Fix #3471, test draw:

Open this [link](https://mf-geoadmin3.int.bgdi.ch/teo_fixes/mobile.html?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttps:%2F%2Fpublic.geo.admin.ch%2FZve1GElEQImi17-pls3W5w&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&mobile=true&X=200760.00&Y=704525.74&zoom=5), click on the line and you should see the 'Show profile' link in the tooltip.