### PR TITLE
Handle contextmenu and touchevents correctly

### DIFF
--- a/src/components/BrowserSnifferService.js
+++ b/src/components/BrowserSnifferService.js
@@ -72,8 +72,7 @@ goog.require('ga_permalink');
           move: 'mousemove',
           end: 'mouseup',
           over: 'mouseover',
-          out: 'mouseout',
-          menu: 'contextmenu'
+          out: 'mouseout'
         },
         touch: {
           start: 'touchstart',
@@ -85,16 +84,14 @@ goog.require('ga_permalink');
           move: 'MSPointerMove',
           end: 'MSPointerUp',
           over: 'MSPointerOver',
-          out: 'MSPointerOut',
-          menu: 'contextmenu'
+          out: 'MSPointerOut'
         },
         pointer: {
           start: 'pointerdown',
           move: 'pointermove',
           end: 'pointerup',
           over: 'pointerover',
-          out: 'pointerout',
-          menu: 'contextmenu'
+          out: 'pointerout'
         }
       };
 

--- a/src/components/EventService.js
+++ b/src/components/EventService.js
@@ -1,0 +1,22 @@
+goog.provide('ga_event_service');
+
+(function() {
+
+  var module = angular.module('ga_event_service', []);
+
+  module.provider('gaEvent', function() {
+    this.$get = function() {
+      var MOUSE_REGEX = /mouse/;
+
+      var EventManager = function() {
+
+        this.isMouse = function(event) {
+          var evt = event.originalEvent || event;
+          return MOUSE_REGEX.test(evt.pointerType || evt.type);
+        };
+      };
+
+      return new EventManager();
+    };
+  });
+})();

