### PR TITLE
Adding tooltip for layernames in layermanager

### DIFF
--- a/src/components/layermanager/partials/layermanager.html
+++ b/src/components/layermanager/partials/layermanager.html
@@ -7,7 +7,7 @@
     <div class="ga-layer-infos ga-grab">
       <button class="ga-icon ga-btn fa fa-remove-sign"
               ng-click="removeLayer(layer)"></button>
-      <label class="ga-checkbox">
+      <label class="ga-checkbox" title="{{layer.label}}">
         <input type="checkbox" ng-model="layer.visible" />
         <span></span>
         {{layer.label}}


### PR DESCRIPTION
Title says it all.

Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3568

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_tooltipl/index.html?topic=swisstopo&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.geologie-spezialkarten_schweiz_papier.metadata&catalogNodes=1538)

Ping @cedricmoullet @davidoesch @mariokeusen 