### PR TITLE
Add reframe service

### DIFF
--- a/src/components/ReframeService.js
+++ b/src/components/ReframeService.js
@@ -1,0 +1,55 @@
+goog.provide('ga_reframe_service');
+
+(function() {
+
+  var module = angular.module('ga_reframe_service', []);
+  /**
+   * Service to transform coordinates from lv03 to lv95 and vice-versa.
+   *
+   */
+  module.provider('gaReframe', function() {
+    this.$get = function($q, $http, gaGlobalOptions) {
+
+      var lv03tolv95Url = gaGlobalOptions.lv03tolv95Url;
+      var lv95tolv03Url = gaGlobalOptions.lv95tolv03Url;
+
+      var Reframe = function() {
+        this.get03To95 = function(coordinates) {
+          var defer = $q.defer();
+          $http.get(lv03tolv95Url, {
+            params: {
+              easting: coordinates[0],
+              northing: coordinates[1]
+            }
+          }).then(function(response) {
+            defer.resolve(response.data.coordinates);
+          }, function() {
+            // Use proj4js on error
+            defer.resolve(ol.proj.transform(coordinates,
+                'EPSG:21781', 'EPSG:2056'));
+          });
+          return defer.promise;
+        };
+
+        this.get95To03 = function(coordinates) {
+          var defer = $q.defer();
+          $http.get(lv95tolv03Url, {
+            params: {
+              easting: coordinates[0],
+              northing: coordinates[1]
+            }
+          }).then(function(response) {
+            defer.resolve(response.data.coordinates);
+          }, function() {
+            // Use proj4js on error
+            defer.resolve(ol.proj.transform(coordinates,
+                'EPSG:2056', 'EPSG:21781'));
+          });
+          return defer.promise;
+        };
+      };
+
+      return new Reframe();
+    };
+  });
+})();

--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -2,12 +2,14 @@ goog.provide('ga_contextpopup_directive');
 
 goog.require('ga_networkstatus_service');
 goog.require('ga_permalink');
