### PR TITLE
Update geojson source file on lang change

### DIFF
--- a/src/components/map/RealtimeLayersService.js
+++ b/src/components/map/RealtimeLayersService.js
@@ -10,15 +10,15 @@ goog.require('ga_map_service');
 
   module.provider('gaRealtimeLayersManager', function() {
     this.$get = function($rootScope, $http, $timeout, gaLayerFilters,
-        gaMapUtils, gaUrlUtils) {
+        gaMapUtils, gaUrlUtils, gaLayers) {
 
       var timers = [];
       var realTimeLayersId = [];
       var geojsonFormat = new ol.format.GeoJSON();
 
       function setLayerSource(layer) {
-        var fullUrl = gaUrlUtils.proxifyUrl(layer.geojsonUrl);
         var olSource = layer.getSource();
+        var fullUrl = gaUrlUtils.proxifyUrl(layer.geojsonUrl);
         $http.get(fullUrl).then(function(response) {
           var data = response.data;
           olSource.clear();
@@ -78,10 +78,13 @@ goog.require('ga_map_service');
         });
 
         // Update geojson source on language change
-        $rootScope.$on('$translateChangeEnd', function(evt) {
+        // This event is triggered after the layersConfig is loaded
+        $rootScope.$on('gaLayersTranslationChange', function(evt) {
 
           realTimeLayersId.forEach(function(bodId, i) {
             var olLayer = gaMapUtils.getMapLayerForBodId(map, bodId);
+            olLayer.geojsonUrl =
+                gaLayers.getLayerProperty(olLayer.bodId, 'geojsonUrl');
             $timeout.cancel(timers[i]);
             setLayerSource(olLayer);
           });

--- a/test/specs/map/RealtimeLayersService.spec.js
+++ b/test/specs/map/RealtimeLayersService.spec.js
@@ -74,7 +74,10 @@ describe('ga_realtimelayers_service', function() {
 
       module(function($provide) {
         $provide.value('gaLayers', {
-          loadConfig: function() {}
+          loadConfig: function() {},
+          getLayerProperty: function(bodId, b) {
+            return 'https://data.geo.admin.ch/' + bodId + '/' + bodId + '_' + gaLang.get() + '.json';
+          }
         });
         var lang = 'custom';
         $provide.value('gaLang', {
@@ -83,7 +86,7 @@ describe('ga_realtimelayers_service', function() {
           },
           set: function(l) {
             lang = l;
-            $rootScope.$broadcast('$translateChangeEnd', lang);
+            $rootScope.$broadcast('gaLayersTranslationChange');
           }
         });
 
@@ -195,10 +198,11 @@ describe('ga_realtimelayers_service', function() {
       var layer = map.getLayers().item(0);
       expect(layer.getSource().getFeatures().length).to.be(1);
 
-      // Here we don't test the change of the url because it's done in another
-      // service, we only test if the data are requetsed on language change.
+      var newLang = 'custom2';
+      dataUrl = dataUrl.replace('_custom', '_' + newLang);
       $httpBackend.expectGET(dataUrl).respond(jsonData1);
       gaLang.set('custom2');
+      expect(layer.geojsonUrl).to.equal(dataUrl);
       $httpBackend.flush();
       $rootScope.$digest();
     });


### PR DESCRIPTION
When changing languages one should download the new geojson URL from the layersConfig file.
This was not the case for mainly 2 reasons.

1. We didn't access the new geojsonUrl in the layersConfig
2. We used to listen to `$translateChangeEnd` which happens before the new layersConfig file was loaded

[Test Link](https://mf-geoadmin3.int.bgdi.ch/gal_geosjon_lang/index.html?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.bafu.hydroweb-messstationen_gefahren)