--- a/src/components/ReframeService.js
+++ b/src/components/ReframeService.js
@@ -14,36 +14,45 @@ goog.provide('ga_reframe_service');
       var lv95tolv03Url = gaGlobalOptions.lv95tolv03Url;
 
       var Reframe = function() {
-        this.get03To95 = function(coordinates) {
+        this.get03To95 = function(coordinates, timeout) {
           var defer = $q.defer();
           $http.get(lv03tolv95Url, {
             params: {
               easting: coordinates[0],
               northing: coordinates[1]
-            }
+            },
+            timeout: timeout
           }).then(function(response) {
             defer.resolve(response.data.coordinates);
-          }, function() {
-            // Use proj4js on error
-            defer.resolve(ol.proj.transform(coordinates,
-                'EPSG:21781', 'EPSG:2056'));
+          }, function(response) {
+            if (response.status == -1) { // cancel
+              defer.reject();
+            } else {
+              defer.resolve(ol.proj.transform(coordinates,
+                  'EPSG:21781', 'EPSG:2056'));
+            }
           });
           return defer.promise;
         };
 
-        this.get95To03 = function(coordinates) {
+        this.get95To03 = function(coordinates, timeout) {
           var defer = $q.defer();
           $http.get(lv95tolv03Url, {
             params: {
               easting: coordinates[0],
               northing: coordinates[1]
-            }
+            },
+            timeout: timeout
           }).then(function(response) {
             defer.resolve(response.data.coordinates);
-          }, function() {
-            // Use proj4js on error
-            defer.resolve(ol.proj.transform(coordinates,
-                'EPSG:2056', 'EPSG:21781'));
+          }, function(response) {
+            if (response.status == -1) { // cancel
+              defer.reject();
+            } else {
+              // Use proj4js on error
+              defer.resolve(ol.proj.transform(coordinates,
+                  'EPSG:2056', 'EPSG:21781'));
+            }
           });
           return defer.promise;
         };

--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -33,7 +33,7 @@ goog.require('ga_what3words_service');
           link: function(scope, element, attrs) {
             var heightUrl = scope.options.heightUrl;
             var qrcodeUrl = scope.options.qrcodeUrl;
-            var startPixel, holdPromise, isPopoverShown;
+            var startPixel, holdPromise, isPopoverShown = false;
             var reframeCanceler = $q.defer();
             var heightCanceler = $q.defer();
             var map = scope.map;

--- a/test/specs/EventService.spec.js
+++ b/test/specs/EventService.spec.js
@@ -1,0 +1,51 @@
+describe('ga_event_service', function() {
+
+  describe('gaEvent', function() {
+    var gaEvent;
+
+    beforeEach(function() {
+      inject(function($injector) {
+        gaEvent = $injector.get('gaEvent');
+      });
+    });
+
+    describe('#isMouse()', function() {
+
+      // Native events mock
+      var mouseEvts = [
+        $.Event('mousedown'),
+        $.Event('pointerdown', {pointerType: 'mouse'})
+      ];
+
+      var notMouseEvts = [
+        $.Event('touchstart'),
+        $.Event('pointerdown', {pointerType: 'pen'}),
+        $.Event('pointerdown', {pointerType: 'touch'})
+      ];
+
+      // Jquery/ol events mock (with originalEvent stored)
+      var origMouseEvts = [];
+      mouseEvts.forEach(function(evt) {
+        origMouseEvts.push({originalEvent: evt});
+      });
+
+      var origNotMouseEvts = [];
+      notMouseEvts.forEach(function(evt) {
+        origNotMouseEvts.push({originalEvent: evt});
+      });
+
+      it('detects mouse events as mouse', function() {
+        mouseEvts.concat(origMouseEvts).forEach(function(evt) {
+          expect(gaEvent.isMouse(evt)).to.be(true);
+        });
+      });
+
+      it('detects others events as not mouse', function() {
+        notMouseEvts.concat(origNotMouseEvts).forEach(function(evt) {
+          expect(gaEvent.isMouse(evt)).to.be(false);
+        });
+      });
+    });
+  });
+});
+

--- a/test/specs/ReframeService.spec.js
+++ b/test/specs/ReframeService.spec.js
@@ -1,5 +1,5 @@
 describe('ga_reframe_service', function() {
-  var $rootScope, $httpBackend, gaReframe, lv03tolv95Url, lv95tolv03Url;
+  var $rootScope, $httpBackend, $q, gaReframe, lv03tolv95Url, lv95tolv03Url;
 
   var buildUrl = function(baseUrl, coords) {
     return baseUrl + '?easting=' + coords[0] + '&northing=' + coords[1];
@@ -11,10 +11,16 @@ describe('ga_reframe_service', function() {
       inject(function($injector, gaGlobalOptions) {
         $rootScope = $injector.get('$rootScope');
         $httpBackend = $injector.get('$httpBackend');
+        $q = $injector.get('$q');
         gaReframe = $injector.get('gaReframe');
         lv03tolv95Url = gaGlobalOptions.lv03tolv95Url;
         lv95tolv03Url = gaGlobalOptions.lv95tolv03Url;
       });
+    });
+
+    afterEach(function() {
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
     });
 
     it('transforms coordinates using the reframe service from LV03 to LV95',
@@ -70,6 +76,30 @@ describe('ga_reframe_service', function() {
         done();
       });
       $httpBackend.flush();
+      $rootScope.$digest();
+    });
+
+    it('can cancel an lv95 to lv03 request via the timeout parameter', function(done) {
+      var coordinates = [2620116.600000524, 1142771.299843073];
+      var url = buildUrl(lv95tolv03Url, coordinates);
+      $httpBackend.expectGET(url).respond(200);
+      var canceler = $q.defer();
+      gaReframe.get95To03(coordinates, canceler.promise).then(angular.noop, function() {
+        done();
+      });
+      canceler.resolve();
+      $rootScope.$digest();
+    });
+
+    it('can cancel an lv03 to lv95 request via the timeout parameter', function(done) {
+      var coordinates = [2620116.600000524, 1142771.299843073];
+      var url = buildUrl(lv03tolv95Url, coordinates);
+      $httpBackend.expectGET(url).respond(200);
+      var canceler = $q.defer();
+      gaReframe.get03To95(coordinates, canceler.promise).then(angular.noop, function() {
+        done();
+      });
+      canceler.resolve();
       $rootScope.$digest();
     });
   });

--- a/test/specs/contextpopup/ContextPopupDirective.spec.js
+++ b/test/specs/contextpopup/ContextPopupDirective.spec.js
@@ -1,5 +1,18 @@
 describe('ga_contextpopup_directive', function() {
-  var element, handlers = {}, viewport, map, originalEvt, $rootScope, gaReframe;
+  var elt, parentScope, handlers = {}, map, $rootScope, gaReframe, $window, $compile, $httpBackend, $timeout, gaWhat3Words, $q, gaPermalink;
+  var expectedHeightUrl = '//api.geo.admin.ch/height?easting=661473&elevation_model=COMB&northing=188192';
+  var expectedReframeUrl = '//api.example.com/reframe/lv03tolv95?easting=661473&northing=188192';
+  var expectedw3wUrl = 'dummy.test.url.com/v2/reverse?coords=46.84203157398991,8.244528382656728&key=testkey&lang=de';
+  var contextPermalink = 'http://test.com?X=188192&Y=661473';
+  var crosshairPermalink = 'http://test.com?crosshair=marker&X=188192&Y=661473';
+
+  var loadDirective = function() {
+    parentScope = $rootScope.$new();
+    var tpl = '<div ga-context-popup ga-context-popup-map="map" ga-context-popup-options="options"></div>';
+    elt = $compile(tpl)(parentScope);
+    $rootScope.$digest();
+    scope = elt.isolateScope();
+  };
 
   beforeEach(function() {
 
@@ -8,9 +21,6 @@ describe('ga_contextpopup_directive', function() {
         msie: false,
         mobile: false,
         phone: false,
-        events: {
-          menu: 'contextmenu'
-        }
       });
 
       $provide.value('gaNetworkStatus', {
@@ -22,167 +32,224 @@ describe('ga_contextpopup_directive', function() {
           return 'de';
         }
       });
-    });
-    originalEvt = {originalEvent: {}};
-    element = angular.element(
-      '<div>' +
-        '<div ga-context-popup ga-context-popup-map="map" ga-context-popup-options="options"></div>' +
-        '<div id="map"></div>' +
-      '</div>');
 
-    inject(function(_$rootScope_, _gaReframe_, $compile) {
-      $rootScope = _$rootScope_;
-      gaReframe = _gaReframe_;
-      map = new ol.Map({});
-      $rootScope.map = map;
-      $rootScope.options = {
-        heightUrl: '//api.geo.admin.ch/height',
-        qrcodeUrl: '//api.geo.admin.ch/qrcodegenerator'
-      };
-      map.on = function(eventType, handler) {
-        handlers[eventType] = handler;
-      };
-      viewport = $(map.getViewport());
-      $compile(element)($rootScope);
-      map.setTarget(element.find('#map')[0]);
-      $rootScope.$digest();
+      $provide.value('gaPermalink', {
+        getHref: function(p) {
+          if (p.crosshair) {
+            return crosshairPermalink;
+          }
+          return contextPermalink;
+        }
+      });
     });
+
+    inject(function($injector) {
+      $rootScope = $injector.get('$rootScope');
+      $window = $injector.get('$window');
+      $compile = $injector.get('$compile');
+      $timeout = $injector.get('$timeout');
+      $httpBackend = $injector.get('$httpBackend');
+      $q = $injector.get('$q');
+      gaPermalink = $injector.get('gaPermalink');
+      gaReframe = $injector.get('gaReframe');
+      gaWhat3Words = $injector.get('gaWhat3Words');
+    });
+
+    $(document.body).append('<div id="map"></div>');
+    map = new ol.Map({target: 'map'});
+    map.on = function(eventType, handler) {
+      handlers[eventType] = handler;
+    };
+    map.getEventPixel = function(event) { return [25, 50]; };
+    map.getEventCoordinate = function(event) { return [661473, 188192]; };
+
+    $rootScope.map = map;
+    $rootScope.options = {
+      heightUrl: '//api.geo.admin.ch/height',
+      qrcodeUrl: '//api.geo.admin.ch/qrcodegenerator'
+    };
+
+    $httpBackend.when('GET', expectedHeightUrl).respond({height: '1233'});
+    $httpBackend.when('GET', expectedReframeUrl).respond({coordinates: [2725984.4037894635, 1180787.4007025931]});
+    $httpBackend.when('GET', expectedw3wUrl).respond({words: 'das.ist.test'});
   });
 
-  it('creates <table> and <td>\'s', function() {
-    var tables = element.find('div.popover-content table');
-    expect(tables.length).to.be(1);
-
-    var tds = $(tables[0]).find('td');
-    expect(tds.length).to.be(16);
+  afterEach(function() {
+    $('#map').remove();
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
   });
 
-  describe('ga_contextpopup_directive handling of popupcontext', function() {
-    var contextmenuEvent;
-    var $httpBackend;
-    var $timeout;
-
-    var expectedHeightUrl = '//api.geo.admin.ch/height' +
-        '?easting=661473&elevation_model=COMB' +
-        '&northing=188192';
-    var expectedReframeUrl = '//api.example.com/reframe/' +
-        'lv03tolv95?easting=661473&northing=188192';
-    var expectedw3wUrl = 'dummy.test.url.com/v2/reverse?coords=46.84203157398991,8.244528382656728&key=testkey&lang=de';
+  describe('on all browser', function() {
+    var mapEvt, mapEvt2, mouseEvt, mouseEvt2, touchEvt, touchEvt2;
 
     beforeEach(inject(function($injector) {
-      map.getEventPixel = function(event) { return [25, 50]; };
-      map.getEventCoordinate = function(event) { return [661473, 188192]; };
+      mapEvt = {
+         stopPropagation: function() {},
+         preventDefault: function() {},
+         pixel: [25, 50],
+         coordinate: [661473, 188192]
+      };
+      mapEvt2 = {
+        stopPropagation: function() {},
+        preventDefault: function() {},
+        pixel: [30, 60],
+        coordinate: [661673, 198192]
+      };
+      mouseEvt = $.extend({type: 'mousedown'}, mapEvt),
+      mouseEvt2 = $.extend({type: 'mouseup'}, mapEvt2),
+      touchEvt = $.extend({type: 'touchstart'}, mapEvt),
+      touchEvt2 = $.extend({type: 'touchend'}, mapEvt2);
 
-      $httpBackend = $injector.get('$httpBackend');
-      $httpBackend.when('GET', expectedHeightUrl).respond(
-        {height: '1233'});
-      $httpBackend.when('GET', expectedReframeUrl).respond(
-        {coordinates: [2725984.4037894635, 1180787.4007025931]});
-      $httpBackend.when('GET', expectedw3wUrl).respond(
-        {words: 'das.ist.test'});
-
-      $timeout = $injector.get('$timeout');
+      loadDirective();
     }));
 
-    afterEach(function() {
-      $httpBackend.verifyNoOutstandingRequest();
+    it('creates <table> and <td>\'s', function() {
+      var tables = elt.find('div.popover-content table');
+      var tds = $(tables[0]).find('td');
+      expect(tables.length).to.be(1);
+      expect(tds.length).to.be(16);
     });
 
-    it('correctly handles map contextmenu events', function() {
+    it('displays information on contextmenu events', function() {
       var spy = sinon.spy(gaReframe, 'get03To95');
+      var spy2 = sinon.spy(gaWhat3Words, 'getWords');
       var evt = $.Event('contextmenu');
       evt.coordinate = [661473, 188192];
       evt.pixel = [25, 50];
-      viewport.trigger(evt);
+      handlers.pointerdown(touchEvt);
+      $(map.getViewport()).trigger(evt);
       $httpBackend.flush();
 
-      var tables = element.find('div.popover-content table');
-      var tds = $(tables[0]).find('td');
-
       expect(spy.callCount).to.eql(1);
+      expect(spy2.callCount).to.eql(1);
+
+      var tables = elt.find('div.popover-content table');
+      var tds = $(tables[0]).find('td');
       expect($(tds[0]).find('a').attr('href')).to.be('contextpopup_lv03_url');
-      expect($(tds[2]).find('a').attr('href')).to.be('contextpopup_lv95_url');
+      expect($(tds[1]).find('a').attr('href')).to.be(contextPermalink);
       expect($(tds[1]).text()).to.be('661\'473.0, 188\'192.0');
+      expect($(tds[2]).find('a').attr('href')).to.be('contextpopup_lv95_url');
       expect($(tds[3]).text()).to.be('2\'725\'984.40, 1\'180\'787.40');
+      expect($(tds[5]).text()).to.be('46.84203, 8.24453');
+      expect($(tds[9]).text()).to.be('442\'396, 5\'187\'887 (zone 32T)');
+      expect($(tds[11]).text()).to.be('32TMS 42396 87887 ');
       expect($(tds[13]).text()).to.be('das.ist.test');
       expect($(tds[15]).text()).to.be('1233 m');
+      expect($(tds[17]).find('a').attr('href')).to.be(crosshairPermalink);
     });
 
-    describe('On device without contextmenu event', function() {
-      var mapEvt;
+    it('displays informations on long touch press', function() {
+      var spy = sinon.spy(gaReframe, 'get03To95');
+      var spy2 = sinon.spy(gaWhat3Words, 'getWords');
+      var spyStop = sinon.spy(touchEvt, 'stopPropagation');
+      var spyPrev = sinon.spy(touchEvt, 'preventDefault');
+      handlers.pointerdown(touchEvt);
+      $timeout.flush();
+      $httpBackend.flush();
 
-      beforeEach(inject(function($compile, gaBrowserSniffer) {
-        mapEvt = {
-           stopPropagation: function() {},
-           preventDefault: function() {},
-           pixel: [25, 50],
-           coordinate: [661473, 188192]
-        };
-        gaBrowserSniffer.touchDevice = true;
-        gaBrowserSniffer.msie = false;
-        gaBrowserSniffer.events.menu = undefined;
+      expect(elt.css('display')).to.be('block');
 
-        $compile(element)($rootScope);
-        map.setTarget(element.find('#map')[0]);
-        $rootScope.$digest();
-      }));
+      expect(spy.callCount).to.eql(1);
+      expect(spy2.callCount).to.eql(1);
+      expect(spyStop.callCount).to.eql(1);
+      expect(spyPrev.callCount).to.eql(1);
 
-      it('correctly emulates contextmenu', function() {
-        $httpBackend.expectGET(expectedHeightUrl);
-        $httpBackend.expectGET(expectedReframeUrl);
-        $httpBackend.expectGET(expectedw3wUrl);
-        var spy = sinon.spy(gaReframe, 'get03To95');
-        handlers.pointerdown(mapEvt);
+      var tables = elt.find('div.popover-content table');
+      var tds = $(tables[0]).find('td');
+      expect($(tds[0]).find('a').attr('href')).to.be('contextpopup_lv03_url');
+      expect($(tds[1]).find('a').attr('href')).to.be(contextPermalink);
+      expect($(tds[1]).text()).to.be('661\'473.0, 188\'192.0');
+      expect($(tds[2]).find('a').attr('href')).to.be('contextpopup_lv95_url');
+      expect($(tds[3]).text()).to.be('2\'725\'984.40, 1\'180\'787.40');
+      expect($(tds[5]).text()).to.be('46.84203, 8.24453');
+      expect($(tds[9]).text()).to.be('442\'396, 5\'187\'887 (zone 32T)');
+      expect($(tds[11]).text()).to.be('32TMS 42396 87887 ');
+      expect($(tds[13]).text()).to.be('das.ist.test');
+      expect($(tds[15]).text()).to.be('1233 m');
+      expect($(tds[17]).find('a').attr('href')).to.be(crosshairPermalink);
+    });
 
-        $timeout.flush();
-        $httpBackend.flush();
+    it('doesn\'t display informations on long touch press if ctrlKey is pressed', function() {
+      var spy = sinon.spy(gaReframe, 'get03To95');
+      var ctrlEvt = $.extend({ctrlKey: true}, touchEvt);
+      handlers.pointerdown(ctrlEvt);
+      $timeout.flush();
+      expect(spy.callCount).to.eql(0);
+      expect(elt.css('display')).to.be('none');
+    });
 
-        var popover = element.find('.popover');
-        expect(popover.css('display')).to.be('block');
+    it('doesn\'t display informations on long mouse press', function() {
+      var spy = sinon.spy(gaReframe, 'get03To95');
+      handlers.pointerdown(mouseEvt);
+      $timeout.flush();
+      expect(spy.callCount).to.eql(0);
+      expect(elt.css('display')).to.be('none');
+    });
 
-        var tables = element.find('div.popover-content table');
-        var tds = $(tables[0]).find('td');
+    it('doesn\'t display information if pointerup event happens before 300ms', function() {
+      var spy = sinon.spy(gaReframe, 'get03To95');
 
-        expect(spy.callCount).to.eql(1);
-        expect($(tds[0]).find('a').attr('href')).to.be('contextpopup_lv03_url');
-        expect($(tds[2]).find('a').attr('href')).to.be('contextpopup_lv95_url');
-        expect($(tds[1]).text()).to.be('661\'473.0, 188\'192.0');
-        expect($(tds[3]).text()).to.be('2\'725\'984.40, 1\'180\'787.40');
-        expect($(tds[13]).text()).to.be('das.ist.test');
-        expect($(tds[15]).text()).to.be('1233 m');
-      });
+      // Touch
+      handlers.pointerdown(touchEvt);
+      handlers.pointerup(touchEvt);
+      $timeout.flush();
+      expect(spy.callCount).to.eql(0);
+      expect(elt.css('display')).to.be('none');
 
-      it('touchend prevents handler from being called', function() {
+      // Mouse
+      handlers.pointerdown(mouseEvt);
+      handlers.pointerup(mouseEvt);
+      $timeout.verifyNoPendingTasks();
+      expect(spy.callCount).to.eql(0);
+      expect(elt.css('display')).to.be('none');
+    });
 
-        // Make sure there aren't any timouts left (this might
-        // compenstate for a bug in angular.mock or angular in general)
-        var spy = sinon.spy(gaReframe, 'get03To95');
-        $timeout.flush();
-        handlers.pointerdown(mapEvt);
-        handlers.pointerup(mapEvt);
-        $timeout.verifyNoPendingTasks();
+    it('doesn\'t display information if pointermove event happens before 300ms', function() {
+      var spy = sinon.spy(gaReframe, 'get03To95');
 
-        var popover = element.find('.popover');
-        expect(spy.callCount).to.eql(0);
-        expect(popover.css('display')).to.be('');
-      });
+      // Touch
+      handlers.pointerdown(touchEvt);
+      handlers.pointermove(touchEvt2);
+      $timeout.flush();
 
-      it('touchmove prevents handler from being called', function() {
+      expect(spy.callCount).to.eql(0);
+      expect(elt.css('display')).to.be('none');
 
-        // Make sure there aren't any timouts left (this might
-        // compenstate for a bug in angular.mock or angular in general)
-        var spy = sinon.spy(gaReframe, 'get03To95');
-        $timeout.flush();
-        handlers.pointerdown(mapEvt);
-        handlers.pointermove({
-          pixel: [30, 60]
-        });
-        $timeout.verifyNoPendingTasks();
+      // Mouse
+      handlers.pointerdown(mouseEvt);
+      handlers.pointermove(mouseEvt2);
+      $timeout.verifyNoPendingTasks();
 
-        var popover = element.find('.popover');
-        expect(spy.callCount).to.eql(0);
-        expect(popover.css('display')).to.be('');
-      });
+      expect(spy.callCount).to.eql(0);
+      expect(elt.css('display')).to.be('none');
+    });
+
+    it('updates w3w text on $translateChangeEnd event', function() {
+      var spy = sinon.stub(gaWhat3Words, 'getWords').returns($q.when('das.ist.test'));
+      var evt = $.Event('contextmenu');
+      evt.coordinate = [661473, 188192];
+      evt.pixel = [25, 50];
+      $(map.getViewport()).trigger(evt);
+      $httpBackend.flush();
+      expect(spy.callCount).to.eql(1);
+
+      $rootScope.$broadcast('$translateChangeEnd');
+      $rootScope.$digest();
+      expect(spy.callCount).to.eql(2);
+    });
+
+    it('updates permalinks on gaPermalinkChange event', function() {
+      var evt = $.Event('contextmenu');
+      evt.coordinate = [661473, 188192];
+      evt.pixel = [25, 50];
+      $(map.getViewport()).trigger(evt);
+      $httpBackend.flush();
+      $rootScope.$digest();
+
+      var spy = sinon.spy(gaPermalink, 'getHref');
+      scope.$broadcast('gaPermalinkChange');
+      expect(spy.callCount).to.eql(2);
     });
   });
 });


### PR DESCRIPTION
Fix #3749 

[test](https://mf-geoadmin3.int.bgdi.ch/teo_fixes/index.html?topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&X=179307.26&Y=632153.45&zoom=3)


This PR fixes the tooltip and the context popup on hybrid devices (touch and mouse).