### PR TITLE
Fix maki regex

### DIFF
--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -71,9 +71,9 @@ goog.require('ga_urlutils_service');
         );
 
         // Replace all old maki urls image by the color service url
-        // Test regex here: https://regex101.com/r/rF2tA1/3
+        // Test regex here: https://regex101.com/r/rF2tA1/4
         kml = kml.replace(
-          /<href>https?:\/\/[a-z\d\.\-]*(bgdi|geo.admin)\.ch[a-zA-Z\d\-_\/]*img\/maki\/([a-z\-]*-24@2x\.png)/g,
+          /<href>https?:\/\/[a-z\d\.\-]*(bgdi|geo.admin)\.ch[a-zA-Z\d\-_\/]*img\/maki\/([a-z\-0-9]*-24@2x\.png)/g,
           '<href>' + gaGlobalOptions.apiUrl + '/color/255,0,0/$2'
         );
 

--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -419,7 +419,8 @@ describe('ga_kml_service', function() {
           'http://map.geo.admin.ch/aaa/aA4-aA4_aA61470313709/img/maki/marker-24@2x.png',
           'http://mf-geoadmin3.dev.bgdi.ch/aaa/aA4-aA4_aA6/img/maki/marker-24@2x.png',
           'https://map.geo.admin.ch/1470313709/img/maki/marker-24@2x.png',
-          'https://mf-geoadmin3.int.bgdi.ch/aaa/aA4-aA4_aA6/img/maki/marker-24@2x.png'
+          'https://mf-geoadmin3.int.bgdi.ch/aaa/aA4-aA4_aA6/img/maki/marker-24@2x.png',
+          'https://mf-geoadmin3.int.bgdi.ch/aaa/aA4-aA4_aA6/img/maki/marker2-24@2x.png'
         ];
         var kml = '<kml>';
         hrefs.forEach(function(href) {


### PR DESCRIPTION
Before:https://map.geo.admin.ch/?topic=cadastre&X=147248.37&Y=713789.91&zoom=11&lang=it&bgLayer=ch.swisstopo.swissimage&catalogNodes=2482&layers=ch.kantone.cadastralwebmap-farbe,KML%7C%7Chttps:%2F%2Fpublic.geo.admin.ch%2FYENb4nSASdmGGDfchTrcvQ&layers_opacity=0.25,1

After: https://mf-geoadmin3.int.bgdi.ch/teo_maki/index.html?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=KML%7C%7Chttps:%2F%2Fpublic.geo.admin.ch%2FYENb4nSASdmGGDfchTrcvQ&X=147283.25&Y=713925.59&zoom=12