### PR TITLE
Using an API KEY to access proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ LAST_PUBLIC_URL := $(shell if [ -f .build-artefacts/last-public-url ];  then cat
 PRINT_URL ?= //print.geo.admin.ch
 PRINT_TECH_URL ?= //service-print.
 LAST_PRINT_URL := $(shell if [ -f .build-artefacts/last-print-url ]; then cat .build-artefacts/last-print-url 2> /dev/null; else echo '-none-'; fi)
-PROXY_URL ?= //pondvarz5b.execute-api.eu-west-1.amazonaws.com/prod
-LAST_PROXY_URL ?= $(shell if [ -f .build-artefacts/last-proxy-ulr ]; then cat .build-artefacts/last-proxy-url 2> /dev/null; else echo '-none-'; fi)
-
+PROXY_URL ?= //service-proxy.prod.bgdi.ch
+LAST_PROXY_URL ?= $(shell if [ -f .build-artefacts/last-proxy-url ]; then cat .build-artefacts/last-proxy-url 2> /dev/null; else echo '-none-'; fi)
+PROXY_API_KEY ?=NO_KEY
+LAST_PROXY_API_KEY ?= $(shell if [ -f .build-artefacts/last-proxy-api-key ]; then cat .build-artefacts/last-proxy-api-key 2> /dev/null; else echo '-none-'; fi)
 PUBLIC_URL_REGEXP ?= ^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*
 ADMIN_URL_REGEXP ?= ^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)
 E2E_TARGETURL ?= https://mf-geoadmin3.dev.bgdi.ch
@@ -150,6 +151,8 @@ help:
 	@echo "- VECTORTILES_URL Service URL (build with: $(LAST_VECTORTILES_URL), current value: $(VECTORTILES_URL))"
 	@echo "- SHOP_URL Service URL        (build with: $(LAST_SHOP_URL), current value: $(SHOP_URL))"
 	@echo "- WMS_URL Service URL         (build with  $(LAST_WMS_URL), current value: $(WMS_URL))"
+	@echo "- PROXY_URL Proxy URL         (build with  $(LAST_PROXY_URL), current value: $(PROXY_URL))"
+	@echo "- PROXY_API_KEY               (build with  $(LAST_PROXY_API_KEY), current value: $(PROXY_API_KEY))"
 	@echo "- APACHE_BASE_PATH Base path  (build with: $(LAST_APACHE_BASE_PATH), current value: $(APACHE_BASE_PATH))"
 	@echo "- APACHE_BASE_DIRECTORY       (build with: $(LAST_APACHE_BASE_DIRECTORY), current value: $(APACHE_BASE_DIRECTORY))"
 	@echo "- SNAPSHOT                    (current value: $(SNAPSHOT))"
@@ -447,6 +450,7 @@ define buildpage
 		--var "print_url=$(PRINT_URL)" \
 		--var "print_tech_url=$(PRINT_TECH_URL)" \
 		--var "proxy_url=$(PROXY_URL)" \
+		--var "proxy_api_key=$(PROXY_API_KEY)" \
 		--var "mapproxy_url=$(MAPPROXY_URL)" \
 		--var "mapproxy_tech_url=$(MAPPROXY_TECH_URL)" \
 		--var "vectortiles_url=$(VECTORTILES_URL)" \

--- a/rc_dev
+++ b/rc_dev
@@ -10,3 +10,4 @@ export SHOP_URL=//shop-bgdi.dev.bgdi.ch
 export PUBLIC_URL=//public.dev.bgdi.ch
 export PRINT_URL=//service-print.dev.bgdi.ch
 export PROXY_URL=//service-proxy.dev.bgdi.ch
+export PROXY_API_KEY=sBdYplnEBT8PIFvKODfTW6MrM9FwJcYt7DdU8h7F

--- a/rc_dev
+++ b/rc_dev
@@ -9,5 +9,5 @@ export WMS_URL=//wms-bgdi.dev.bgdi.ch
 export SHOP_URL=//shop-bgdi.dev.bgdi.ch
 export PUBLIC_URL=//public.dev.bgdi.ch
 export PRINT_URL=//service-print.dev.bgdi.ch
-export PROXY_URL=//service-proxy.dev.bgdi.ch
+export PROXY_URL=//gsi5ppz2kf.execute-api.eu-west-1.amazonaws.com/dev
 export PROXY_API_KEY=sBdYplnEBT8PIFvKODfTW6MrM9FwJcYt7DdU8h7F

