### PR TITLE
Remove usage of $http success/error in SeaDirective

### DIFF
--- a/src/components/seo/SeoDirective.js
+++ b/src/components/seo/SeoDirective.js
@@ -52,7 +52,8 @@ goog.require('ga_seo_service');
                     var locdef = $q.defer();
                     gaLayers.getMetaDataOfLayer(layerId)
                         .then(function(response) {
-                          scope.layerMetadatas.push($sce.trustAsHtml(response.data));
+                          scope.layerMetadatas.push($sce.trustAsHtml(
+                              response.data));
                           locdef.resolve();
                         }, function() {
                           locdef.resolve();

--- a/src/components/seo/SeoDirective.js
+++ b/src/components/seo/SeoDirective.js
@@ -51,10 +51,10 @@ goog.require('ga_seo_service');
                   var getMetadata = function(layerId) {
                     var locdef = $q.defer();
                     gaLayers.getMetaDataOfLayer(layerId)
-                        .success(function(data) {
-                          scope.layerMetadatas.push($sce.trustAsHtml(data));
+                        .then(function(response) {
+                          scope.layerMetadatas.push($sce.trustAsHtml(response.data));
                           locdef.resolve();
-                        }).error(function() {
+                        }, function() {
                           locdef.resolve();
                         });
                     return locdef.promise;


### PR DESCRIPTION
From what I read here https://github.com/geoadmin/mf-geoadmin3/blob/451789df747e14294e8670486956c93b7c848f8c/src/components/map/MapService.js#L900 getMetaDataOfLayer uses $http. This makes usage of then instead of success/error in SeoDirective.js where this function is used.