### PR TITLE
Test CORS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ LAST_PUBLIC_URL := $(shell if [ -f .build-artefacts/last-public-url ];  then cat
 PRINT_URL ?= //print.geo.admin.ch
 PRINT_TECH_URL ?= //service-print.
 LAST_PRINT_URL := $(shell if [ -f .build-artefacts/last-print-url ]; then cat .build-artefacts/last-print-url 2> /dev/null; else echo '-none-'; fi)
+PROXY_URL ?= //service-proxy.prod.bgdi.ch
+LAST_PROXY_URL ?= $(shell if [ -f .build-artefacts/last-proxy-ulr ]; then cat .build-artefacts/last-proxy-url 2> /dev/null; else echo '-none-'; fi)
 
 PUBLIC_URL_REGEXP ?= ^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*
 ADMIN_URL_REGEXP ?= ^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)
@@ -52,10 +54,10 @@ GIT_BRANCH := $(shell if [ -f .build-artefacts/deployed-git-branch ]; then cat .
 GIT_LAST_BRANCH := $(shell if [ -f .build-artefacts/last-git-branch ]; then cat .build-artefacts/last-git-branch 2> /dev/null; else echo 'dummy'; fi)
 BRANCH_TO_DELETE ?=
 DEPLOY_ROOT_DIR := /var/www/vhosts/mf-geoadmin3/private/branch
-OL_VERSION ?= v4.1.0 # v4.1.0, 14 april 2017
-OL_CESIUM_VERSION ?= v1.26 # v1.26, 4 april 2017
-CESIUM_VERSION ?= a2c421d39ac3f43b047681049dd517f489747a72 # camptocamp/c2c_patches_vector_tiles_labels, 20 april 2017
-NGEO_VERSION ?= 3ecccd0c805ccf29dc8fe406dd4309bd292d50c8 # master, 16 january 2017
+OL_VERSION ?= v4.1.0 # v4.1.0, April 14 2017
+OL_CESIUM_VERSION ?= v1.26 # # v1.26, April 4 2017
+CESIUM_VERSION ?= a2c421d39ac3f43b047681049dd517f489747a72 # camptocamp/c2c_patches_vector_tiles_labels, April 20 2017
+NGEO_VERSION ?= 4f3430b4d27bb0a7e2f0c7356fbcca8f134991e5 # master, April 27 2017
 DEFAULT_TOPIC_ID ?= ech
 TRANSLATION_FALLBACK_CODE ?= de
 LANGUAGES ?= '[\"de\", \"fr\", \"it\", \"en\", \"rm\"]'
@@ -460,10 +462,7 @@ prd/geoadmin.appcache: src/geoadmin.mako.appcache \
 	    --var "deploy_target=$(DEPLOY_TARGET)" \
 	    --var "apache_base_path=$(APACHE_BASE_PATH)" \
 	    --var "languages=$(LANGUAGES)" \
-	    --var "api_url=$(API_URL)" \
-	    --var "print_url=$(PRINT_URL)" \
-	    --var "s3basepath=$(S3_BASE_PATH)" \
-	    --var "public_url=$(PUBLIC_URL)" $< > $@
+	    --var "s3basepath=$(S3_BASE_PATH)" $< > $@
 	mv $@ prd/geoadmin.$(VERSION).appcache
 
 prd/cache/: .build-artefacts/last-version \
@@ -494,6 +493,7 @@ define buildpage
 		--var "api_tech_url=$(API_TECH_URL)" \
 		--var "print_url=$(PRINT_URL)" \
 		--var "print_tech_url=$(PRINT_TECH_URL)" \
+		--var "proxy_url=$(PROXY_URL)" \
 		--var "mapproxy_url=$(MAPPROXY_URL)" \
 		--var "mapproxy_tech_url=$(MAPPROXY_TECH_URL)" \
 		--var "vectortiles_url=$(VECTORTILES_URL)" \
@@ -544,6 +544,7 @@ prd/index.html: src/index.mako.html \
 	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-public-url \
 	    .build-artefacts/last-print-url \
+	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
@@ -560,6 +561,7 @@ prd/mobile.html: src/index.mako.html \
 	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-public-url \
 	    .build-artefacts/last-print-url \
+	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
@@ -575,6 +577,7 @@ prd/embed.html: src/index.mako.html \
 	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-public-url \
 	    .build-artefacts/last-print-url \
+	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
@@ -617,6 +620,7 @@ src/index.html: src/index.mako.html \
 	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-public-url \
 	    .build-artefacts/last-print-url \
+	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,desktop,,,,$(S3_SRC_BASE_PATH))
 
