### PR TITLE
HTTP2 detection and single-domain tiles

### DIFF
--- a/src/components/BrowserSnifferService.js
+++ b/src/components/BrowserSnifferService.js
@@ -108,6 +108,30 @@ goog.require('ga_permalink');
         isBlobSupported = !!new Blob;
       } catch (e) {
       }
+
+      // detect http2 support
+      var h2 = false;
+      // Firefox
+      // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/nextHopProtocol
+      if (!msie && /Firefox/.test(ua) && $window.performance &&
+          $window.performance.getEntriesByType) {
+        var perf = $window.performance.getEntriesByType('resource');
+        if (perf[0] && perf[0].nextHopProtocol == 'h2') {
+          h2 = true;
+        }
+      // Chrome
+      // http://stackoverflow.com/questions/36041204/detect-connection-protocol-http-2-spdy-from-javascript
+      } else if (chrome && $window.chrome && $window.chrome.loadTimes) {
+        if ($window.chrome.loadTimes().connectionInfo == 'h2') {
+          h2 = true;
+        }
+      // Generic
+      // http://stackoverflow.com/questions/36041204/detect-connection-protocol-http-2-spdy-from-javascript
+      } else if ($window.performance && $window.performance.timing) {
+        if ($window.performance.timing.nextHopProtocol == 'h2') {
+          h2 = true;
+        }
+      }
       return {
         msie: msie, // false or ie version number
         webkit: webkit,
@@ -124,7 +148,8 @@ goog.require('ga_permalink');
         isInFrame: ($window.location != $window.parent.location),
         webgl: !(typeof WebGLRenderingContext === 'undefined'),
         animation: (!msie || msie > 9),
-        blob: isBlobSupported
+        blob: isBlobSupported,
+        h2: h2
       };
     };
   });

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -400,6 +400,13 @@ goog.require('ga_urlutils_service');
         gaStylesFromLiterals, gaGlobalOptions, gaPermalink,
         gaLang, gaTime) {
 
+      var h2 = function(domainsArray) {
+        if (gaBrowserSniffer.h2) {
+          return domainsArray.slice(1, 2);
+        }
+        return domainsArray;
+      };
+
       var Layers = function(dfltWmsSubdomains, dfltWmtsNativeSubdomains,
           dfltWmtsMapProxySubdomains, dfltVectorTilesSubdomains,
           wmsUrlTemplate, wmtsGetTileUrlTemplate,
@@ -670,7 +677,7 @@ goog.require('ga_urlutils_service');
           var requestedLayer = config3d.serverLayerName || bodId;
           var tileset = new Cesium.Cesium3DTileset({
             url: getVectorTilesUrl(requestedLayer, timestamp,
-                dfltVectorTilesSubdomains),
+                h2(dfltVectorTilesSubdomains)),
             maximumNumberOfLoadedTiles: 3
           });
           tileset.bodId = bodId;
@@ -714,8 +721,8 @@ goog.require('ga_urlutils_service');
               url: getWmtsGetTileTpl(requestedLayer, timestamp,
                   '4326', format, hasNativeTiles),
               tileSize: 256,
-              subdomains: hasNativeTiles ? dfltWmtsNativeSubdomains :
-                  dfltWmtsMapProxySubdomains
+              subdomains: hasNativeTiles ? h2(dfltWmtsNativeSubdomains) :
+                  h2(dfltWmtsMapProxySubdomains)
             };
           } else if (config3d.type == 'wms') {
             var tileSize = 512;
@@ -833,7 +840,7 @@ goog.require('ga_urlutils_service');
                 tileGrid: gaTileGrid.get(layer.resolutions,
                     layer.minResolution),
                 tileLoadFunction: tileLoadFunction,
-                urls: getImageryUrls(wmtsTplUrl, dfltWmtsNativeSubdomains),
+                urls: getImageryUrls(wmtsTplUrl, h2(dfltWmtsNativeSubdomains)),
                 crossOrigin: crossOrigin
               });
             }

--- a/test/specs/BrowserSnifferService.spec.js
+++ b/test/specs/BrowserSnifferService.spec.js
@@ -329,6 +329,117 @@ describe('ga_browsersniffer_service', function() {
         });
       });
     });
+
+    describe('detect http 2', function() {
+
+      it('IE browsers not supported', function() {
+        win.navigator.userAgent = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; InfoPath.3)';
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+
+        win.navigator.userAgent = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; InfoPath.3)';
+ snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+
+        win.navigator.userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; InfoPath.3; rv:11.0) like Gecko';
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+
+        win.navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240';
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+
+
+      });
+      
+      it('Chrome browsers with no loadTimes', function() {
+        
+        // standard chrome doesn't support
+        win.navigator.userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.111 Safari/537.36';
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+      });
+      
+      it('Chrome browsers with loadTime without h2', function() {
+        win.navigator.userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.111 Safari/537.36';
+
+        win.chrome = {
+          loadTimes: function() {
+            return {
+              connectionInfo: 'http/1.0'
+            };
+          }
+        };
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+        
+      });
+      
+      it('Chrome browsers with loadTime without h2', function() {
+        win.navigator.userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.111 Safari/537.36';
+        //Detecting h2
+        win.chrome = {
+          loadTimes: function() {
+            return {
+              connectionInfo: 'h2'
+            };
+          }
+        };
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(true);
+
+      });
+
+      it('Firefox without support', function() {
+        win.navigator.userAgent = 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:36.0) Gecko/20100101 Firefox/36.0';
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+      });
+
+      it('Firefox with http1 only', function() {
+        win.navigator.userAgent = 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:36.0) Gecko/20100101 Firefox/36.0';
+        win.performance = {
+          getEntriesByType: function() {
+            return [{nextHopProtocol: 'http/1.0'}];
+          }
+        };
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+      });
+
+      it('Firefox with http2', function() {
+        win.navigator.userAgent = 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:36.0) Gecko/20100101 Firefox/36.0';
+        win.performance = {
+          getEntriesByType: function() {
+            return [{nextHopProtocol: 'h2'}];
+          }
+        };
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(true);
+      });
+
+      it('Generic browser with http1', function() {
+        win.performance = {
+          timing: {
+            nextHopProtocol: 'http/1.0'
+          }
+        };
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(false);
+      });
+
+      it('Generic browser with h2', function() {
+        win.performance = {
+          timing: {
+            nextHopProtocol: 'h2'
+          }
+        };
+        snif = injector.get('gaBrowserSniffer');
+        expect(snif.h2).to.be.eql(true);
+      });
+
+
+
+    });
   });
 });
-


### PR DESCRIPTION
This PR adds capabilities to detect http2 browser detection. Only firefox and chrome offer this detection possibilities. And it only works when the application itself is loaded via http2 - on our context this means that it works on int/prod, but not on dev.

In addition, when http2 is supported, we load our tiles with single domain. This should increase performance a little bit as we safe the time needed to negotiate for a connection. http2 offers multi-plexing over one single connection.

On Firefox and Chrome, we should see single-domain access to tiles. On all other browsers, we still use the multi-domain approach (even in Edge, which would support http2)

Please test on various browsers and let me know your impressions. (Compare to map.geo.admin.ch)

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_h2/index.html?)