### PR TITLE
[WIP] Using topic groups and horizontal scrolling bar

### DIFF
--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -108,7 +108,7 @@ goog.require('ga_translation_service');
               }
               var labelsOnly = false;
               var url = scope.options.catalogUrlTemplate
-                  .replace('{Topic}', topic.id);
+                  .replace('{Topic}', topic.topicFallback);
               // If the topic has not changed that means we need to update only
               // labels
               if (lastUrlUsed == url) {

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -184,7 +184,7 @@ goog.require('ga_what3words_service');
               url = gaUrlUtils.append(url, tokenized.parameters[i]);
             }
             url = gaUrlUtils.append(url, 'lang=' + gaLang.get());
-            url = url.replace('{Topic}', gaTopic.get().id);
+            url = url.replace('{Topic}', gaTopic.get().topicFallback);
 
             $scope.childoptions.searchUrl = url;
             $scope.childoptions.query = q;

--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -450,7 +450,7 @@ goog.require('ga_urlutils_service');
             $scope.select = function(res) {
               unregisterMove();
               loadGeometry(res.attrs.layer, res.attrs.featureId,
-                           gaTopic.get().id,
+                           gaTopic.get().fallbackTopic,
                            $scope.options.featureUrl, function(f) {
                 $rootScope.$broadcast('gaTriggerTooltipRequest', {
                   features: [f],

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -503,7 +503,7 @@ goog.require('ga_topic_service');
               var mapSize = map.getSize();
               var mapExtent = map.getView().calculateExtent(mapSize);
               var htmlUrl = scope.options.htmlUrlTemplate
-                            .replace('{Topic}', gaTopic.get().id)
+                            .replace('{Topic}', gaTopic.get().topicFallback)
                             .replace('{Layer}', bodId)
                             .replace('{Feature}', featureId);
               return $http.get(htmlUrl, {

--- a/src/components/topic/TopicDirective.js
+++ b/src/components/topic/TopicDirective.js
@@ -17,6 +17,12 @@ goog.require('ga_topic_service');
           },
           scope: {},
           link: function(scope, element, attrs) {
+            var indexedTopic = [];
+            // Only because IE9 doesn't support flex
+            // We need to use this magic number and an extra wrapper
+            var desktopTopicWidth = 159.5;
+            var baseTopicGrpClsName = 'ga-topic-group-wrapper-';
+            var topicGroupWidths = {};
 
             // Because ng-repeat creates a new scope for each item in the
             // collection we can't use ng-click="activeTopic = topic" in
@@ -32,6 +38,23 @@ goog.require('ga_topic_service');
               }
             });
 
+            scope.groupedTopics = function() {
+              indexedTopic = [];
+              return scope.topics;
+            };
+
+            scope.topicPerGroup = function(topic) {
+              var isNewTopicGroup =
+                  indexedTopic.indexOf(topic.topicGroup) == -1;
+              if (isNewTopicGroup) {
+                indexedTopic.push(topic.topicGroup);
+                topicGroupWidths[baseTopicGrpClsName + topic.topicGroup] = 0;
+              }
+              topicGroupWidths[baseTopicGrpClsName + topic.topicGroup] +=
+                desktopTopicWidth;
+              return isNewTopicGroup;
+            };
+
             gaTopic.loadConfig().then(function() {
               scope.topics = gaTopic.getTopics();
               scope.activeTopic = gaTopic.get();
@@ -39,6 +62,9 @@ goog.require('ga_topic_service');
                 element.find('.ga-topic-item').tooltip({
                   placement: 'bottom'
                 });
+                for (var key in topicGroupWidths) {
+                  element.find('.' + key).css('width', topicGroupWidths[key]);
+                }
               });
               scope.$on('gaTopicChange', function(evt, newTopic) {
                 if (scope.activeTopic != newTopic) {

--- a/src/components/topic/partials/topic.html
+++ b/src/components/topic/partials/topic.html
@@ -1,8 +1,11 @@
-<div class="ga-topic-item"
-     ng-repeat="topic in ::topics"
-     ng-click="setActiveTopic(topic)"
-     ng-class="{'ga-topic-active': topic == activeTopic}"
-     data-original-title="{{topic.tooltip | translate}}">
-  <div translate>{{::topic.id}}</div>
-  <div class="ga-topics-sprite ga-topics-sprite-{{::topic.id}}"></div>
+<div class="ga-topic-group" ng-repeat="topicG in ::groupedTopics() | filter:topicPerGroup">
+  <div class="ga-topic-group-wrapper ga-topic-group-wrapper-{{::topicG.topicGroup}}">
+    <div ng-repeat="topic in topics | filter:{topicGroup: topicG.topicGroup}">
+      <div class="ga-topic-item" ng-click="setActiveTopic(topic)"
+         ng-class="{'ga-topic-active': topic == activeTopic}"
+         data-original-title="{{topic.tooltip | translate}}">
+      <div translate>{{::topic.id}}</div>
+      <div class="ga-topics-sprite ga-topics-sprite-{{::topic.id}}"></div>
+    </div>
+  </div>
 </div>

--- a/src/components/topic/style/topic.less
+++ b/src/components/topic/style/topic.less
@@ -119,9 +119,9 @@
   }
 
   @-webkit-keyframes play1 {.play1-frames;}
- 
-  @keyframes play1 {.play1-frames;}  
-  
+
+  @keyframes play1 {.play1-frames;}
+
   @-webkit-keyframes play2 {.play2-frames;}
 
   @keyframes play2 {.play2-frames;}
@@ -130,17 +130,27 @@
     width: 640px;
     padding: 0px 4px;
     transition: width 1s ease, height 1s ease;
+    overflow-x: hidden;
 
-    & > div {
-      float: left;
-      margin: 2px;
-      padding: 3px;
-      border: 1px solid transparent;
-      cursor: pointer;
-      width: 154px;
-      text-align: center;
+    .ga-topic-group {
+      width: 640px;
+      overflow-x: scroll;
 
-      &.ga-topic-active, &:hover {
+      .ga-topic-wrapper {
+        display: inline-block;
+      }
+
+      .ga-topic-item {
+        float: left;
+        margin: 2px;
+        padding: 3px;
+        border: 1px solid transparent;
+        cursor: pointer;
+        width: 154px;
+        text-align: center;
+      }
+
+      .ga-topic-active, .ga-topic-item:hover {
         border: 1px solid #c6c6c6;
         background-color: #efefef;
       }
@@ -148,14 +158,20 @@
 
     // Transform to a simple list when screen is really too small
     @media (max-width: 910px), (max-height: @screen-sm-max-height) {
-      width: 160px;
+      width: 175px;
       height: 250px;
       padding: 0px;
       overflow-y: auto;
       overflow-x: hidden;
-      
-      & > div {
-        width: 140px;
+
+      .ga-topic-group {
+        width: 160px;
+        overflow-x: hidden;
+        display: block;
+
+        .ga-topic-group-wrapper {
+          width: auto !important;
+        }
 
         .ga-topics-sprite {
           display: none;

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -273,8 +273,8 @@ itemscope itemtype="http://schema.org/WebApplication"
   % if device == 'desktop':
       <div class="pull-right">
         <a target="_blank"
-           translate="{{topicId + '_service_link_label'}}"
-           translate-attr="{href: topicId + '_service_link_href'}"></a>
+           translate="{{topicFallback + '_service_link_label'}}"
+           translate-attr="{href: topicFallback + '_service_link_href'}"></a>
       </div>
   % endif
     </div><!-- #footer -->
@@ -435,7 +435,7 @@ itemscope itemtype="http://schema.org/WebApplication"
              data-toggle="collapse" href="#catalog"
              ga-collapsible-show="globals.catalogShown">
             <i class="fa fa-caret-down"></i>
-            <span>{{topicId | translate}}</span>
+            <span>{{topicFallback | translate}}</span>
 
   % if device == 'desktop':
             <span ga-help="32,37,39" ga-help-options="{showOnHover:true}"></span>
@@ -508,7 +508,7 @@ itemscope itemtype="http://schema.org/WebApplication"
               </div>
               <hr>
               <p>
-                <a target="_blank" translate translate-attr="{href: topicId + '_service_link_href'}">{{topicId + '_service_link_label'}}</a>
+                <a target="_blank" translate translate-attr="{href: topicFallback + '_service_link_href'}">{{topicFallback + '_service_link_label'}}</a>
                 <br>
                 <a target="_blank" href="https://www.geo.admin.ch/{{langId}}/about-swiss-geoportal/impressum.html#copyright" translate>copyright_label</a>
               </p>

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -187,6 +187,7 @@ goog.require('ga_topic_service');
 
     var onTopicChange = function(event, topic) {
       $scope.topicId = topic.id;
+      $scope.topicFallback = topic.topicFallback;
 
       // iOS 7 minimal-ui meta tag bug
       if (gaBrowserSniffer.ios) {
@@ -210,6 +211,7 @@ goog.require('ga_topic_service');
 
     gaTopic.loadConfig().then(function() {
       $scope.topicId = gaTopic.get().id;
+      $scope.topicFallback = gaTopic.get().topicFallback;
 
       if (initWithPrint) {
         $scope.globals.printShown = true;

--- a/test/specs/catalogtree/CatalogtreeDirective.spec.js
+++ b/test/specs/catalogtree/CatalogtreeDirective.spec.js
@@ -43,6 +43,7 @@ describe('ga_catalogtree_directive', function() {
           return {
             id: 'sometopic',
             selectedLayers: ['bar'],
+            topicFallback: 'sometopic',
             langs: [{
               value: 'somelang',
               label: 'somelang'
@@ -90,7 +91,10 @@ describe('ga_catalogtree_directive', function() {
   });*/
 
   it('update the catalog when the topic change', function() {
-    $rootScope.$broadcast('gaTopicChange', {id: 'sometopic2'});
+    $rootScope.$broadcast('gaTopicChange', {
+      id: 'sometopic2',
+      topicFallback: 'sometopic2'
+    });
     $httpBackend.expectGET(expectedUrl1);
     $httpBackend.flush();
   });

--- a/test/specs/topic/TopicDirective.spec.js
+++ b/test/specs/topic/TopicDirective.spec.js
@@ -3,9 +3,11 @@ describe('ga_topic_directive', function() {
 
   beforeEach(function() {
     topics = [{
-      id: 'sometopic'
+      id: 'sometopic',
+      topicGroup: 1
     }, {
-      id: 'anothertopic'
+      id: 'anothertopic',
+      topicGroup: 2
     }];
 
     module(function($provide) {
@@ -58,7 +60,11 @@ describe('ga_topic_directive', function() {
 
       it('updates correctly the html on first topic change event', function() {
         var items = element.find('.ga-topic-item');
+        var topicGroup1 = element.find('.ga-topic-group-wrapper-1');
+        var topicGroup2 = element.find('.ga-topic-group-wrapper-2');
         expect(items.length).to.be(2);
+        expect(topicGroup1.length).to.be(1);
+        expect(topicGroup2.length).to.be(1);
         expect($(items[0]).hasClass('ga-topic-active')).to.be(true);
         expect($(items[1]).hasClass('ga-topic-active')).to.be(false);
       });

--- a/test/specs/topic/TopicDirective.spec.js
+++ b/test/specs/topic/TopicDirective.spec.js
@@ -4,9 +4,11 @@ describe('ga_topic_directive', function() {
   beforeEach(function() {
     topics = [{
       id: 'sometopic',
+      topicFallback: 'sometopic',
       topicGroup: 1
     }, {
       id: 'anothertopic',
+      topicFallback: 'anothertopic',
       topicGroup: 2
     }];
 

--- a/test/specs/topic/TopicService.spec.js
+++ b/test/specs/topic/TopicService.spec.js
@@ -4,25 +4,27 @@ describe('ga_topic_service', function() {
     var gaTopic, $httpBackend, $rootScope, gaGlobalOptions, topicPermalink, gaPermalink,
         expectedUrl = 'http://localhost:8081/123456/services',
         topics = [{
-          'langs': 'de,fr,it',
-          'selectedLayers': [],
-          'backgroundLayers': [
+          langs: 'de,fr,it',
+          selectedLayers: [],
+          backgroundLayers: [
             'ch.swisstopo.pixelkarte-farbe',
             'ch.swisstopo.pixelkarte-grau',
             'ch.swisstopo.swissimage'
           ],
-          'id': 'sometopic',
-          'showCatalog': true
+          id: 'sometopic',
+          topicFallback: 'sometopic',
+          showCatalog: true
         }, {
-          'langs': 'de,fr',
-          'selectedLayers': [],
-          'backgroundLayers': [
+          langs: 'de,fr',
+          selectedLayers: [],
+          backgroundLayers: [
             'ch.swisstopo.pixelkarte-grau',
             'ch.swisstopo.pixelkarte-farbe',
             'ch.swisstopo.swissimage'
           ],
-          'id': 'anothertopic',
-          'showCatalog': true
+          id: 'anothertopic',
+          topicFallback: 'anothertopic',
+          showCatalog: true
         }];
 
     beforeEach(function() {


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3157

Not being able to use flex because of IE9 is not fun. @oterral knows what I am talking about.

Here is a [Test Link](https://mf-geoadmin3.int.bgdi.ch/gal_topic_groups/index.html?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fgal_topic_groups&lang=en)

This PR introduces the concepts of topics group, e.g. groups appear on the same line.
It is generic enough that we can create as many topic group as we want without changing the code.

This PR works with
https://github.com/geoadmin/mf-chsdi3/pull/2311

Before merging:

1. Add all missing single topics
2. Add all images and translations
3. Update `bod_master` with migration script
4.  Remove https://github.com/geoadmin/mf-chsdi3/commit/9db0dd58da8bca36ddfbb0ba436a9f540c25af35
5. Merge https://github.com/geoadmin/mf-chsdi3/pull/2311
6. Merge this PR