### PR TITLE
Add default empty style and debug function when property based style is not found

### DIFF
--- a/src/components/StylesFromLiteralsService.js
+++ b/src/components/StylesFromLiteralsService.js
@@ -6,7 +6,7 @@ goog.provide('ga_stylesfromliterals_service');
 
   module.provider('gaStylesFromLiterals', function() {
 
-    this.$get = function() {
+    this.$get = function($window) {
 
       function getOlStyleForPoint(options, shape) {
         if (shape === 'circle') {
@@ -121,6 +121,8 @@ goog.provide('ga_stylesfromliterals_service');
 
         this.defaultVal = 'defaultVal';
 
+        this.defaultStyle = new ol.style.Style();
+
         this.styles = {
           point: {},
           line: {},
@@ -211,6 +213,13 @@ goog.provide('ga_stylesfromliterals_service');
         return olStyle;
       };
 
+      olStyleForPropertyValue.prototype.alertDebug_ = function(value, id) {
+        value = value === '' ? '<empty string>' : value;
+        $window.alert('Feature ID: ' + id + '. No matching style found ' +
+            'for key ' + this.key + ' and value ' + value + '.');
+        return this.defaultStyle;
+      };
+
       olStyleForPropertyValue.prototype.getFeatureStyle = function(feature,
           resolution) {
         if (this.type === 'single') {
@@ -229,6 +238,9 @@ goog.provide('ga_stylesfromliterals_service');
           value = value !== undefined ? value : this.defaultVal;
           var geomType = getGeomTypeFromGeometry(feature.getGeometry());
           var olStyles = this.styles[geomType][value];
+          if (!olStyles) {
+            return this.alertDebug_(value, feature.getId());
+          }
           var res = this.getOlStyleForResolution_(olStyles, resolution);
           var labelProperty = res.labelProperty;
           if (labelProperty) {
@@ -241,6 +253,9 @@ goog.provide('ga_stylesfromliterals_service');
           var value = properties[this.key];
           var geomType = getGeomTypeFromGeometry(feature.getGeometry());
           var olStyles = this.findOlStyleInRange_(value, geomType);
+          if (!olStyles) {
+            return this.alertDebug_(value, feature.getId());
+          }
           var res = this.getOlStyleForResolution_(olStyles, resolution);
           var labelProperty = res.labelProperty;
           if (labelProperty) {

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -747,6 +747,23 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
       expect(olImage.getStroke().getColor()).to.equal('#F55555');
       expect(olImage.getStroke().getWidth()).to.equal(2);
+
+      olFeature = geoJsonFormat.readFeature(
+        '{"type": "Feature",' +
+          '"geometry": {' +
+            '"coordinates": [' +
+              '11000,' +
+              '21000' +
+            '],' +
+            '"type": "Point"' +
+          '},' +
+          '"properties": {' +
+            '"foo": 1000' +
+          '}}'
+      );
+      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olImage = olStyle.getImage();
+      expect(olStyle.getImage()).to.equal(null);
     });
 
     it('supports range type style assignment resolution dependent', function() {
@@ -856,6 +873,23 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
       expect(olImage.getStroke().getColor()).to.equal('#F55555');
       expect(olImage.getStroke().getWidth()).to.equal(2);
+
+      olFeature = geoJsonFormat.readFeature(
+        '{"type": "Feature",' +
+          '"geometry": {' +
+            '"coordinates": [' +
+              '11000,' +
+              '21000' +
+            '],' +
+            '"type": "Point"' +
+          '},' +
+          '"properties": {' +
+            '"foo": 1000' +
+          '}}'
+      );
+      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olImage = olStyle.getImage();
+      expect(olStyle.getImage()).to.equal(null);
     });
   });
 });


### PR DESCRIPTION
This is mainly to detect errors in data or style configuration when integrating a geojson layer.

This follows the comments made by @rebert and @Sgachet .

Fix for https://github.com/geoadmin/mf-chsdi3/issues/2463

[Test Link](https://mf-geoadmin3.int.bgdi.ch/gal_vector/index.html?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fgas_hydroweb_grundwasserzustand&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-grau&X=110287.54&Y=632740.86&zoom=3&layers=ch.bafu.hydroweb-messstationen_grundwasserzustand)