@@ -629,6 +633,7 @@ src/mobile.html: src/index.mako.html \
 	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-public-url \
 	    .build-artefacts/last-print-url \
+	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,mobile,,,,$(S3_SRC_BASE_PATH))
 
@@ -641,6 +646,7 @@ src/embed.html: src/index.mako.html \
 	    .build-artefacts/last-wms-url \
 	    .build-artefacts/last-public-url \
 	    .build-artefacts/last-print-url \
+	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,embed,,,,$(S3_SRC_BASE_PATH))
 
@@ -653,16 +659,14 @@ src/TemplateCacheModule.js: src/TemplateCacheModule.mako.js \
 
 apache/app.conf: apache/app.mako-dot-conf \
 	    ${MAKO_CMD} \
-	    .build-artefacts/last-api-url \
 	    .build-artefacts/last-apache-base-path \
 	    .build-artefacts/last-apache-base-directory \
+	    .build-artefacts/last-api-url \
 	    .build-artefacts/last-version
 	${PYTHON_CMD} ${MAKO_CMD} \
 	    --var "apache_base_path=$(APACHE_BASE_PATH)" \
-	    --var "api_url=$(API_URL)" \
-	    --var "print_url=$(PRINT_URL)" \
-	    --var "public_url=$(PUBLIC_URL)" \
 	    --var "apache_base_directory=$(APACHE_BASE_DIRECTORY)" \
+	    --var "api_url=$(API_URL)" \
 	    --var "version=$(VERSION)" $< > $@
 
 test/karma-conf-debug.js: test/karma-conf.mako.js ${MAKO_CMD}
@@ -799,6 +803,10 @@ ${PYTHON_VENV}:
 	mkdir -p $(dir $@)
 	test "$(PRINT_URL)" != "$(LAST_PRINT_URL)" && echo $(PRINT_URL) > .build-artefacts/last-print-url || :
 
+.build-artefacts/last-proxy-url::
+	mkdir -p $(dir $@)
+	test "$(PROXY_URL)" != "$(LAST_PROXY_URL)" && echo $(PROXY_URL) > .build-artefacts/last-proxy-url || :
+
 .build-artefacts/last-apache-base-path::
 	mkdir -p $(dir $@)
 	test "$(APACHE_BASE_PATH)" != "$(LAST_APACHE_BASE_PATH)" && \
@@ -855,3 +863,5 @@ clean:
 	rm -f src/mobile.html
 	rm -f src/embed.html
 	rm -rf prd
+	rm -rf src/ngeo
+	git submodule update --init

--- a/rc_dev
+++ b/rc_dev
@@ -8,4 +8,5 @@ export VECTORTILES_URL=//vectortiles{s}.dev.bgdi.ch
 export WMS_URL=//wms-bgdi.dev.bgdi.ch
 export SHOP_URL=//shop-bgdi.dev.bgdi.ch
 export PUBLIC_URL=//public.dev.bgdi.ch
-export PRINT_URL=//service-print.dev.ch
+export PRINT_URL=//service-print.dev.bgdi.ch
+export PROXY_URL=//service-proxy.dev.bgdi.ch

