### PR TITLE
Localcomparator for topic ordering

### DIFF
--- a/src/components/topic/TopicDirective.js
+++ b/src/components/topic/TopicDirective.js
@@ -31,6 +31,21 @@ goog.require('ga_topic_service');
               scope.activeTopic = newTopic;
             };
 
+            scope.localeSensitiveComparator = function(o1, o2) {
+              var v1 = o1.value;
+              var v2 = o2.value;
+              var groupId1 = v1.groupId;
+              var groupId2 = v2.groupId;
+              if (groupId1 != groupId2 && typeof(groupId1) == 'number' &&
+                  typeof(groupId2) == 'number') {
+                return groupId1 < groupId2 ? -1 : 1;
+              }
+              var name1 = v1.name;
+              var name2 = v2.name;
+              // Compare strings alphabetically, taking locale into account
+              return name1.localeCompare(name2);
+            };
+
             scope.$watch('activeTopic', function(newTopic) {
               if (newTopic && scope.topics) {
                 modal.modal('hide');

--- a/src/components/topic/partials/topic.html
+++ b/src/components/topic/partials/topic.html
@@ -8,7 +8,7 @@
       <div class="modal-body">
         <div class="input-modal-container">
           <div class="ga-topic-item"
-               ng-repeat="topic in topics | orderBy:['groupId', 'name']"
+               ng-repeat="topic in topics | orderBy:null:null:localeSensitiveComparator"
                ng-click="setActiveTopic(topic)"
                ng-class="{'ga-topic-active': topic == activeTopic}"
                data-original-title="{{topic.tooltip | translate}}">

--- a/test/specs/topic/TopicDirective.spec.js
+++ b/test/specs/topic/TopicDirective.spec.js
@@ -6,6 +6,8 @@ describe('ga_topic_directive', function() {
       id: 'sometopic'
     }, {
       id: 'anothertopic'
+    }, {
+      id: 'finaltopic'
     }];
 
     module(function($provide) {
@@ -29,7 +31,7 @@ describe('ga_topic_directive', function() {
 
     module(function($translateProvider) {
       $translateProvider.translations('en',
-          {'anothertopic': 'Zombie', 'sometopic': 'Alien'});
+          {'anothertopic': 'Zombie', 'sometopic': 'Alien', 'finaltopic': 'Énergie'});
     });
 
     inject(function($injector) {
@@ -67,41 +69,44 @@ describe('ga_topic_directive', function() {
 
       it('reorders correctly the html on lang change event', function() {
         var items = element.find('.ga-topic-item');
-        expect(items.length).to.be(2);
+        expect(items.length).to.be(3);
         expect($(items[0]).text()).to.be('anothertopic');
-        expect($(items[1]).text()).to.be('sometopic');
+        expect($(items[1]).text()).to.be('finaltopic');
+        expect($(items[2]).text()).to.be('sometopic');
         $translate.use('en');
         $rootScope.$broadcast('translateChangeEnd', {language: 'en'});
         $rootScope.$digest();
         items = element.find('.ga-topic-item');
         expect($(items[0]).text()).to.be('Alien');
-        expect($(items[1]).text()).to.be('Zombie');
+        expect($(items[1]).text()).to.be('Énergie');
+        expect($(items[2]).text()).to.be('Zombie');
       });
 
       it('updates correctly the html on first topic change event', function() {
         var items = element.find('.ga-topic-item');
-        expect(items.length).to.be(2);
+        expect(items.length).to.be(3);
         expect($(items[0]).hasClass('ga-topic-active')).to.be(false);
-        expect($(items[1]).hasClass('ga-topic-active')).to.be(true);
+        expect($(items[1]).hasClass('ga-topic-active')).to.be(false);
+        expect($(items[2]).hasClass('ga-topic-active')).to.be(true);
       });
 
       it('updates correctly the html on multiple topic change event', function() {
         $rootScope.$broadcast('gaTopicChange', topics[1]);
         $rootScope.$digest();
         var items = element.find('.ga-topic-item');
-        expect(items.length).to.be(2);
+        expect(items.length).to.be(3);
         expect($(items[0]).hasClass('ga-topic-active')).to.be(true);
 
         $rootScope.$broadcast('gaTopicChange', topics[0]);
         $rootScope.$digest();
         var items = element.find('.ga-topic-item');
-        expect(items.length).to.be(2);
-        expect($(items[1]).hasClass('ga-topic-active')).to.be(true);
+        expect(items.length).to.be(3);
+        expect($(items[2]).hasClass('ga-topic-active')).to.be(true);
       });
 
       it('changes topic on click', function() {
         var items = element.find('.ga-topic-item');
-        expect(items.length).to.be(2);
+        expect(items.length).to.be(3);
         var item0 = $(items[0]);
         var item1 = $(items[1]);
         item1.click();


### PR DESCRIPTION
Have a look at topic énergie here:

https://map.geo.admin.ch?lang=fr

collection, expression, reverse, comparator

We can't combine multiple comparators for a collection, so I finally had to create my own.

Proof in angular tests:
https://github.com/gkalpak/angular.js/blob/master/test/ng/filter/orderBySpec.js


[Test Link](https://mf-geoadmin3.int.bgdi.ch/gal_localcomparator/index.html?lang=fr)
