### PR TITLE
[WIP] [3dtiles] Activate 3d shadows

### DIFF
--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -316,6 +316,7 @@ goog.require('ga_urlutils_service');
               gaTime.get());
           var requestedLayer = config3d.serverLayerName || bodId;
           var provider = new Cesium.CesiumTerrainProvider({
+            requestVertexNormals: true,
             url: getTerrainUrl(requestedLayer, timestamp),
             availableLevels: gaGlobalOptions.terrainAvailableLevels,
             rectangle: gaMapUtils.extentToRectangle(

--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -134,6 +134,23 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions,
     scene.screenSpaceCameraController.inertiaZoom = 0.9;
     scene.screenSpaceCameraController.minimumZoomDistance = 2;
 
+    var lightCamera = new Cesium.Camera(scene);
+    lightCamera.setView({
+      orientation: {
+        pitch: Cesium.Math.toRadians(-110)
+      }
+    });
+
+    // shadows
+    scene.shadowMap = new Cesium.ShadowMap({
+      enabled: boolParam('shadows', true),
+      context: scene.context,
+      lightCamera: lightCamera,
+      darkness: floatParam('shadowDarkness', '0.75'),
+      softShadows: boolParam('softShadows', true),
+      maximumDistance: 1000
+    });
+
     enableOl3d(cesiumViewer, enabled);
 
     // Add default 3d layer which ar enot linked to a 2d layer


### PR DESCRIPTION
Activate the cesium shadows, demo:
https://mf-geoadmin3.int.bgdi.ch/3dtiles_shadows/index.html

The "darkness" can be changed with the `shadowDarkness` parameter (between 0 and 1, default is 0.75):
https://mf-geoadmin3.int.bgdi.ch/3dtiles_shadows/index.html?shadowDarkness=0.5

The soft shadow config can be changed with the `softShadows` parameter (true / or false, default is true):
https://mf-geoadmin3.int.bgdi.ch/3dtiles_shadows/index.html?softShadows=false

The position of the sun is the current position of the sun but it could be changed.

There's no shadows with the terrain; are the normals returned? do we want it?


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/3dtiles_shadows/1903050750/index.html)</jenkins>