--- a/rc_int
+++ b/rc_int
@@ -9,4 +9,5 @@ export VECTORTILES_URL=//vectortiles{s}.int.bgdi.ch
 export WMS_URL=//wms-bgdi.int.bgdi.ch
 export SHOP_URL=//shop-bgdi.int.bgdi.ch
 export PUBLIC_URL=//public.int.bgdi.ch
-export PRINT_URL=//service-print.int.ch
+export PRINT_URL=//service-print.int.bgdi.ch
+export PROXY_URL=//service-proxy.dev.bgdi.ch

--- a/rc_prod
+++ b/rc_prod
@@ -10,3 +10,4 @@ export WMS_URL=//wms.geo.admin.ch
 export SHOP_URL=//shop.swisstopo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export PRINT_URL=//print.geo.admin.ch
+export PROXY_URL=//service-proxy.prod.bgdi.ch

--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -5,7 +5,7 @@ goog.provide('ga_urlutils_service');
 
   module.provider('gaUrlUtils', function() {
 
-    this.$get = function(gaGlobalOptions, $http, $window) {
+    this.$get = function(gaGlobalOptions, $http, $q, $window) {
 
       var UrlUtils = function(shortenUrl) {
 
@@ -38,7 +38,7 @@ goog.provide('ga_urlutils_service');
           return (this.isValid(url) && /^https/.test(url));
         };
 
-        // Test if URL represents resource that needs to pass via ogcProxy
+        // Test if URL represents resource that needs to pass via proxy
         this.needsProxy = function(url) {
           if (this.isBlob(url)) {
             return false;
@@ -48,11 +48,56 @@ goog.provide('ga_urlutils_service');
                   /.*kmz$/.test(url));
         };
 
-        this.proxifyUrl = function(url) {
+        // Test using a head request if the remote resource enables CORS
+        this.isCorsEnabled = function(url) {
+          return $http.head(url, { timeout: 1500 });
+        };
+
+        this.buildProxyUrl = function(url) {
+          if (!this.isValid(url)) {
+            return url;
+          }
+          var parts = /^(http|https)(:\/\/)(.+)/.exec(url);
+          var protocol = parts[1];
+          var resource = parts[3];
+          // proxy is RESTFful, <service>/<protocol>/<resource>
+          return gaGlobalOptions.proxyUrl + protocol + '/' +
+              encodeURIComponent(resource);
+        };
+
+        this.proxifyUrlInstant = function(url) {
           if (this.needsProxy(url)) {
-            return gaGlobalOptions.ogcproxyUrl + encodeURIComponent(url);
+            return this.buildProxyUrl(url);
           }
           return url;
+        };
+
+        this.getCesiumProxy = function() {
+          var that = this;
+          return {
+            getURL: function(resource) {
+              if (that.needsProxy(resource)) {
+                return that.buildProxyUrl(resource);
+              }
+              return resource;
+            }
+          };
+        };
+
+        this.proxifyUrl = function(url) {
+          var that = this;
+          var deferred = $q.defer();
+          if (!this.isBlob(url) && this.isHttps(url) &&
+              !this.isAdminValid(url) && !/.*kmz$/.test(url)) {
+            this.isCorsEnabled(url).then(function(enabled) {
+              deferred.resolve(url);
+            }, function() {
+              deferred.resolve(that.buildProxyUrl(url));
+            });
+          } else {
+            deferred.resolve(this.proxifyUrlInstant(url));
+          }
+          return deferred.promise;
         };
 
         this.shorten = function(url, timeout) {

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -779,7 +779,7 @@ goog.require('ga_urlutils_service');
           var dsP = Cesium.KmlDataSource.load(config3d.url, {
             camera: scene.camera,
             canvas: scene.canvas,
-            proxy: new Cesium.DefaultProxy(gaGlobalOptions.ogcproxyUrl)
+            proxy: gaUrlUtils.getCesiumProxy()
           });
           return dsP;
         };
@@ -915,13 +915,14 @@ goog.require('ga_urlutils_service');
               extent: extent
             });
             var setLayerSource = function() {
-              var fullUrl = gaUrlUtils.proxifyUrl(layer.geojsonUrl);
               var geojsonFormat = new ol.format.GeoJSON();
-              $http.get(fullUrl).then(function(response) {
-                olSource.clear();
-                olSource.addFeatures(
-                  geojsonFormat.readFeatures(response.data)
-                );
+              gaUrlUtils.proxifyUrl(layer.geojsonUrl).then(function(proxyUrl) {
+                $http.get(proxyUrl).then(function(response) {
+                  olSource.clear();
+                  olSource.addFeatures(
+                    geojsonFormat.readFeatures(response.data)
+                  );
+                });
               });
             };
 

--- a/src/components/map/RealtimeLayersService.js
+++ b/src/components/map/RealtimeLayersService.js
@@ -18,20 +18,21 @@ goog.require('ga_map_service');
 
       function setLayerSource(layer) {
         var olSource = layer.getSource();
-        var fullUrl = gaUrlUtils.proxifyUrl(layer.geojsonUrl);
-        $http.get(fullUrl).then(function(response) {
-          var data = response.data;
-          olSource.clear();
-          olSource.addFeatures(
-            geojsonFormat.readFeatures(data)
-          );
-          if (!layer.preview) {
-            var layerIdIndex = realTimeLayersId.indexOf(layer.bodId);
-            timers[layerIdIndex] = setLayerUpdateInterval(layer);
-            if (data.timestamp) {
-              $rootScope.$broadcast('gaNewLayerTimestamp', data.timestamp);
+        gaUrlUtils.proxifyUrl(layer.geojsonUrl).then(function(proxyUrl) {
+          $http.get(proxyUrl).then(function(response) {
+            var data = response.data;
+            olSource.clear();
+            olSource.addFeatures(
+              geojsonFormat.readFeatures(data)
+            );
+            if (!layer.preview) {
+              var layerIdIndex = realTimeLayersId.indexOf(layer.bodId);
+              timers[layerIdIndex] = setLayerUpdateInterval(layer);
+              if (data.timestamp) {
+                $rootScope.$broadcast('gaNewLayerTimestamp', data.timestamp);
+              }
             }
-          }
+          });
         });
       }
 

--- a/src/components/map/WmsService.js
+++ b/src/components/map/WmsService.js
@@ -22,14 +22,6 @@ goog.require('ga_urlutils_service');
 
       var getCesiumImageryProvider = function(layer) {
         var params = layer.getSource().getParams();
-        var proxy;
-        if (!gaUrlUtils.isAdminValid(layer.url)) {
-          proxy = {
-            getURL: function(resource) {
-               return gaUrlUtils.proxifyUrl(resource);
-            }
-          };
-        }
         var wmsParams = {
           layers: params.LAYERS,
           format: params.FORMAT || 'image/png',
@@ -57,7 +49,7 @@ goog.require('ga_urlutils_service');
           minimumRetrievingLevel: window.minimumRetrievingLevel,
           url: gaUrlUtils.append(layer.url, gaUrlUtils.toKeyValue(wmsParams)),
           rectangle: gaMapUtils.extentToRectangle(extent),
-          proxy: proxy,
+          proxy: gaUrlUtils.getCesiumProxy(),
           tilingScheme: new Cesium.GeographicTilingScheme(),
           hasAlphaChannel: true,
           availableLevels: window.imageryAvailableLevels

--- a/src/components/offline/OfflineService.js
+++ b/src/components/offline/OfflineService.js
@@ -468,8 +468,10 @@ goog.require('ga_styles_service');
             // if the layer is a KML
             if (gaMapUtils.isKmlLayer(layer) &&
                 /^https?:\/\//.test(layer.url)) {
-              $http.get(gaUrlUtils.proxifyUrl(layer.url)).then(function(resp) {
-                gaStorage.setItem(layer.id, resp.data);
+              gaUrlUtils.proxifyUrl(layer.url).then(function(url) {
+                $http.get(url).then(function(resp) {
+                  gaStorage.setItem(layer.id, resp.data);
+                });
               });
               layersBg.push(false);
               continue;

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -468,22 +468,23 @@ goog.require('ga_topic_service');
                     sourceProj || mapProj,
                     {'INFO_FORMAT': 'text/plain', 'LANG': gaLang.get()});
                 if (!is3dActive() && url) {
-                  url = gaUrlUtils.proxifyUrl(url);
-                  all.push($http.get(url, {
-                    timeout: canceler.promise,
-                    layer: layerToQuery
-                  }).then(function(response) {
-                    var text = response.data;
-                    if (/(Server Error|ServiceException)/.test(text)) {
-                      return 0;
-                    }
-                    var feat = new ol.Feature({
-                      geometry: null,
-                      description: '<pre>' + text + '</pre>'
-                    });
-                    showVectorFeature(feat, response.config.layer);
-                    return 1;
-                  }));
+                  gaUrlUtils.proxifyUrl(url).then(function(proxyUrl) {
+                    all.push($http.get(proxyUrl, {
+                      timeout: canceler.promise,
+                      layer: layerToQuery
+                    }).then(function(response) {
+                      var text = response.data;
+                      if (/(Server Error|ServiceException)/.test(text)) {
+                        return 0;
+                      }
+                      var feat = new ol.Feature({
+                        geometry: null,
+                        description: '<pre>' + text + '</pre>'
+                      });
+                      showVectorFeature(feat, response.config.layer);
+                      return 1;
+                    }));
+                  });
                 }
               });
 

--- a/src/geoadmin.mako.appcache
+++ b/src/geoadmin.mako.appcache
@@ -8,7 +8,7 @@
 # Version ${version}
 
 CACHE:
-${s3basepath}${version}/lib/build.js	
+${s3basepath}${version}/lib/build.js
 ${s3basepath}${version}/style/app.css
 ${s3basepath}${version}/style/font-awesome-4.5.0/font/fontawesome-webfont.woff
 ${s3basepath}${version}/services

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -790,6 +790,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         var shopUrl = setBackend(prtl + '${shop_url}', prtl + '${shop_tech_url}', 'shop_url');
         var publicUrl = setBackend(prtl + '${public_url}', prtl + '${public_tech_url}', 'public_url');
         var printUrl = setBackend(prtl + '${print_url}', prtl + '${print_tech_url}', 'print_url');
+        var proxyUrl = prtl + '${proxy_url}' + '/';
         var apiOverwrite = !!(getParam('api_url') || env);
         ngeo.baseModuleTemplateUrl = 'ngeo/src/modules';
         module.constant('gaGlobalOptions', {
@@ -801,6 +802,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           mapUrl: location.origin + pathname,
           apiUrl: apiUrl,
           printUrl: printUrl,
+          proxyUrl: proxyUrl,
           mapproxyUrl: mapproxyUrl,
           vectorTilesUrl: vectorTilesUrl,
           shopUrl: shopUrl,
@@ -810,7 +812,6 @@ itemscope itemtype="http://schema.org/WebApplication"
           cachedApiUrl: apiUrl + cacheAdd,
           cachedPrintUrl: printUrl + cacheAdd,
           resourceUrl: location.origin + s3pathname + '${versionslashed}',
-          ogcproxyUrl: apiUrl + '/ogcproxy?url=',
           wmsUrl: wmsUrl,
           w3wUrl: 'https://api.what3words.com',
           lv03tolv95Url: 'https://geodesy.geo.admin.ch/reframe/lv03tolv95',

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -9,6 +9,7 @@ beforeEach(function() {
     var apiUrl = '//api3.geo.admin.ch';
     var publicUrl = '//public.geo.admin.ch';
     var printUrl = '//print.geo.admin.ch';
+    var proxyUrl = '//proxy.geo.admin.ch';
     var mapproxyUrl = '//wmts{s}.geo.admin.ch';
     var shopUrl = '//shop.bgdi.ch';
     var wmsUrl = '//wms.geo.admin.ch';
@@ -33,7 +34,7 @@ beforeEach(function() {
       cachedApiUrl: location.protocol + apiUrl + cacheAdd,
       cachedPrintUrl: location.protocol + printUrl + cacheAdd,
       resourceUrl: location.origin + pathname + versionSlashed,
-      ogcproxyUrl: location.protocol + apiUrl + '/ogcproxy?url=',
+      proxyUrl: location.protocol + proxyUrl + '/',
       wmsUrl: location.protocol + wmsUrl,
       w3wUrl: 'dummy.test.url.com',
       lv03tolv95Url: '//api.example.com/reframe/lv03tolv95',

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -1,11 +1,12 @@
 describe('ga_urlutils_service', function() {
 
   describe('gaUrlUtils', function() {
-    var gaUrlUtils;
+    var gaUrlUtils, gaGlobalOptions;
 
     beforeEach(function() {
       inject(function($injector) {
         gaUrlUtils = $injector.get('gaUrlUtils');
+        gaGlobalOptions = $injector.get('gaGlobalOptions');
       });
     });
 
@@ -87,11 +88,74 @@ describe('ga_urlutils_service', function() {
       });
     });
 
-    describe('#proxifyUrl()', function() {
+    describe('#proxifyUrlInstant()', function() {
       it('applies proxy correctly', function() {
-        expect(gaUrlUtils.proxifyUrl('http://data.geo.admin.ch')).to.be(window.location.protocol + '//api3.geo.admin.ch/ogcproxy?url=http%3A%2F%2Fdata.geo.admin.ch');
-        expect(gaUrlUtils.proxifyUrl('https://data.geo.admin.ch')).to.be('https://data.geo.admin.ch');
-        expect(gaUrlUtils.proxifyUrl('blob:https://myblob.ch/7a910681-938c-4011-8d75-2b64035a40a7')).to.be('blob:https://myblob.ch/7a910681-938c-4011-8d75-2b64035a40a7');
+        expect(gaUrlUtils.proxifyUrlInstant('http://data.geo.admin.ch')).to.be(
+            gaGlobalOptions.proxyUrl + 'http/data.geo.admin.ch');
+        expect(gaUrlUtils.proxifyUrlInstant('https://data.geo.admin.ch')).to.be(
+            'https://data.geo.admin.ch');
+        expect(gaUrlUtils.proxifyUrlInstant('blob:https://myblob.ch/7a910681-938c-4011-8d75-2b64035a40a7')).to.be(
+            'blob:https://myblob.ch/7a910681-938c-4011-8d75-2b64035a40a7');
+      });
+    });
+
+    describe('#getCesiumProxy()', function() {
+      it('applies proxy correctly', function() {
+        var cProxy = gaUrlUtils.getCesiumProxy();
+        expect(cProxy.getURL('http://dummyresource.com')).to.be(
+            gaGlobalOptions.proxyUrl + 'http/dummyresource.com');
+        cProxy = gaUrlUtils.getCesiumProxy();
+        expect(cProxy.getURL('https://data.geo.admin.ch')).to.be(
+            'https://data.geo.admin.ch');
+      });
+    });
+
+    describe('#proxifyUrl()', function() {
+      var $rootScope, $httpBackend;
+      beforeEach(inject(function($injector) {
+        $httpBackend = $injector.get('$httpBackend');
+        $rootScope = $injector.get('$rootScope');
+      }));
+
+      it('applies a proxy correctly on http://data.geo.admin.ch', function(done) {
+        gaUrlUtils.proxifyUrl('http://data.geo.admin.ch').then(function(url) {
+          expect(url).to.be(gaGlobalOptions.proxyUrl + 'http/data.geo.admin.ch');
+          done();
+        });
+        $rootScope.$digest();
+      });
+
+      it('applies a proxy correctly on http://ineedaproxybadly.ch', function(done) {
+        gaUrlUtils.proxifyUrl('http://ineedaproxybadly.ch').then(function(url) {
+          expect(url).to.be(gaGlobalOptions.proxyUrl + 'http/ineedaproxybadly.ch');
+          done();
+        });
+        $rootScope.$digest();
+      });
+
+      it('does not apply a proxy on https://data.geo.admin.ch', function(done) {
+        gaUrlUtils.proxifyUrl('https://data.geo.admin.ch').then(function(url) {
+          expect(url).to.be('https://data.geo.admin.ch');
+          done();
+        });
+        $rootScope.$digest();
+      });
+
+      it('does not apply a proxy on blob:https://myblob.ch/7a910681-938c-4011-8d75-2b64035a40a7', function(done) {
+        gaUrlUtils.proxifyUrl('blob:https://myblob.ch/7a910681-938c-4011-8d75-2b64035a40a7').then(function(url) {
+          expect(url).to.be('blob:https://myblob.ch/7a910681-938c-4011-8d75-2b64035a40a7');
+          done();
+        });
+        $rootScope.$digest();
+      });
+
+      it('does not apply a proxy on https://corsenable.com/dummy.kml', function(done) {
+        $httpBackend.expectHEAD('https://corsenable.com/dummy.kml').respond(200, '');
+        gaUrlUtils.proxifyUrl('https://corsenable.com/dummy.kml').then(function(url) {
+          expect(url).to.be('https://corsenable.com/dummy.kml');
+          done();
+        });
+        $httpBackend.flush();
       });
     });
 

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -980,7 +980,7 @@ describe('ga_map_service', function() {
         expect(args[0]).to.be('http://foo.kml');
         expect(args[1].camera).to.be(scene.camera);
         expect(args[1].canvas).to.be(scene.canvas);
-        expect(args[1].proxy).to.be.an(Cesium.DefaultProxy);
+        expect(args[1].proxy.getURL('http://foo.kml')).to.be('http://proxy.geo.admin.ch/http/foo.kml');
         spy.restore();
       });
     });
@@ -1026,7 +1026,7 @@ describe('ga_map_service', function() {
           minResolution: 0.5,
           maxResolution: 100,
           opacity: 0.35,
-          geojsonUrl: 'https://my.json',
+          geojsonUrl: 'http://my.json',
           styleUrl: '//mystyle.json'
         }
       };
@@ -1140,7 +1140,7 @@ describe('ga_map_service', function() {
 
         it('returns a GeoJSON layer', function() {
           $httpBackend.expectGET('http://mystyle.json').respond({});
-          $httpBackend.expectGET(gaGlobalOptions.ogcproxyUrl + 'https%3A%2F%2Fmy.json').respond({
+          $httpBackend.expectGET(gaGlobalOptions.proxyUrl + 'http/my.json').respond({
             'features': [{
               'type': 'Feature',
               'geometry': {

--- a/test/specs/map/WmsService.spec.js
+++ b/test/specs/map/WmsService.spec.js
@@ -84,9 +84,11 @@ describe('ga_wms_service', function() {
       expect(prov.rectangle.north).to.be(0.8425581080106397);
 
       if (options.useThirdPartyData) {
-        expect(prov.proxy.getURL('a')).to.be(gaGlobalOptions.ogcproxyUrl + 'a');
+        expect(prov.proxy.getURL('http://wms.ch')).to.be(
+            gaGlobalOptions.proxyUrl + 'http/wms.ch');
       } else {
-        expect(prov.proxy).to.be(undefined);
+        expect(prov.proxy.getURL('https://wms.geo.admin.ch')).to.be(
+            'https://wms.geo.admin.ch');
       }
       expect(prov.tilingScheme).to.be.an(Cesium.GeographicTilingScheme);
       expect(prov.hasAlphaChannel).to.be(true);


### PR DESCRIPTION
With this PR it is now possible to load external resources in geoadmin without proxy, provided that:

1. It supports https
2. It supports CORS


[Test Link](https://mf-geoadmin3.int.bgdi.ch/gal_proxify/index.html)