--- a/rc_int
+++ b/rc_int
@@ -10,5 +10,5 @@ export WMS_URL=//wms-bgdi.int.bgdi.ch
 export SHOP_URL=//shop-bgdi.int.bgdi.ch
 export PUBLIC_URL=//public.int.bgdi.ch
 export PRINT_URL=//service-print.int.bgdi.ch
-export PROXY_URL=//service-proxy.int.bgdi.ch
+export PROXY_URL=//nl1klo3swe.execute-api.eu-west-1.amazonaws.com/int
 export PROXY_API_KEY=sBdYplnEBT8PIFvKODfTW6MrM9FwJcYt7DdU8h7F

--- a/rc_int
+++ b/rc_int
@@ -11,3 +11,4 @@ export SHOP_URL=//shop-bgdi.int.bgdi.ch
 export PUBLIC_URL=//public.int.bgdi.ch
 export PRINT_URL=//service-print.int.bgdi.ch
 export PROXY_URL=//service-proxy.int.bgdi.ch
+export PROXY_API_KEY=sBdYplnEBT8PIFvKODfTW6MrM9FwJcYt7DdU8h7F

--- a/rc_prod
+++ b/rc_prod
@@ -11,3 +11,4 @@ export SHOP_URL=//shop.swisstopo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export PRINT_URL=//print.geo.admin.ch
 export PROXY_URL=//service-proxy.prod.bgdi.ch
+export PROXY_API_KEY=sBdYplnEBT8PIFvKODfTW6MrM9FwJcYt7DdU8h7F

--- a/src/components/importkml/ImportKmlDirective.js
+++ b/src/components/importkml/ImportKmlDirective.js
@@ -14,7 +14,7 @@ goog.require('ga_urlutils_service');
 
   module.controller('GaImportKmlDirectiveController',
       function($scope, $http, $q, $translate, gaBrowserSniffer, gaKml,
-          gaUrlUtils, $rootScope) {
+          gaUrlUtils, gaGlobalOptions, $rootScope) {
         var fileReader;
         $scope.isIE9 = (gaBrowserSniffer.msie == 9);
         $scope.isIE = !isNaN(gaBrowserSniffer.msie);
@@ -53,6 +53,9 @@ goog.require('ga_urlutils_service');
             // Angularjs doesn't handle onprogress event
             gaUrlUtils.proxifyUrl($scope.fileUrl).then(function(url) {
               $http.get(url, {
+                headers: {
+                  'x-api-key': gaGlobalOptions.proxyApiKey,
+                },
                 cache: true,
                 timeout: $scope.canceler.promise
               }).then(function(response) {

--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -357,7 +357,8 @@ goog.require('ga_urlutils_service');
           } else {
             return gaUrlUtils.proxifyUrl(url).then(function(proxyUrl) {
               return $http.get(proxyUrl, {
-                cache: true
+                cache: true,
+                headers: {'x-api-key': gaGlobalOptions.proxyApiKey}
               }).then(function(response) {
                 var data = response.data;
                 var fileSize = response.headers('content-length');

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -798,6 +798,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         var publicUrl = setBackend(prtl + '${public_url}', prtl + '${public_tech_url}', 'public_url');
         var printUrl = setBackend(prtl + '${print_url}', prtl + '${print_tech_url}', 'print_url');
         var proxyUrl = prtl + '${proxy_url}' + '/';
+        var proxyApiKey = '${proxy_api_key}';
         var apiOverwrite = !!(getParam('api_url') || env);
 
         module.constant('gaGlobalOptions', {
@@ -810,6 +811,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           apiUrl: apiUrl,
           printUrl: printUrl,
           proxyUrl: proxyUrl,
+          proxyApiKey: proxyApiKey,
           mapproxyUrl: mapproxyUrl,
           vectorTilesUrl: vectorTilesUrl,
           shopUrl: shopUrl,
@@ -825,7 +827,9 @@ itemscope itemtype="http://schema.org/WebApplication"
           lv95tolv03Url: 'https://geodesy.geo.admin.ch/reframe/lv95tolv03',
           w3wApiKey: 'OM48J50Y',
           whitelist: [
-            'https://' + window.location.host + '/**'
+            'https://' + window.location.host + '/**',
+            'https://*.execute-api.eu-west-1.amazonaws.com/**',
+            'https://service-proxy.*.bgdi.ch/**',
           ],
           defaultTopicId: '${default_topic_id}',
           translationFallbackCode: '${translation_fallback_code}',


### PR DESCRIPTION
To use the various _service-proxy_ proxy, you must provide a valid API KEY


[Demo](https://mf-chsdi3.int.bgdi.ch/shorten/7288d6eaf9) (very heavy KML, please wait)

Nota: PR to _gal_proxy_integration_