+goog.require('ga_reframe_service');
 goog.require('ga_what3words_service');
 (function() {
 
   var module = angular.module('ga_contextpopup_directive', [
     'ga_networkstatus_service',
     'ga_permalink',
+    'ga_reframe_service',
     'ga_what3words_service',
     'pascalprecht.translate'
   ]);
@@ -15,7 +17,7 @@ goog.require('ga_what3words_service');
   module.directive('gaContextPopup',
       function($rootScope, $http, $translate, $q, $timeout, $window,
           gaBrowserSniffer, gaNetworkStatus, gaPermalink, gaGlobalOptions,
-          gaLang, gaWhat3Words) {
+          gaLang, gaWhat3Words, gaReframe) {
         return {
           restrict: 'A',
           replace: true,
@@ -28,7 +30,6 @@ goog.require('ga_what3words_service');
           link: function(scope, element, attrs) {
             var heightUrl = scope.options.heightUrl;
             var qrcodeUrl = scope.options.qrcodeUrl;
-            var lv03tolv95Url = scope.options.lv03tolv95Url;
 
             // The popup content is updated (a) on contextmenu events,
             // and (b) when the permalink is updated.
@@ -149,13 +150,8 @@ goog.require('ga_what3words_service');
                   scope.altitude = parseFloat(response.data.height);
                 });
 
-                $http.get(lv03tolv95Url, {
-                  params: {
-                    easting: coord21781[0],
-                    northing: coord21781[1]
-                  }
-                }).then(function(response) {
-                  coord2056 = response.data.coordinates;
+                gaReframe.get03To95(coord21781).then(function(coords) {
+                  coord2056 = coords;
                   scope.coord2056 = formatCoordinates(coord2056, 2);
                 });
 

--- a/src/components/search/SearchDirective.js
+++ b/src/components/search/SearchDirective.js
@@ -153,17 +153,18 @@ goog.require('ga_what3words_service');
             return;
           }
           // Coordinate?
-          var position = gaSearchGetCoordinate(
-              $scope.map.getView().getProjection().getExtent(), q);
+          var extent = $scope.map.getView().getProjection().getExtent();
+          gaSearchGetCoordinate(extent, q).then(function(position) {
+            if (position) {
+              gaMapUtils.moveTo($scope.map, $scope.ol3d, 8, position);
+              gaMarkerOverlay.add($scope.map, position, true);
+            }
+          });
 
           // w3w word?
           var w3w = gaWhat3Words.getCoordinate(q);
 
-          if (position) {
-            gaMapUtils.moveTo($scope.map, $scope.ol3d, 8, position);
-            gaMarkerOverlay.add($scope.map, position, true);
-          //TODO: canceling requests that might be out there...
-          } else if (w3w) {
+          if (w3w) {
             w3w.then(function(response) {
               var res = response.data;
               if (res && res.geometry && res.geometry.lng && res.geometry.lat) {

--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -1,7 +1,10 @@
 goog.provide('ga_search_service');
+
+goog.require('ga_reframe_service');
 (function() {
 
   var module = angular.module('ga_search_service', [
+    'ga_reframe_service'
   ]);
 
   var DMSDegree = '[0-9]{1,2}[°|º]\\s*';
@@ -28,12 +31,18 @@ goog.provide('ga_search_service');
   // It's a limitiation of proj4 and a sensible default (precision is 10km)
   var MGRSMinimalPrecision = 7;
 
+  var roundCoordinates = function(coords) {
+    return [Math.round(coords[0] * 1000) / 1000,
+      Math.round(coords[1] * 1000) / 1000];
+  };
+
   module.provider('gaSearchGetCoordinate', function() {
-    this.$get = function($window) {
+    this.$get = function($window, $q, gaReframe) {
+
       return function(extent, query) {
         var position;
-        var valid = false;
 
+        // Parse MGRS notation
         var matchMGRS = query.match(regexMGRS);
         if (matchMGRS && matchMGRS.length == 1) {
           var mgrsStr = matchMGRS[0].split(' ').join('');
@@ -41,11 +50,12 @@ goog.provide('ga_search_service');
             var wgs84 = $window.proj4.mgrs.toPoint(matchMGRS[0]);
             position = ol.proj.transform(wgs84, 'EPSG:4326', 'EPSG:21781');
             if (ol.extent.containsCoordinate(extent, position)) {
-              valid = true;
+              return $q.when(roundCoordinates(position));
             }
           }
         }
 
+        // Parse degree EPSG:4326 notation
         var matchDMSN = query.match(regexpDMSN);
         var matchDMSE = query.match(regexpDMSE);
         if (matchDMSN && matchDMSN.length == 1 &&
@@ -81,12 +91,12 @@ goog.provide('ga_search_service');
                 'EPSG:4326', 'EPSG:21781');
           if (ol.extent.containsCoordinate(
             extent, position)) {
-              valid = true;
+            return $q.when(roundCoordinates(position));
           }
         }
 
         var match = query.match(regexpCoordinate);
-        if (match && !valid) {
+        if (match) {
           var left = parseFloat(match[1].replace(/\'/g, ''));
           var right = parseFloat(match[2].replace(/\'/g, ''));
           //Old school entries like '600 000 200 000'
@@ -96,35 +106,32 @@ goog.provide('ga_search_service');
             right = parseFloat(match[4].replace(/\'/g, '') +
                                match[5].replace(/\'/g, ''));
           }
-
-          position =
-            [left > right ? left : right,
+          position = [left > right ? left : right,
               right < left ? right : left];
-          if (ol.extent.containsCoordinate(
-              extent, position)) {
-            valid = true;
-          } else {
-            position = ol.proj.transform(position,
-              'EPSG:2056', 'EPSG:21781');
-            if (ol.extent.containsCoordinate(
-                extent, position)) {
-              valid = true;
-            } else {
-              position =
-                [left < right ? left : right,
-                  right > left ? right : left];
-              position = ol.proj.transform(position,
-                'EPSG:4326', 'EPSG:21781');
-              if (ol.extent.containsCoordinate(
-                extent, position)) {
-                valid = true;
-              }
+          // LV03 or EPSG:21781
+          if (ol.extent.containsCoordinate(extent, position)) {
+            return $q.when(roundCoordinates(position));
+          }
+
+          // Match decimal notation EPSG:4326
+          if (left <= 180 && left >= -180 &&
+              right <= 180 && right >= -180) {
+            position = [left > right ? right : left,
+                right < left ? left : right];
+            position = ol.proj.transform(position, 'EPSG:4326', 'EPSG:21781');
+            if (ol.extent.containsCoordinate(extent, position)) {
+              return $q.when(roundCoordinates(position));
             }
           }
+
+          // Match LV95 coordinates
+          return gaReframe.get95To03(position).then(function(position) {
+            if (ol.extent.containsCoordinate(extent, position)) {
+              return roundCoordinates(position);
+            }
+          });
         }
-        return valid ?
-          [Math.round(position[0] * 1000) / 1000,
-          Math.round(position[1] * 1000) / 1000] : undefined;
+        return $q.when(undefined);
       };
     };
   });

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -818,6 +818,8 @@ itemscope itemtype="http://schema.org/WebApplication"
           ogcproxyUrl: apiUrl + '/ogcproxy?url=',
           wmsUrl: wmsUrl,
           w3wUrl: 'https://api.what3words.com',
+          lv03tolv95Url: 'https://geodesy.geo.admin.ch/reframe/lv03tolv95',
+          lv95tolv03Url: 'https://geodesy.geo.admin.ch/reframe/lv95tolv03',
           w3wApiKey: 'OM48J50Y',
           whitelist: [
             'https://' + window.location.host + '/**'

--- a/src/js/ContextPopupController.js
+++ b/src/js/ContextPopupController.js
@@ -7,8 +7,7 @@ goog.provide('ga_contextpopup_controller');
       function($scope, gaGlobalOptions) {
         $scope.options = {
           heightUrl: gaGlobalOptions.apiUrl + '/rest/services/height',
-          qrcodeUrl: gaGlobalOptions.apiUrl + '/qrcodegenerator',
-          lv03tolv95Url: 'https://geodesy.geo.admin.ch/reframe/lv03tolv95'
+          qrcodeUrl: gaGlobalOptions.apiUrl + '/qrcodegenerator'
         };
 
       });

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -35,6 +35,8 @@ beforeEach(function() {
       ogcproxyUrl: location.protocol + apiUrl + '/ogcproxy?url=',
       wmsUrl: location.protocol + wmsUrl,
       w3wUrl: 'dummy.test.url.com',
+      lv03tolv95Url: '//api.example.com/reframe/lv03tolv95',
+      lv95tolv03Url: '//api.example.com/reframe/lv95tolv03',
       w3wApiKey: 'testkey',
       whitelist: [
         'https://' + window.location.host + '/**'

--- a/test/specs/ReframeService.spec.js
+++ b/test/specs/ReframeService.spec.js
@@ -1,0 +1,76 @@
+describe('ga_reframe_service', function() {
+  var $rootScope, $httpBackend, gaReframe, lv03tolv95Url, lv95tolv03Url;
+
+  var buildUrl = function(baseUrl, coords) {
+    return baseUrl + '?easting=' + coords[0] + '&northing=' + coords[1];
+  };
+
+  describe('gaReframeService', function() {
+
+    beforeEach(function() {
+      inject(function($injector, gaGlobalOptions) {
+        $rootScope = $injector.get('$rootScope');
+        $httpBackend = $injector.get('$httpBackend');
+        gaReframe = $injector.get('gaReframe');
+        lv03tolv95Url = gaGlobalOptions.lv03tolv95Url;
+        lv95tolv03Url = gaGlobalOptions.lv95tolv03Url;
+      });
+    });
+
+    it('transforms coordinates using the reframe service from LV03 to LV95',
+        function(done) {
+      var coordinates = [620116.6, 142771.3];
+      var url = buildUrl(lv03tolv95Url, coordinates);
+      var response = [2620116.600000524, 1142771.299843073];
+      $httpBackend.expectGET(url).respond({ c: response });
+
+      gaReframe.get03To95(coordinates).then(function(coords) {
+        expect(coords).to.eql(response.c);
+        done();
+      });
+      $httpBackend.flush();
+      $rootScope.$digest();
+    });
+
+    it('transforms coordinates using the reframe service from LV95 to LV03',
+        function(done) {
+      var coordinates = [2620116.600000524, 1142771.299843073];
+      var url = buildUrl(lv95tolv03Url, coordinates);
+      var response = [620116.600001048, 142771.2996861463];
+      $httpBackend.expectGET(url).respond({ c: response });
+
+      gaReframe.get95To03(coordinates).then(function(coords) {
+        expect(coords).to.eql(response.c);
+        done();
+      });
+      $httpBackend.flush();
+      $rootScope.$digest();
+    });
+
+    it('falls back on proj4js on error for LV03 to LV95', function(done) {
+      var coordinates = [620116.6, 142771.3];
+      var url = buildUrl(lv03tolv95Url, coordinates);
+      $httpBackend.expectGET(url).respond(400);
+
+      gaReframe.get03To95(coordinates).then(function(coords) {
+        expect(coords).to.eql([2620116.600000524, 1142771.299843073]);
+        done();
+      });
+      $httpBackend.flush();
+      $rootScope.$digest();
+    });
+
+    it('falls back on proj4js on error for LV95 to LV03', function(done) {
+      var coordinates = [2620116.600000524, 1142771.299843073];
+      var url = buildUrl(lv95tolv03Url, coordinates);
+      $httpBackend.expectGET(url).respond(400);
+
+      gaReframe.get95To03(coordinates).then(function(coords) {
+        expect(coords).to.eql([620116.600001048, 142771.2996861463]);
+        done();
+      });
+      $httpBackend.flush();
+      $rootScope.$digest();
+    });
+  });
+});

--- a/test/specs/contextpopup/ContextPopupDirective.spec.js
+++ b/test/specs/contextpopup/ContextPopupDirective.spec.js
@@ -1,5 +1,5 @@
 describe('ga_contextpopup_directive', function() {
-  var element, handlers = {}, viewport, map, originalEvt, $rootScope;
+  var element, handlers = {}, viewport, map, originalEvt, $rootScope, gaReframe;
 
   beforeEach(function() {
 
@@ -30,12 +30,12 @@ describe('ga_contextpopup_directive', function() {
         '<div id="map"></div>' +
       '</div>');
 
-    inject(function(_$rootScope_, $compile) {
+    inject(function(_$rootScope_, _gaReframe_, $compile) {
       $rootScope = _$rootScope_;
+      gaReframe = _gaReframe_;
       map = new ol.Map({});
       $rootScope.map = map;
       $rootScope.options = {
-        lv03tolv95Url: '//api.example.com/reframe/lv03tolv95',
         heightUrl: '//api.geo.admin.ch/height',
         qrcodeUrl: '//api.geo.admin.ch/qrcodegenerator'
       };
@@ -89,6 +89,7 @@ describe('ga_contextpopup_directive', function() {
     });
 
     it('correctly handles map contextmenu events', function() {
+      var spy = sinon.spy(gaReframe, 'get03To95');
       var evt = $.Event('contextmenu');
       evt.coordinate = [661473, 188192];
       evt.pixel = [25, 50];
@@ -98,6 +99,7 @@ describe('ga_contextpopup_directive', function() {
       var tables = element.find('div.popover-content table');
       var tds = $(tables[0]).find('td');
 
+      expect(spy.callCount).to.eql(1);
       expect($(tds[0]).find('a').attr('href')).to.be('contextpopup_lv03_url');
       expect($(tds[2]).find('a').attr('href')).to.be('contextpopup_lv95_url');
       expect($(tds[1]).text()).to.be('661\'473.0, 188\'192.0');
@@ -129,6 +131,7 @@ describe('ga_contextpopup_directive', function() {
         $httpBackend.expectGET(expectedHeightUrl);
         $httpBackend.expectGET(expectedReframeUrl);
         $httpBackend.expectGET(expectedw3wUrl);
+        var spy = sinon.spy(gaReframe, 'get03To95');
         handlers.pointerdown(mapEvt);
 
         $timeout.flush();
@@ -140,6 +143,7 @@ describe('ga_contextpopup_directive', function() {
         var tables = element.find('div.popover-content table');
         var tds = $(tables[0]).find('td');
 
+        expect(spy.callCount).to.eql(1);
         expect($(tds[0]).find('a').attr('href')).to.be('contextpopup_lv03_url');
         expect($(tds[2]).find('a').attr('href')).to.be('contextpopup_lv95_url');
         expect($(tds[1]).text()).to.be('661\'473.0, 188\'192.0');
@@ -152,12 +156,14 @@ describe('ga_contextpopup_directive', function() {
 
         // Make sure there aren't any timouts left (this might
         // compenstate for a bug in angular.mock or angular in general)
+        var spy = sinon.spy(gaReframe, 'get03To95');
         $timeout.flush();
         handlers.pointerdown(mapEvt);
         handlers.pointerup(mapEvt);
         $timeout.verifyNoPendingTasks();
 
         var popover = element.find('.popover');
+        expect(spy.callCount).to.eql(0);
         expect(popover.css('display')).to.be('');
       });
 
@@ -165,6 +171,7 @@ describe('ga_contextpopup_directive', function() {
 
         // Make sure there aren't any timouts left (this might
         // compenstate for a bug in angular.mock or angular in general)
+        var spy = sinon.spy(gaReframe, 'get03To95');
         $timeout.flush();
         handlers.pointerdown(mapEvt);
         handlers.pointermove({
@@ -173,6 +180,7 @@ describe('ga_contextpopup_directive', function() {
         $timeout.verifyNoPendingTasks();
 
         var popover = element.find('.popover');
+        expect(spy.callCount).to.eql(0);
         expect(popover.css('display')).to.be('');
       });
     });


### PR DESCRIPTION
[test link](https://mf-geoadmin3.int.bgdi.ch/gal_reframe/index.html)

When looking for a coordinate in LV95 we then transform it to LV03 using proj4js.
Neverthless, this transformation is rather inaccurate and we had costumers complain about it via webgis feedback.

This PR introduces a reframe service for transformations from

- lv03 to lv95
- lv95 to lv03

using geodesy service.

If the service doesn't work for any reason, we simply fallback to the transformation using proj4js.

Before (no reframe via search):

![no_reframe](https://cloud.githubusercontent.com/assets/3306154/22113663/4eb929be-de67-11e6-8d1c-8d68141eef6d.PNG)

After (with reframe via search):

![with_reframe](https://cloud.githubusercontent.com/assets/3306154/22113672/5e419f38-de67-11e6-87d9-f6f0d154618f.PNG)


