### PR TITLE
Add layers_params PL parameter

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -111,8 +111,12 @@ goog.provide('ga_urlutils_service');
               kv = keyValue.split('=');
               key = this_.tryDecodeURIComponent(kv[0]);
               if (angular.isDefined(key)) {
-                obj[key] = angular.isDefined(kv[1]) ?
-                    this_.tryDecodeURIComponent(kv[1]) : true;
+                if (kv.length > 1) {
+                  obj[key] = this_.tryDecodeURIComponent(
+                      kv.splice(1, kv.length - 1).join('='));
+                } else {
+                  obj[key] = true;
+                }
               }
             }
           });

--- a/src/components/map/PermalinkLayersService.js
+++ b/src/components/map/PermalinkLayersService.js
@@ -44,6 +44,7 @@ goog.require('ga_wms_service');
 
       var layersParamValue = gaPermalink.getParams().layers;
       var layersOpacityParamValue = gaPermalink.getParams().layers_opacity;
+      var layersParamsValue = gaPermalink.getParams().layers_params;
       var layersVisibilityParamValue =
           gaPermalink.getParams().layers_visibility;
       var layersTimestampParamValue =
@@ -53,6 +54,8 @@ goog.require('ga_wms_service');
       var layerSpecs = layersParamValue ? layersParamValue.split(',') : [];
       var layerOpacities = layersOpacityParamValue ?
           layersOpacityParamValue.split(',') : [];
+      var layerParams = layersParamsValue ?
+          layersParamsValue.split(',') : [];
       var layerVisibilities = layersVisibilityParamValue ?
           layersVisibilityParamValue.split(',') : [];
       var layerTimestamps = layersTimestampParamValue ?
@@ -183,7 +186,9 @@ goog.require('ga_wms_service');
                       p.layers_visibility ?
                           p.layers_visibility.split(',') : false,
                       p.layers_timestamp ?
-                          p.layers_timestamp.split(',') : undefined
+                          p.layers_timestamp.split(',') : undefined,
+                      p.layers_params ?
+                          p.layers_params.split(',') : undefined
             );
           } else {
             addLayers(topic.selectedLayers.slice(0).reverse());
@@ -195,7 +200,7 @@ goog.require('ga_wms_service');
         };
 
         var addLayers = function(layerSpecs, opacities, visibilities,
-            timestamps) {
+            timestamps, parameters) {
           var nbLayersToAdd = layerSpecs.length;
           angular.forEach(layerSpecs, function(layerSpec, index) {
             var layer;
@@ -207,6 +212,8 @@ goog.require('ga_wms_service');
                 false : true;
             var timestamp = (timestamps && index < timestamps.length &&
                 timestamps != '') ? timestamps[index] : '';
+            var params = (parameters && index < parameters.length) ?
+                gaUrlUtils.parseKeyValue(parameters[index]) : undefined;
             var bodLayer = gaLayers.getLayer(layerSpec);
             if (bodLayer) {
               // BOD layer.
@@ -241,6 +248,9 @@ goog.require('ga_wms_service');
                         gaTime.get());
                   }
                   layer.time = timestamp;
+                }
+                if (params && layer.getSource().updateParams) {
+                  layer.getSource().updateParams(params);
                 }
                 map.addLayer(layer);
               }
@@ -341,7 +351,7 @@ goog.require('ga_wms_service');
           } else {
             // We add layers from 'layers' parameter
             addLayers(layerSpecs, layerOpacities, layerVisibilities,
-                layerTimestamps);
+                layerTimestamps, layerParams);
           }
 
           gaTime.allowStatusUpdate = true;


### PR DESCRIPTION
For emapis functionality - but could be used for other use cases as well.

This PR adds a new permalink parameters. We already have [layers_opacity, layers_visibility and layers_timestamp](http://help.geo.admin.ch/?id=54&lang=de) to configure layers specifically. The new `layers_params` parameter allows to add request parameters to any image layer requests.

In the emapis case, it allows to specifcy an equery parameter with `layer_params=equery...`.

It's open if we want to document this. I'm also open to other name suggestions. @loicgasser I don't think ESRI conventions makes sense here, as we already have other params with same pattern.

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_layerparams/index.html?topic=emapis&layers=ch.blw.emapis-hochbau&lang=de&bgLayer=voidLayer&X=166308.27&Y=610841.50&zoom=0&catalogNodes=1916&layers_params=equery%3D(typ_code%3D41))

@davidoesch @oterral Thoughts?

