### PR TITLE
Fix part of #3693: The no info popup is no longer displayed if a vect…

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -396,6 +396,7 @@ goog.require('ga_topic_service');
               var mapRes = map.getView().getResolution();
               var mapProj = map.getView().getProjection();
               var pixel = map.getPixelFromCoordinate(coordinate);
+              var all = []; // List of promises launched
               var layersToQuery = getLayersToQuery(map);
 
               // When 3d is Active we use the cesium native function to get the
@@ -407,6 +408,7 @@ goog.require('ga_topic_service');
                    var prim = pickedObjects[i].primitive;
                    if (isFeatureQueryable(prim.olFeature)) {
                      showVectorFeature(prim.olFeature, prim.olLayer);
+                     all.push($q.when(1));
                      break;
                    }
                 }
@@ -417,23 +419,19 @@ goog.require('ga_topic_service');
                   var feature = findVectorFeature(map, pixel, layerToQuery);
                   if (feature) {
                     showVectorFeature(feature, layerToQuery);
+                    all.push($q.when(1));
                   }
                 });
               }
 
-              var all = []; // List of promises launched
-
               // Go through all queryable bod layers.
               // Launch identify requests.
               layersToQuery.bodLayers.forEach(function(layerToQuery) {
+                var config = gaLayers.getLayer(layerToQuery.bodId);
                 var geometry = new ol.geom.Point(coordinate);
-                var returnGeometry = !!gaLayers.getLayerProperty(
-                    layerToQuery.bodId, 'highlightable');
-                var shopLayer = (gaLayers.getLayerProperty(
-                    layerToQuery.bodId, 'shop') && !gaLayers.getLayerProperty(
-                    layerToQuery.bodId, 'shopMulti'));
-                var shopMultiLayer = gaLayers.getLayerProperty(
-                    layerToQuery.bodId, 'shopMulti');
+                var returnGeometry = !!config.highlightable;
+                var shopLayer = config.shop && !config.shopMulti;
+                var shopMultiLayer = config.shopMulti;
 
                 var limit = shopMultiLayer ? 10 : null;
                 var order = limit ? 'distance' : null;


### PR DESCRIPTION
…or feature is selected

[Before](https://map.geo.admin.ch/index.html?X=211791.12&Y=705905.01&zoom=8.949734757417549&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers_opacity=0.3,0.3,0.3,0.5,1,1&layers=ch.bafu.wrz-jagdbanngebiete_select,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.hangneigung-ueber_30,ch.swisstopo-karto.skitouren,ch.bav.haltestellen-oev,KML%7C%7Chttp:%2F%2Fwww.skitourenguru.ch%2Fcalc_data%2Fkml%2FSwitzerland_RiskSymbol079.kml&layers_visibility=false,true,true,true,false,true)

[After](https://mf-geoadmin3.int.bgdi.ch/teo_tooltip/index.html?X=211791.12&Y=705905.01&zoom=8.949734757417549&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers_opacity=0.3,0.3,0.3,0.5,1,1&layers=ch.bafu.wrz-jagdbanngebiete_select,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.hangneigung-ueber_30,ch.swisstopo-karto.skitouren,ch.bav.haltestellen-oev,KML%7C%7Chttp:%2F%2Fwww.skitourenguru.ch%2Fcalc_data%2Fkml%2FSwitzerland_RiskSymbol079.kml&layers_visibility=false,true,true,true,false,true)


How to:

  1) Click on the icon
  2) The tootlip shouldn't be close after 5 secs

Fix #3693 