### PR TITLE
Fix offline on iOS 10

### DIFF
--- a/src/components/StorageService.js
+++ b/src/components/StorageService.js
@@ -66,10 +66,14 @@ goog.require('ga_browsersniffer_service');
         this.init = function() {
           if (!isInitialized && $window.localforage &&
               gaBrowserSniffer.mobile) {
+            // iOS 10 manages indexedDB but localforage has a wrong detection.
+            // iOS 10 doesn't accept a webSQL db of 50MB exactly, that's why
+            // 1023 instead of 1024 is specified in size parameter. To remove
+            // when localforage will support indexedDB for iOS 10.
             $window.localforage.config({
               name: 'map.geo.admin.ch',
               storeName: 'ga',
-              size: 50 * 1024 * 1024, // Only use by webSQL
+              size: 50 * 1024 * 1023,
               version: (gaBrowserSniffer.msie) ? 1 : '1.0',
               description: 'Storage for map.geo.admin.ch'
             });
@@ -78,7 +82,7 @@ goog.require('ga_browsersniffer_service');
             // Exceptions:
             // Android default browser -> websql
             // iOS Chrome, Opera -> websql
-            // iOS 7 Safari -> websql
+            // iOS Safari -> websql
             isInitialized = true;
           }
         };

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1076,7 +1076,7 @@ goog.require('ga_urlutils_service');
          * Use by offline to store in local storage.
          */
         getTileKey: function(tileUrl) {
-          return tileUrl.replace(/^\/\/wmts[0-9]/, '');
+          return tileUrl.replace(/^\/\/wmts[0-9]{0,3}/, '');
         },
 
         /**

--- a/src/components/offline/OfflineService.js
+++ b/src/components/offline/OfflineService.js
@@ -138,7 +138,7 @@ goog.require('ga_styles_service');
             if (percentCached <= 95) { // Download failed
               $rootScope.$broadcast('gaOfflineError');
               $window.alert($translate.instant('offline_less_than_95'));
-
+              $window.console.log(errorReport);
             } else { // Download succeed
               gaStorage.setItem(extentKey, extent);
               $rootScope.$broadcast('gaOfflineSuccess', progress);
@@ -183,9 +183,12 @@ goog.require('ga_styles_service');
                   return;
                 }
                 if (err) {
-                  if (err.code == err.QUOTA_ERR) {
+                  // err.QUOTQ_ERR for websql
+                  // DOMException.QUOTA_EXCEEDED_ERR for localstorage
+                  if (err.code == err.QUOTA_ERR ||
+                        err.code == DOMException.QUOTA_EXCEEDED_ERR) {
                     isStorageFull = true;
-                    alert($translate.instant('offline_space_warning'));
+                    $window.alert($translate.instant('offline_space_warning'));
                     nbTilesFailed = nbTilesTotal - nbTilesCached;
                     onDlProgress();
                   } else {

--- a/test/specs/StorageService.spec.js
+++ b/test/specs/StorageService.spec.js
@@ -77,7 +77,7 @@ describe('ga_storage_service', function() {
         var arg = spy.firstCall.args[0];
         expect(arg.name).to.be('map.geo.admin.ch');
         expect(arg.storeName).to.be('ga');
-        expect(arg.size).to.be(52428800);
+        expect(arg.size).to.be(52377600);
         expect(arg.version).to.be('1.0');
         expect(arg.description).to.be('Storage for map.geo.admin.ch');
         spy.restore();

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -1586,8 +1586,13 @@ describe('ga_map_service', function() {
 
     describe('#getTileKey()', function() {
       it('gets the tile\'s key', function() {
-        var tileUrl = '//wmts5.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/21781/18/15/20.jpeg';
-        expect(gaMapUtils.getTileKey(tileUrl)).to.eql('.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/21781/18/15/20.jpeg');
+        [
+          '//wmts5.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/21781/18/15/20.jpeg',
+          '//wmts54.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/21781/18/15/20.jpeg',
+          '//wmts540.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/21781/18/15/20.jpeg'
+        ].forEach(function(url) {
+          expect(gaMapUtils.getTileKey(url)).to.eql('.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/21781/18/15/20.jpeg');
+        });
       });
     });
 


### PR DESCRIPTION
Fix #3638 

[Test on iOS 10](https://mf-geoadmin3.dev.bgdi.ch/ltteo/mobile.html?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&dev3d=true&zoom=1&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&mobile=true)

Tested on iPhone 5s and iPad pro