### PR TITLE
Fix #3033: Replace $http.success and error deprecated methods

### DIFF
--- a/src/components/FileStorageService.js
+++ b/src/components/FileStorageService.js
@@ -37,14 +37,15 @@ goog.provide('ga_filestorage_service');
         // Get the accessible url of the file from an adminId
         this.getFileUrlFromAdminId = function(adminId) {
           var deferred = $q.defer();
-          $http.get(getServiceUrl(adminId)).success(function(data) {
+          $http.get(getServiceUrl(adminId)).then(function(response) {
+            var data = response.data;
             if (data && data.fileId) {
               var url = getPublicUrl(data.fileId);
               deferred.resolve(url);
             } else {
               deferred.reject();
             }
-          }).error(function() {
+          }, function() {
             deferred.reject();
           });
           return deferred.promise;
@@ -58,21 +59,18 @@ goog.provide('ga_filestorage_service');
         // if id is an fileId --> fork the file
         //     returns new adminId and new file url
         this.save = function(id, content, contentType) {
-          var deferred = $q.defer();
-          $http.post(getServiceUrl(id), content, {
+          return $http.post(getServiceUrl(id), content, {
             headers: {
               'Content-Type': contentType
             }
-          }).success(function(data) {
-            deferred.resolve({
+          }).then(function(response) {
+            var data = response.data;
+            return {
               adminId: data.adminId,
               fileId: data.fileId,
               fileUrl: getPublicUrl(data.fileId)
-            });
-          }).error(function() {
-            deferred.reject();
+            };
           });
-          return deferred.promise;
         };
 
 

--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -145,8 +145,8 @@ goog.require('ga_what3words_service');
                     northing: coord21781[1],
                     elevation_model: gaGlobalOptions.defaultElevationModel
                   }
-                }).success(function(response) {
-                  scope.altitude = parseFloat(response.height);
+                }).then(function(response) {
+                  scope.altitude = parseFloat(response.data.height);
                 });
 
                 $http.get(lv03tolv95Url, {
@@ -154,8 +154,8 @@ goog.require('ga_what3words_service');
                     easting: coord21781[0],
                     northing: coord21781[1]
                   }
-                }).success(function(response) {
-                  coord2056 = response.coordinates;
+                }).then(function(response) {
+                  coord2056 = response.data.coordinates;
                   scope.coord2056 = formatCoordinates(coord2056, 2);
                 });
 

--- a/src/components/featuretree/FeaturetreeDirective.js
+++ b/src/components/featuretree/FeaturetreeDirective.js
@@ -50,10 +50,10 @@ goog.require('ga_previewfeatures_service');
               params: {
                 geometryFormat: 'geojson'
               }
-            }).success(function(data) {
-              feature.geojson = data.feature;
+            }).then(function(response) {
+              feature.geojson = response.data.feature;
               deferred.resolve(true);
-            }).error(function() {
+            }, function() {
               deferred.reject(false);
             });
           } else {

--- a/src/components/feedback/FeedbackDirective.js
+++ b/src/components/feedback/FeedbackDirective.js
@@ -181,10 +181,10 @@ goog.require('ga_permalink');
                 }
 
                 scope.showProgress = true;
