### PR TITLE
Increase s-maxage to 15 minutes for critical resources

### DIFF
--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -159,7 +159,7 @@ def _save_to_s3(in_data, dest, mimetype, bucket_name, compress=True, cached=True
         compressed = True
 
     if cached is False:
-        cache_control = 'max-age=0, must-revalidate, s-maxage=60'
+        cache_control = 'max-age=0, must-revalidate, s-maxage=900'
 
     extra_args['ACL'] = 'public-read'
     extra_args['ContentType'] = mimetype


### PR DESCRIPTION
1 minute s-maxage results in some peaks that appear to often. With increasing it to 15 minutes, we hope to address this a little bit better.

Note: you have to wait 15 minutes after a deploy before the new index.html files are visible (that's the downside).