### PR TITLE
Fix #3719: Don't remove features when the layer is removed

### DIFF
--- a/test/specs/measure/MeasureService.spec.js
+++ b/test/specs/measure/MeasureService.spec.js
@@ -708,15 +708,40 @@ describe('ga_measure_service', function() {
         expect(stubRm.called).to.be(false);
       });
 
-      it('removes overlays attached to features when the layer is removed', function() {
-        map.addLayer(layer);
-        gaMeasure.registerOverlaysEvents(map, layer);
-        map.removeLayer(layer);
-        expect(stubRm.calledTwice).to.be(true);
-        expect(stubRm.args[0][0]).to.be(feat2);
-        expect(stubRm.args[1][0]).to.be(feat1);
-        expect(feat1.get('overlays')).to.be(undefined);
-        expect(feat2.get('overlays')).to.be(undefined);
+      describe('add/removes overlays when the layer is added/removed', function() {
+
+        it('does nothing when the layer is not displayed in layers manager', function() {
+          map.addLayer(layer);
+          gaMeasure.registerOverlaysEvents(map, layer);
+          layer.setVisible(false);
+          expect(stubRm.called).to.be(false);
+        });
+
+        it('does nothing if features are not measure features', function() {
+          layer.displayInLayerManager = true;
+          map.addLayer(layer);
+          gaMeasure.registerOverlaysEvents(map, layer);
+          layer.setVisible(false);
+          expect(stubRm.called).to.be(false);
+        });
+
+        it('works', function() {
+          layer.displayInLayerManager = true;
+          layer.getSource().addFeatures([featMeas1, featMeas2]);
+          map.addLayer(layer);
+          gaMeasure.registerOverlaysEvents(map, layer);
+          expect(stubRm.called).to.be(false);
+
+          map.getLayers().pop();
+          expect(stubRm.calledTwice).to.be(true);
+          expect(stubRm.args[0][0]).to.be(featMeas1);
+          expect(stubRm.args[1][0]).to.be(featMeas2);
+
+          map.getLayers().insertAt(0, layer);
+          expect(stubAdd.calledTwice).to.be(true);
+          expect(stubAdd.getCall(0).calledWithExactly(map, layer, featMeas1)).to.be(true);
+          expect(stubAdd.getCall(1).calledWithExactly(map, layer, featMeas2)).to.be(true);
+        });
       });
 
       describe('add/removes overlays on visibility changes', function() {


### PR DESCRIPTION
Move up/down the layer "Dessin" from the layer manager:
[Before](https://map.geo.admin.ch/?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&layers=ch.swisstopo.zeitreihen,KML%7C%7Chttps:%2F%2Fpublic.int.bgdi.ch%2FdpndAGOOTtK0h7NNzz0KIw&layers_timestamp=18641231,) the layer disappeared

[After](https://mf-geoadmin3.int.bgdi.ch/teo_fixes/index.html?topic=ech&lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&layers=ch.swisstopo.zeitreihen,KML%7C%7Chttps:%2F%2Fpublic.int.bgdi.ch%2FdpndAGOOTtK0h7NNzz0KIw&layers_timestamp=18641231,) the layer still exists