### PR TITLE
[WIP] Remove view's extent

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -662,8 +662,7 @@ goog.require('ga_urlutils_service');
               subdomains: dfltWmsSubdomains
             };
           }
-          var extent = gaMapUtils.intersectWithDefaultExtent(config3d.extent ||
-              ol.proj.get(gaGlobalOptions.defaultEpsg).getExtent());
+          var extent = config3d.extent || gaMapUtils.defaultExtent;
           if (params) {
             var minRetLod = gaMapUtils.getLodFromRes(config3d.maxResolution) ||
                 window.minimumRetrievingLevel;
@@ -707,8 +706,7 @@ goog.require('ga_urlutils_service');
           var olLayer;
           var timestamp = this.getLayerTimestampFromYear(bodId, gaTime.get());
           var crossOrigin = 'anonymous';
-          var extent = gaMapUtils.intersectWithDefaultExtent(layer.extent ||
-              ol.proj.get(gaGlobalOptions.defaultEpsg).getExtent());
+          var extent = layer.extent || gaMapUtils.defaultExtent;
 
           // For some obscure reasons, on iOS, displaying a base 64 image
           // in a tile with an existing crossOrigin attribute generates
@@ -1022,13 +1020,14 @@ goog.require('ga_urlutils_service');
       // Level of detail for the default resolution
       var lodForDfltRes = gaGlobalOptions.defaultLod;
       var dfltResIdx = resolutions.indexOf(gaGlobalOptions.defaultResolution);
-
+      var proj = ol.proj.get(gaGlobalOptions.defaultEpsg);
+      var extent = gaGlobalOptions.defaultExtent || proj.getExtent();
       return {
         Z_PREVIEW_LAYER: 1000,
         Z_PREVIEW_FEATURE: 1100,
         Z_FEATURE_OVERLAY: 2000,
         preload: 6, //Number of upper zoom to preload when offline
-        defaultExtent: gaGlobalOptions.defaultExtent,
+        defaultExtent: extent,
         viewResolutions: resolutions,
         defaultResolution: gaGlobalOptions.defaultResolution,
         getViewResolutionForZoom: function(zoom) {

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -62,7 +62,6 @@ goog.require('ga_topic_service');
         view: new ol.View({
           projection: defaultProjection,
           center: ol.extent.getCenter(gaMapUtils.defaultExtent),
-          extent: gaMapUtils.defaultExtent,
           resolution: gaMapUtils.defaultResolution,
           resolutions: gaMapUtils.viewResolutions
         }),

--- a/test/karma-conf.mako.js
+++ b/test/karma-conf.mako.js
@@ -12,6 +12,7 @@ module.exports = function(config) {
   // list of files / patterns to load in the browser
   files: [
     {pattern: 'style/font-awesome-4.5.0/font/*', watched: false, included: false, served: true},
+    {pattern: 'checker', watched: false, included: false, served: true},
   % if mode == 'release':
     'style/app.css',
     'lib/d3.min.js',


### PR DESCRIPTION
Some layer have an extent bigger than the default one.

This PR will work when chsdi will return an extent property in the layersConfig

[Test](https://mf-geoadmin3.int.bgdi.ch/teo_fixes/index.html?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swiss-map-vector1000.metadata&X=171889.81&Y=622188.44&zoom=0)