### PR TITLE
Update setuptools on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -682,7 +682,7 @@ $(addprefix .build-artefacts/annotated/, $(SRC_JS_FILES) src/TemplateCacheModule
 ${PYTHON_VENV}:
 	mkdir -p .build-artefacts
 	virtualenv --no-site-packages $@
-	${PIP_CMD} install -U pip
+	${PIP_CMD} install -U pip setuptools
 
 .build-artefacts/last-version::
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Branch deployed to dev is based on this PR.
Fixes the bug with distribute where it doesn't reconize MarkupSafe is indeed installed. (which is now part of setuptools)