-                $http(params).success(function(response) {
+                $http(params).then(function() {
                   resetF();
                   scope.success = true;
-                }).error(function(response) {
+                }, function() {
                   resetF();
                   scope.error = true;
                 });

--- a/src/components/importwms/ImportWmsDirective.js
+++ b/src/components/importwms/ImportWmsDirective.js
@@ -50,12 +50,12 @@ goog.require('ga_wms_service');
               $scope.canceler = $q.defer();
 
               // Angularjs doesn't handle onprogress event
-              $http.get(proxyUrl, {timeout: $scope.canceler.promise})
-              .success(function(data, status, headers, config) {
+              $http.get(proxyUrl, {
+                timeout: $scope.canceler.promise
+              }).then(function(response) {
                 $scope.userMessage = $translate.instant('upload_succeeded');
-                $scope.displayFileContent(data);
-              })
-              .error(function(data, status, headers, config) {
+                $scope.displayFileContent(response.data);
+              }, function() {
                 $scope.error = true;
                 $scope.userMessage = $translate.instant('upload_failed');
                 $scope.progress = 0;

--- a/src/components/offline/OfflineService.js
+++ b/src/components/offline/OfflineService.js
@@ -466,10 +466,9 @@ goog.require('ga_styles_service');
             // if the layer is a KML
             if (gaMapUtils.isKmlLayer(layer) &&
                 /^https?:\/\//.test(layer.url)) {
-              $http.get(gaUrlUtils.proxifyUrl(layer.url))
-                .success(function(data) {
-                  gaStorage.setItem(layer.id, data);
-                });
+              $http.get(gaUrlUtils.proxifyUrl(layer.url)).then(function(resp) {
+                gaStorage.setItem(layer.id, resp.data);
+              });
               layersBg.push(false);
               continue;
             }

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -745,7 +745,8 @@ goog.require('ga_urlutils_service');
             canceller = $q.defer();
             var http = $http.get(url, {
                timeout: canceller.promise
-            }).success(function(data) {
+            }).then(function(response) {
+              var data = response.data;
               if (!$scope.options.printing) {
                 return;
               }
@@ -780,7 +781,7 @@ goog.require('ga_urlutils_service');
               } else {
                 $scope.downloadUrl(data.getURL);
               }
-            }).error(function() {
+            }, function() {
               if ($scope.options.printing == false) {
                 pollErrors = 0;
                 return;
@@ -804,7 +805,8 @@ goog.require('ga_urlutils_service');
         var http = $http.post(printUrl + '?url=' + encodeURIComponent(printUrl),
           spec, {
           timeout: canceller.promise
-        }).success(function(data) {
+        }).then(function(response) {
+          var data = response.data;
           if (movieprint) {
             //start polling process
             var pollUrl = $scope.options.printPath + 'progress?id=' +
@@ -816,7 +818,7 @@ goog.require('ga_urlutils_service');
           } else {
             $scope.downloadUrl(data.getURL);
           }
-        }).error(function() {
+        }, function() {
           $scope.options.printing = false;
         });
       });
@@ -929,7 +931,8 @@ goog.require('ga_urlutils_service');
     $scope.$watch('active', function(newVal, oldVal) {
       if (newVal === true) {
         if (!$scope.printConfigLoaded) {
-          loadPrintConfig().success(function(data) {
+          loadPrintConfig().then(function(response) {
+            var data = response.data;
             $scope.capabilities = data;
             angular.forEach($scope.capabilities.layouts, function(lay) {
               lay.stripped = lay.name.substr(2);

--- a/src/components/profile/example/index.html
+++ b/src/components/profile/example/index.html
@@ -114,8 +114,8 @@
             function getData() {
               var template = 'components/profile/example/profile.json';
               var http = $http.get(template);
-              http.success(function(data, status) {
-                $rootScope.$broadcast('gaProfileDataLoaded', data);
+              http.then(function(response) {
+                $rootScope.$broadcast('gaProfileDataLoaded', response.data);
               });
             }
 
@@ -125,8 +125,8 @@
               var template = 'components/profile/example/profile.json';
               var http = $http.get(template);
               var dataRandom = [];
-              http.success(function(data, status) {
-                angular.forEach(data, function(value, key) {
+              http.then(function(response) {
+                angular.forEach(response.data, function(value, key) {
                   value.alts.DTM25 += Math.round(Math.random() * 200);
                   this.push(value);
                 }, dataRandom);

--- a/src/components/search/SearchTypesDirectives.js
+++ b/src/components/search/SearchTypesDirectives.js
@@ -220,15 +220,16 @@ goog.require('ga_urlutils_service');
         $http.get(url, {
           cache: true,
           timeout: canceler.promise
-        }).success(function(data) {
+        }).then(function(response) {
+          var data = response.data;
           $scope.results = data.results;
           if (data.fuzzy) {
             $scope.fuzzy = '_fuzzy';
           }
           $scope.options.announceResults($scope.type, data.results.length);
-        }).error(function(data, statuscode) {
+        }, function(response) {
           // If request is canceled, statuscode is 0 and we don't announce it
-          if (statuscode !== 0) {
+          if (response.status !== 0) {
             $scope.options.announceResults($scope.type, 0);
           }
         });
@@ -397,7 +398,8 @@ goog.require('ga_urlutils_service');
               params: {
                  geometryFormat: 'geojson'
               }
-            }).success(function(result) {
+            }).then(function(response) {
+              var result = response.data;
               selectedFeatures[key] = result.feature;
               cb(result.feature);
             });

--- a/src/js/FeaturetreeController.js
+++ b/src/js/FeaturetreeController.js
@@ -119,13 +119,13 @@ goog.require('ga_print_service');
             params: {
               lang: lang
             }
-          }).success(function(data, status, headers, config) {
-            printElementLoaded(data, bodId);
-          }).error(function(data, status, headers, config) {
+          }).then(function(response) {
+            printElementLoaded(response.data, bodId);
+          }, function(response) {
             printElementLoaded('<div>' +
                 'There was a problem loading this feature. Layer: ' + bodId +
                 ', feature: ' + layer.features[i].id +
-                ', status: ' + status + '<div>', 'failure');
+                ', status: ' + response.status + '<div>', 'failure');
           });
         }
       }


### PR DESCRIPTION
Fix #3033 

[Test](https://mf-geoadmin3.int.bgdi.ch/teo_deprecated/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,)