### PR TITLE
Fix #3736: Use empty style instead of 'default'

### DIFF
--- a/src/components/map/WmsService.js
+++ b/src/components/map/WmsService.js
@@ -41,7 +41,7 @@ goog.require('ga_urlutils_service');
                 '{northProjected},{eastProjected}',
           width: '256',
           height: '256',
-          styles: params.STYLES || 'default',
+          styles: params.STYLES || '',
           transparent: 'true'
         };
 

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -1,11 +1,12 @@
 describe('ga_stylesfromliterals_service', function() {
 
   describe('gaStylesFromLiterals', function() {
-    var gaStylesFromLiterals;
+    var gaStylesFromLiterals, $window;
 
     beforeEach(function() {
       inject(function($injector) {
         gaStylesFromLiterals = $injector.get('gaStylesFromLiterals');
+        $window = $injector.get('$window');
       });
     });
 
@@ -761,9 +762,12 @@ describe('ga_stylesfromliterals_service', function() {
             '"foo": 1000' +
           '}}'
       );
+      var stub = sinon.stub($window, 'alert');
       olStyle = gaStyle.getFeatureStyle(olFeature);
       olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.equal(null);
+      expect(stub.calledWithExactly('Feature ID: undefined. No matching style found for key foo and value 1000.')).to.be(true);
+      stub.restore();
     });
 
     it('supports range type style assignment resolution dependent', function() {
@@ -887,9 +891,12 @@ describe('ga_stylesfromliterals_service', function() {
             '"foo": 1000' +
           '}}'
       );
+      var stub = sinon.stub($window, 'alert');
       olStyle = gaStyle.getFeatureStyle(olFeature);
       olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.equal(null);
+      expect(stub.calledWithExactly('Feature ID: undefined. No matching style found for key foo and value 1000.')).to.be(true);
+      stub.restore();
     });
   });
 });

--- a/test/specs/map/WmsService.spec.js
+++ b/test/specs/map/WmsService.spec.js
@@ -46,7 +46,7 @@ describe('ga_wms_service', function() {
       // Tests WMS params
       options.VERSION = options.VERSION || '1.3.0';
       options.FORMAT = options.FORMAT || 'image%2Fpng';
-      options.STYLES = options.STYLES || 'default';
+      options.STYLES = options.STYLES || '';
 
       var params = source.getParams();
       expect(params.LAYERS).to.be(options.LAYERS);


### PR DESCRIPTION
[Test](https://mf-geoadmin3.int.bgdi.ch/teo_fixes/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,WMS%7C%7CBAUZONEN_GR_HN%7C%7Chttp:%2F%2Fwms.stauffer-studach.ch:8091%2Fgeoserver%2Fwms%7C%7CDatenblatt:BAUZONEN_GR_HN%7C%7C1.3.0&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&lon=9.44278&lat=46.80274&elevation=7296&heading=358.995&pitch=-66.877)