### PR TITLE
Show more precision on tooltip popup markers

### DIFF
--- a/src/components/draw/partials/drawstyle.html
+++ b/src/components/draw/partials/drawstyle.html
@@ -107,7 +107,7 @@
     </div>
   </label>
 </div>
-<div ga-measure="feature"></div>
+<div ga-measure="feature" ga-coordinate-precision="0"></div>
 
 <div ng-repeat="t in ::options.linkTypes" class="ga-popover-content ga-html-{{t.label}}">
   <label ng-if="t.label == 'link'">

--- a/src/components/measure/MeasureDirective.js
+++ b/src/components/measure/MeasureDirective.js
@@ -13,7 +13,8 @@ goog.require('ga_measure_service');
       restrict: 'A',
       templateUrl: 'components/measure/partials/measure.html',
       scope: {
-        feature: '=gaMeasure'
+        feature: '=gaMeasure',
+        precision: '=gaCoordinatePrecision'
       },
       link: function(scope, elt) {
         var deregisterKey;
@@ -27,7 +28,7 @@ goog.require('ga_measure_service');
           if (geom instanceof ol.geom.Point) {
             var coord = ol.proj.transform(geom.getCoordinates(),
                 gaGlobalOptions.defaultEpsg, 'EPSG:2056');
-            scope.coord = gaMeasure.formatCoordinates(coord);
+            scope.coord = gaMeasure.formatCoordinates(coord, scope.precision);
           } else {
             scope.distance = gaMeasure.getLength(geom);
             scope.surface = gaMeasure.getArea(geom);

--- a/src/components/measure/MeasureService.js
+++ b/src/components/measure/MeasureService.js
@@ -13,8 +13,8 @@ goog.require('ga_measure_filter');
       var Measure = function() {
 
         // Transform 2111333 in 2'111'333
-        this.formatCoordinates = function(coordinates) {
-          var raw = ol.coordinate.toStringXY(coordinates, 0);
+        this.formatCoordinates = function(coordinates, prec) {
+          var raw = ol.coordinate.toStringXY(coordinates, prec || 0);
           if (coordinates && coordinates.length === 3) {
             raw += ', ' + coordinates[2].toFixed(1);
           }

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -43,7 +43,8 @@ goog.require('ga_topic_service');
                'ng-mouseleave="options.onMouseLeave($event)">' +
             '<div ng-bind-html="html.snippet"></div>' +
             '<div ng-if="html.showVectorInfos" class="ga-vector-tools">' +
-              '<div ga-measure="html.feature"></div>' +
+              '<div ga-measure="html.feature" ' +
+                    'ga-coordinate-precision="3"></div>' +
               '<div ng-if="html.showProfile" ' +
                    'ga-profile-bt="html.feature"></div>' +
             '</div>' +

--- a/test/specs/measure/MeasureService.spec.js
+++ b/test/specs/measure/MeasureService.spec.js
@@ -35,6 +35,13 @@ describe('ga_measure_service', function() {
       it('returns formatted 3D coordinates', function() {
         expect(gaMeasure.formatCoordinates([2457749.999996144, 1056249.999834365, 451.423])).to.eql("2'457'750, 1'056'250, 451.4");
       });
+
+      it('returns correct precision', function() {
+        expect(gaMeasure.formatCoordinates([2457749.999996144, 1056249.999834365], 0)).to.eql("2'457'750, 1'056'250");
+        expect(gaMeasure.formatCoordinates([2457749.899996144, 1056249.899834365], 1)).to.eql("2'457'749.9, 1'056'249.9");
+        expect(gaMeasure.formatCoordinates([2457749.899996144, 1056249.899834365], 3)).to.eql("2'457'749.900, 1'056'249.900");
+      });
+
     });
 
    describe('#getLength()', function() {


### PR DESCRIPTION
When clicking on a marker (either one places via pl parameter, search or kml), we only see meters. This PR will show millimeter precision in the tooltips for markers.

People complained about it, because when you enter a coordinate in the search with mm precision, the accosiated tooltip does not contain mm...and sharing is harder that way.

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_prec/index.html)