### PR TITLE
Cloudfront headers and infra configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,10 @@ deploydev:
 		./scripts/deploydev.sh; \
 	fi
 
+.PHONY: s3deployinfra
+s3deployinfra: guard-SNAPSHOT guard-S3_MF_GEOADMIN3_INFRA .build-artefacts/requirements.timestamp
+	./scripts/deploysnapshot.sh $(SNAPSHOT) infra;
+
 .PHONY: s3deployint
 s3deployint: guard-SNAPSHOT guard-S3_MF_GEOADMIN3_INT .build-artefacts/requirements.timestamp
 	./scripts/deploysnapshot.sh $(SNAPSHOT) int;
@@ -256,6 +260,21 @@ s3deploybranch: guard-S3_MF_GEOADMIN3_INT \
 	./scripts/clonebuild.sh ${CLONEDIR} int ${DEPLOY_GIT_BRANCH} ${DEEP_CLEAN} ${NAMED_BRANCH};
 	${PYTHON_CMD} ./scripts/s3manage.py upload ${CLONEDIR}/mf-geoadmin3 int ${NAMED_BRANCH};
 
+.PHONY: s3deploybranchinfra
+s3deploybranchinfra: guard-S3_MF_GEOADMIN3_INFRA \
+	              guard-CLONEDIR \
+	              guard-DEPLOY_GIT_BRANCH \
+	              guard-DEEP_CLEAN \
+	              guard-NAMED_BRANCH \
+	              .build-artefacts/requirements.timestamp
+	./scripts/clonebuild.sh ${CLONEDIR} infra ${DEPLOY_GIT_BRANCH} ${DEEP_CLEAN} ${NAMED_BRANCH};
+	${PYTHON_CMD} ./scripts/s3manage.py upload ${CLONEDIR}/mf-geoadmin3 infra ${NAMED_BRANCH};
+
+
+.PHONY: s3listinfra
+s3listinfra: guard-S3_MF_GEOADMIN3_INFRA .build-artefacts/requirements.timestamp
+	${PYTHON_CMD} ./scripts/s3manage.py list infra;
+
 .PHONY: s3listint
 s3listint: guard-S3_MF_GEOADMIN3_INT .build-artefacts/requirements.timestamp
 	${PYTHON_CMD} ./scripts/s3manage.py list int;
@@ -263,6 +282,10 @@ s3listint: guard-S3_MF_GEOADMIN3_INT .build-artefacts/requirements.timestamp
 .PHONY: s3listprod
 s3listprod: guard-S3_MF_GEOADMIN3_PROD .build-artefacts/requirements.timestamp
 	${PYTHON_CMD} ./scripts/s3manage.py list prod;
+
+.PHONY: s3infoinfra
+s3infoinfra: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_INFRA .build-artefacts/requirements.timestamp
+	${PYTHON_CMD} ./scripts/s3manage.py info ${S3_VERSION_PATH} infra;
 
 .PHONY: s3infoint
 s3infoint: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_INT .build-artefacts/requirements.timestamp
@@ -272,6 +295,10 @@ s3infoint: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_INT .build-artefacts/requ
 s3infoprod: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_PROD .build-artefacts/requirements.timestamp
 	${PYTHON_CMD} ./scripts/s3manage.py info ${S3_VERSION_PATH} prod;
 
+.PHONY: s3activateinfra
+s3activateinfra: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_INFRA .build-artefacts/requirements.timestamp
+	${PYTHON_CMD} ./scripts/s3manage.py activate ${S3_VERSION_PATH} infra;
+
 .PHONY: s3activateint
 s3activateint: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_INT .build-artefacts/requirements.timestamp
 	${PYTHON_CMD} ./scripts/s3manage.py activate ${S3_VERSION_PATH} int;
@@ -279,6 +306,10 @@ s3activateint: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_INT .build-artefacts/
 .PHONY: s3activateprod
 s3activateprod: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_PROD .build-artefacts/requirements.timestamp
 	${PYTHON_CMD} ./scripts/s3manage.py activate ${S3_VERSION_PATH} prod;
+
+.PHONY: s3deleteinfra
+s3deleteinfra: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_INFRA .build-artefacts/requirements.timestamp
+	${PYTHON_CMD} ./scripts/s3manage.py delete ${S3_VERSION_PATH} infra;
 
 .PHONY: s3deleteint
 s3deleteint: guard-S3_VERSION_PATH guard-S3_MF_GEOADMIN3_INT .build-artefacts/requirements.timestamp

--- a/rc_infra
+++ b/rc_infra
@@ -1,0 +1,11 @@
+export KEEP_VERSION=true
+export DEPLOY_TARGET=int
+export E2E_TARGETURL=https://mf-geoadmin3.infra.bgdi.ch
+export APACHE_BASE_PATH=
+export VARNISH_HOSTS=(ip-10-220-6-234.eu-west-1.compute.internal ip-10-220-4-93.eu-west-1.compute.internal)
+export API_URL=//mf-chsdi3.int.bgdi.ch
+export MAPPROXY_URL=//wmts{s}.int.bgdi.ch
+export WMS_URL=//wms-bgdi.int.bgdi.ch
+export SHOP_URL=//shop-bgdi.int.bgdi.ch
+export PUBLIC_URL=//public.int.bgdi.ch
+export PRINT_URL=//service-print.int.ch

--- a/scripts/deploysnapshot.sh
+++ b/scripts/deploysnapshot.sh
@@ -6,7 +6,7 @@ T="$(date +%s)"
 set -o errexit
 
 # Check if snapshot parameter is supplied and there are 2 parameters
-if [ "$2" != "int" ] && [ "$2" != "prod" ]
+if [ "$2" != "int" ] && [ "$2" != "prod" ] && [ "$2" != "infra" ]
 then
   echo "Error: Please specify 1) snapshot directoy and 2) target."
   exit 1

--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -159,7 +159,7 @@ def _save_to_s3(in_data, dest, mimetype, bucket_name, compress=True, cached=True
         compressed = True
 
     if cached is False:
-        cache_control = 'no-cache'
+        cache_control = 'max-age=0, must-revalidate, s-maxage=60'
 
     extra_args['ACL'] = 'public-read'
     extra_args['ContentType'] = mimetype
@@ -459,7 +459,7 @@ def parse_arguments(argv):
     elif cmd_type in ('list'):
         deploy_target = argv[2].lower()
 
-    if deploy_target not in ('int', 'prod'):
+    if deploy_target not in ('infra', 'int', 'prod'):
         print('%s is not a valid deploy target' % deploy_target)
         sys.exit(1)
 


### PR DESCRIPTION
This PR adds an infra configuration to be able to deploy the application to the infra bucket in the same ways as int/prod.

It also changes the headers for the no-cache files (html, appcache, etc) to better work with CloudFront.

Old:
`Cache-Control: no-cache`
New:
`Cache-Control: max-age=0, must-revalidate, s-maxage=60`

The desired effect is that
a) browser never cache it (max-age=0 and must-revalidate)
b) Cloudfront (or other shared caches) can cache it for 1 minute.

Note that a ctrl-F5 should even prevent getting the data from cloudfront.

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_cf/index.html)