### PR TITLE
Remove unsupported platform

### DIFF
--- a/test/saucelabs/test.py
+++ b/test/saucelabs/test.py
@@ -66,8 +66,6 @@ if __name__ == '__main__':
             'version': "47.0", 'screenResolution': "1280x1024"},
         # Internet Exeplorer
         {'platform': "Windows 7", 'browserName': "internet explorer",
-            'version': "9.0", 'screenResolution': "1280x1024"},
-        {'platform': "Windows 7", 'browserName': "internet explorer",
             'version': "10.0", 'screenResolution': "1280x1024"},
         {'platform': "Windows 7", 'browserName': "internet explorer",
             'version': "11.0", 'screenResolution': "1280x1024"},


### PR DESCRIPTION
It seems that the combination of IE9 and Windows 7 are not supported by sauclabs anymore.

```Warning: you have no plugins providing access control for builds, so falling back to legacy behavior of permitting any downstream builds to be triggered.```

See also:
https://jenkins.prod.bgdi.ch/job/geoadmin3/727/console

It works now as expected without this platform.