### PR TITLE
Removing features with invalid geometries before printing

### DIFF
--- a/src/components/GeomUtilsService.js
+++ b/src/components/GeomUtilsService.js
@@ -21,6 +21,15 @@ goog.provide('ga_geomutils_service');
       }
     };
 
+    // Ensure valid linear ring
+    var isValidLinearRing = function(linearRing) {
+      var coords = linearRing.getCoordinates();
+      if (coords.length <= 3) {
+         return false;
+      }
+      return true;
+    };
+
     // Ensure polygon is closed
     var closePolygon = function(polygon) {
       var coords = [];
@@ -100,8 +109,10 @@ goog.provide('ga_geomutils_service');
             } else if (geometry instanceof ol.geom.Polygon) {
                isValid = isValidMultiGeom(this, geometry,
                    geometry.getLinearRings());
-            } else if (geometry instanceof ol.geom.LinearRing ||
-                geometry instanceof ol.geom.LineString) {
+            } else if (geometry instanceof ol.geom.LinearRing) {
+              isValid = isValidLinearRing(geometry) &&
+                !this.hasUniqueCoord(geometry.getCoordinates());
+            } else if (geometry instanceof ol.geom.LineString) {
               isValid = !this.hasUniqueCoord(geometry.getCoordinates());
             }
             if (!isValid) {

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -331,8 +331,28 @@ goog.require('ga_urlutils_service');
               styles = ol.style.Style.defaultFunction(feature);
             }
           }
-
+          // Removing feature with invalid geometries
           var geometry = feature.getGeometry();
+          var polygons = [];
+          if (geometry.getType() == 'MultiPolygon') {
+            polygons = geometry.getPolygons();
+          }
+          if (geometry.getType() == 'Polygon') {
+            polygons[0] = geometry;
+          }
+          for (var ii = 0, max = polygons.length; ii < max; ii++) {
+            var polygon = polygons[ii];
+            var coordinates = polygon.getCoordinates();
+            for (var jj = 0, max = coordinates.length; jj < max; jj++) {
+              var ring = coordinates[jj];
+              if (ring.length < 4) {
+                return {
+                  encFeatures: [],
+                  encStyles: []
+                };
+              }
+            }
+          }
           var styleToEncode;
           if (styles && styles.length > 0) {
             styleToEncode = styles[0];

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -331,28 +331,7 @@ goog.require('ga_urlutils_service');
               styles = ol.style.Style.defaultFunction(feature);
             }
           }
-          // Removing feature with invalid geometries
           var geometry = feature.getGeometry();
-          var polygons = [];
-          if (geometry.getType() == 'MultiPolygon') {
-            polygons = geometry.getPolygons();
-          }
-          if (geometry.getType() == 'Polygon') {
-            polygons[0] = geometry;
-          }
-          for (var ii = 0, max = polygons.length; ii < max; ii++) {
-            var polygon = polygons[ii];
-            var coordinates = polygon.getCoordinates();
-            for (var jj = 0, max = coordinates.length; jj < max; jj++) {
-              var ring = coordinates[jj];
-              if (ring.length < 4) {
-                return {
-                  encFeatures: [],
-                  encStyles: []
-                };
-              }
-            }
-          }
           var styleToEncode;
           if (styles && styles.length > 0) {
             styleToEncode = styles[0];

--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -583,8 +583,9 @@ describe('ga_kml_service', function() {
         $rootScope.$digest();
       });
 
-      it('don\'t remove geometries with good coordinates, at least 2 (#3334)', function(done) {
-        var uniqCoords = '<coordinates>1,0,0 2,0,0</coordinates>';
+      // Note: a 2 points LinearRing is not a valid geometry
+      it('don\'t remove geometries with good coordinates, at least 4 (#3334)', function(done) {
+        var uniqCoords = '<coordinates>1,0,0 2,0,0 2,2,0 1,0,0</coordinates>';
         var linearRing = '<LinearRing>' + uniqCoords + '</LinearRing>';
         var polygon = '<Polygon>' +
             '<outerBoundaryIs>' + linearRing + '</outerBoundaryIs>' +


### PR DESCRIPTION
Trying to fix https://github.com/geoadmin/mf-geoadmin3/issues/3714

The application is sending invalid GeoJSON geometries to the print server. For the record, the [GeoJSON format](https://tools.ietf.org/html/rfc7946)

The following [KML](https://www.procrastinatio.org/kml/2points-multipolygons.kml) has invalid (multi)polygons

On prod, this KML makes print crash:
https://s.geo.admin.ch/71bfa62ee8

With this PR, invalid geometries are removed:

https://mf-geoadmin3.int.bgdi.ch/mom_geom_valid

https://mf-chsdi3.int.bgdi.ch/shorten/71bfa870ae

