### PR TITLE
Change caching header and only use no-cache

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -63,10 +63,9 @@ RewriteRule ^${apache_base_path}/[0-9]+/(img|lib|style|locales)(.*) ${apache_bas
 # and http://tools.ietf.org/html/rfc2616
 <LocationMatch ^${apache_base_path}/(index.html|mobile.html|embed.html|geoadmin.${version}.appcache)$>
     Header unset Age
-    Header unset Last-Modified
     Header unset Vary
     Header unset Cache-Control
     Header unset Pragma
-    Header set Cache-Control "no-cache, must-revalidate"
+    Header set Cache-Control "no-cache"
     Header set Pragma "no-cache"
 </LocationMatch>

--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -159,7 +159,7 @@ def _save_to_s3(in_data, dest, mimetype, bucket_name, compress=True, cached=True
         compressed = True
 
     if cached is False:
-        cache_control = 'no-cache, no-store, max-age=0, must-revalidate'
+        cache_control = 'no-cache'
 
     extra_args['ACL'] = 'public-read'
     extra_args['ContentType'] = mimetype


### PR DESCRIPTION
I was reading up on http caching over Christmas :=). This should reduce the transferred data of our non cached resources, mainly the html pages of map.geo.admin.ch.

Before, we used the no-store header, which forced the browsers to alwas download the complete html content from the server. With only the no-cache header, we only download the html when either last-modified date changed or the etag changed. Otherwise, we simply respond with a 304. The difference is 8KB less data transfered per request. Also, page loads faster. Note that 304 still registers as a hit/visit, so it won't impact statistics.

Note that the client still checks the server (in our case S3) for new content on every new attempt - so it should never use old pages.

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_caching/index.html)

We save around 4GB of daily data transfer and we safe 20$ per month.