### PR TITLE
Manage if bg is not yet loaded

### DIFF
--- a/src/js/GaCesium.js
+++ b/src/js/GaCesium.js
@@ -172,7 +172,7 @@ var GaCesium = function(map, gaPermalink, gaLayers, gaGlobalOptions,
   };
 
   var manageTilesets = function(primitives, scene, bg) {
-    var show = !/^voidLayer$/.test(bg.id);
+    var show = !bg || !/^voidLayer$/.test(bg.id);
     primitives.forEach(function(prim) {
       if (!scene.primitives.contains(prim)) {
         scene.primitives.add(prim);


### PR DESCRIPTION
[test](https://mf-geoadmin3.int.bgdi.ch/fix_3694/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&dev3d=true&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&lon=7.89741&lat=46.60055&elevation=9535&heading=359.752&pitch=-45.555)

@davidoesch is this version better with IE11 ?