### PR TITLE
Fix #3571: Use the same responsive breakpoints in css and js

### DIFF
--- a/src/components/WindowService.js
+++ b/src/components/WindowService.js
@@ -1,0 +1,177 @@
+goog.provide('ga_window_service');
+(function() {
+
+  var module = angular.module('ga_window_service', []);
+
+  module.provider('gaWindow', function() {
+    this.$get = function($window) {
+
+      var breakpointsWidth = {
+        // Width
+        // 0px to 480px
+        'xs': $('<div class="ga-visible-xs"></div>'),
+        // 481px to 768px
+        's': $('<div class="ga-visible-s"></div>'),
+        // 769px to 992px
+        'm': $('<div class="ga-visible-m"></div>'),
+        // 993px to Infinity
+        'l': $('<div class="ga-visible-l"></div>')
+      };
+
+      var breakpointsHeight = {
+        // Height
+        // 0 to 480px
+        'xs': $('<div class="ga-visible-xs"></div>'),
+        // 481px to 600px
+        's': $('<div class="ga-visible-s"></div>'),
+        // 601px to 800px
+        'm': $('<div class="ga-visible-m"></div>'),
+        // 801px to Infinity
+        'l': $('<div class="ga-visible-l"></div>'),
+      };
+
+      var width = new ResponsiveToolkit('width', breakpointsWidth,
+          $window.document);
+      var height = new ResponsiveToolkit('height', breakpointsHeight,
+          $window.document);
+
+      var Win = function() {
+
+        this.isWidth = function(str) {
+          return width.is(str);
+        };
+
+        this.isHeight = function(str) {
+          return height.is(str);
+        };
+      };
+      return new Win();
+    };
+  });
+
+  /**
+   * Code comes from:
+   * https://github.com/maciej-gurban/responsive-bootstrap-toolkit
+   */
+  var ResponsiveToolkit = function(name, breakpoints, document) {
+    this.breakpoints = breakpoints;
+
+    /**
+     * Returns true if current breakpoint matches passed alias
+     */
+    this.is = function(str) {
+      if (str.charAt(0) == '<' || str.charAt(0) == '>') {
+        return _isMatchingExpression(str, this.breakpoints);
+      }
+      return this.breakpoints[str] && this.breakpoints[str].is(':visible');
+    };
+
+    $(document).ready(function() {
+      var divClass = 'ga-window-' + name;
+      var div = $('.' + divClass).remove();
+      div = $('<div class="ga-window ' + divClass + '"></div>');
+      div.appendTo('body');
+      $.each(breakpoints, function(alias) {
+        breakpoints[alias].appendTo(div);
+      });
+    });
+
+    /**
+     * Splits the expression in into <|> [=] alias
+     */
+    var _splitExpression = function(str) {
+
+      // Used operator
+      var operator = str.charAt(0);
+      // Include breakpoint equal to alias?
+      var orEqual = (str.charAt(1) == '=') ? true : false;
+
+      /**
+       * Index at which breakpoint name starts.
+       *
+       * For:  >sm, index = 1
+       * For: >=sm, index = 2
+       */
+      var index = 1 + (orEqual ? 1 : 0);
+
+      /**
+       * The remaining part of the expression, after the operator, will be
+       * treated as the breakpoint name to compare with.
+       */
+      var breakpointName = str.slice(index);
+
+      return {
+        operator: operator,
+        orEqual: orEqual,
+        breakpointName: breakpointName
+      };
+    };
+
+    /**
+     * Returns true if currently active breakpoint matches the expression
+     */
+    var _isAnyActive = function(aliases, breakpoints) {
+      var found = false;
+      $.each(aliases, function(index, alias) {
+        // Once first breakpoint matches, return true and break out of the loop
+        if (breakpoints[alias].is(':visible')) {
+          found = true;
+          return false;
+        }
+      });
+      return found;
+    };
+
+    /**
+     * Determines whether current breakpoint matches the expression given
+     */
+    var _isMatchingExpression = function(str, breakpoints) {
+
+      var expression = _splitExpression(str);
+
+      // Get names of all breakpoints
+      var breakpointList = Object.keys(breakpoints);
+
+      // Get index of sought breakpoint in the list
+      var pos = breakpointList.indexOf(expression.breakpointName);
+
+      // Breakpoint found
+      if (pos !== -1) {
+
+        var start = 0;
+        var end = 0;
+
+        /**
+         * Parsing viewport.is('<=md') we interate from smallest breakpoint
+         * ('xs') and end at 'md' breakpoint, indicated in the expression,
+         * That makes: start = 0, end = 2 (index of 'md' breakpoint)
+         *
+         * Parsing viewport.is('<md') we start at index 'xs' breakpoint, and
+         * end at 'sm' breakpoint, one before 'md'.
+         * Which makes: start = 0, end = 1
+         */
+        if (expression.operator == '<') {
+            start = 0;
+            end = expression.orEqual ? ++pos : pos;
+        }
+        /**
+         * Parsing viewport.is('>=sm') we interate from breakpoint 'sm' and end
+         * at the end of breakpoint list.
+         * That makes: start = 1, end = undefined
+         *
+         * Parsing viewport.is('>sm') we start at breakpoint 'md' and end at
+         * the end of breakpoint list.
+         * Which makes: start = 2, end = undefined
+         */
+        if (expression.operator == '>') {
+            start = expression.orEqual ? pos : ++pos;
+            end = undefined;
+        }
+
+        var acceptedBreakpoints = breakpointList.slice(start, end);
+
+        return _isAnyActive(acceptedBreakpoints, breakpoints);
+      }
+    };
+  };
+})();

--- a/src/components/catalogtree/style/catalogtree.less
+++ b/src/components/catalogtree/style/catalogtree.less
@@ -82,7 +82,7 @@
     label {
       padding-right: 20px;
 
-      @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+      @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
         padding-right: 2.2em;
       }
     }

--- a/src/components/controls3d/style/controls3d.less
+++ b/src/components/controls3d/style/controls3d.less
@@ -10,7 +10,7 @@
   width: 200px;
   z-index: 600;
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     width: 120px;
     height: @control-btn-size-px;
   }
@@ -40,7 +40,7 @@
     width: 74px;
     padding-top: 5px;
 
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       background: none;
       width: 50px;
       height: auto;
@@ -63,7 +63,7 @@
       color: #ed1c24;
     }
 
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       width: @control-btn-size-px;
       height: @control-btn-size-px;
       background-size: @control-btn-size-px;
@@ -86,7 +86,7 @@
     text-shadow: 0px 1px 3px #020202;
     margin: 2px;
 
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       display: none;
     }
   }
@@ -117,7 +117,7 @@
     width: 27px;
     height: 72px;
 
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       width: 18px;
       height: 47px;
       background-size: 18px 47px;
@@ -128,7 +128,7 @@
       width: 78px;
       height: 100px;
 
-      @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+      @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
          width: 49px;
          height: 65px;
          background-size: 49px 65px;
@@ -140,7 +140,7 @@
       width: 100px;
       height: 38px;
 
-      @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+      @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
          width: 66px;
          height: 25px;
          background-size: 66px 25px;
@@ -161,7 +161,7 @@
        font-size: inherit;
      }
 
-     @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+     @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       top: 8px;
       font-size: 1.5em;
       width: 20px;

--- a/src/components/draw/DrawStyleDirective.js
+++ b/src/components/draw/DrawStyleDirective.js
@@ -2,16 +2,18 @@ goog.provide('ga_drawstyle_directive');
 
 goog.require('ga_styles_service');
 goog.require('ga_urlutils_service');
+goog.require('ga_window_service');
 
 (function() {
 
   var module = angular.module('ga_drawstyle_directive', [
     'ga_styles_service',
-    'ga_urlutils_service'
+    'ga_urlutils_service',
+    'ga_window_service'
   ]);
 
   module.directive('gaDrawStyle', function($document, $window, $translate,
-      gaGlobalOptions, gaStyleFactory, gaUrlUtils) {
+      gaGlobalOptions, gaStyleFactory, gaUrlUtils, gaWindow) {
 
     // Find the corresponding style
     var findIcon = function(olIcon, icons) {
@@ -301,7 +303,7 @@ goog.require('ga_urlutils_service');
             bt.popover({
               html: true,
               placement: function() {
-                return win.width() < 480 ? 'top' : 'auto right';
+                return gaWindow.isWidth('xs') ? 'top' : 'auto right';
               },
               content: content,
               title: title,

--- a/src/components/draw/style/draw.less
+++ b/src/components/draw/style/draw.less
@@ -40,7 +40,7 @@
         font-weight: bold;
       }
 
-      @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+      @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
         &:first-child {
           margin-left: 0px;
         }

--- a/src/components/feedback/style/feedback.less
+++ b/src/components/feedback/style/feedback.less
@@ -28,7 +28,7 @@
       button {
         margin: 5px 15px;
         
-        @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+        @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
           margin: 5px 3px;
         }
         

--- a/src/components/layermanager/style/layermanager.less
+++ b/src/components/layermanager/style/layermanager.less
@@ -94,7 +94,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
 
-      @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+      @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
         padding-left: 2.8em;
       }
     }

--- a/src/components/offline/style/offline.less
+++ b/src/components/offline/style/offline.less
@@ -75,7 +75,7 @@
     margin-left: -@bt-half-px;
     width: unit(@bt-width, px);
 
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       bottom: 21px;
     }
   }

--- a/src/components/popup/PopupDirective.js
+++ b/src/components/popup/PopupDirective.js
@@ -2,20 +2,21 @@ goog.provide('ga_popup_directive');
 
 goog.require('ga_browsersniffer_service');
 goog.require('ga_print_service');
+goog.require('ga_window_service');
 (function() {
 
   var module = angular.module('ga_popup_directive', [
     'ga_browsersniffer_service',
     'ga_print_service',
-    'pascalprecht.translate'
+    'pascalprecht.translate',
+    'ga_window_service'
   ]);
 
   module.directive('gaPopup',
-    function($rootScope, $translate, $window, gaBrowserSniffer, gaPrint) {
+    function($rootScope, $translate, $window, gaBrowserSniffer, gaPrint,
+        gaWindow) {
       var zIndex;
-      var screenLimit = 0;
-      var screenTabletLimit = 768;
-      var screenMobileLimit = 480;
+      var screenLimit = 'xs';
 
       var bringUpFront = function(el) {
         // We get the initial z-index css.
@@ -58,10 +59,10 @@ goog.require('ga_print_service');
           // Init some utilities variables.
           var className = element[0].className;
           if (/ga-popup-tablet/.test(className)) {
-            screenLimit = screenTabletLimit;
+            screenLimit = 's';
           }
           if (/ga-popup-mobile/.test(className)) {
-            screenLimit = screenMobileLimit;
+            screenLimit = 'xs';
           }
 
           // Initialize the popup properties
@@ -210,8 +211,8 @@ goog.require('ga_print_service');
             if (scope.options.isReduced) {
               return;
             }
-            var winWidth = win.width();
-            if (winWidth > screenLimit) {
+            if (gaWindow.isWidth('>' + screenLimit)) {
+              var winWidth = win.width();
               var winHeight = win.height();
               var popupWidth = element.outerWidth();
               var popupHeight = element.outerHeight();

--- a/src/components/search/style/search.less
+++ b/src/components/search/style/search.less
@@ -22,7 +22,7 @@
   .ga-search-title {
     font-weight: bold;
   } 
-  @media (max-width: 992px), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-desktop), (max-height: @screen-s-height) {
     .ga-search-title {
       display: none;
     }
@@ -50,16 +50,26 @@
   .ga-search-1 {
     .ga-search-results {
       max-height: 415px;
-      @media (max-height: 550px) {
+
+      @media (max-height: @screen-s-height) {
         max-height: 325px;
+      }
+
+      @media (max-height: @screen-xs-height) {
+        max-height: 218px;
       }
     }
   }
   .ga-search-2 {
     .ga-search-results {
       max-height: 190px;
-      @media (max-height: 550px) {
+
+      @media (max-height: @screen-s-height) {
         max-height: 150px;
+      }
+
+      @media (max-height: @screen-xs-height) {
+        max-height: 94px;
       }
     }
   }
@@ -85,7 +95,7 @@
       padding: 3px 20px;
       font-size: 11px;
 
-      @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+      @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
         padding: 6px 10px;
         font-size: 13px;
       }

--- a/src/components/search/style/search.less
+++ b/src/components/search/style/search.less
@@ -140,7 +140,7 @@
     background-color: #E9E9E9;
     font-size: 14px;
 
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       padding: 5px 5px;
     }
   }
@@ -163,7 +163,7 @@
   .fa-remove-sign {
     right: 0;
     
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       font-size: 24px;
     }
   }

--- a/src/components/swipe/style/swipe.less
+++ b/src/components/swipe/style/swipe.less
@@ -66,7 +66,7 @@
       padding-right: 3px;
     }
     
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       bottom: 20px;
     } 
   }

--- a/src/components/topic/style/topic.less
+++ b/src/components/topic/style/topic.less
@@ -14,104 +14,42 @@
 
   .modal-dialog {
     width: 100%;
+    height: ~"calc(100% - 178px)";
     max-width: 850px;
+    max-height: 660px;
+
+    .modal-content {
+      height: 100%;
+    }
 
     .modal-body {
-      max-height: 950px;
+      height: ~"calc(100% - 58px)";
+      overflow-x: hidden;
 
-      @media (max-height: 1040px) {
-        max-height: 855px;
-      }
-
-      @media (max-height: 970px) {
-        max-height: 760px;
-      }
-
-      @media (max-height: 860px) {
-        max-height: 670px;
-      }
-
-      @media (max-height: 770px) {
-        max-height: 580px;
-      }
-
-      @media (max-height: 680px) {
-        max-height: 485px;
-      }
-
-      @media (max-height: 585px) {
-        max-height: 395px;
-      }
-
-      @media (max-height: 495px) {
-        max-height: 298px;
-      }
-
-      @media (max-height: 405px) {
-        max-height: 210px;
-      }
-
-      @media (max-height: 315px) {
-        max-height: 120px;
+      @media (max-width: @screen-phone) {
+        max-height: none !important;
       }
     }
 
     @media (max-width: @screen-desktop) {
       max-width: 692px;
-      top: 40px;
     }
 
-    @media (max-width: 780px) {
+    @media (max-width: @screen-tablet) {
       max-width: 535px;
-      top: 35px;
+      top: 50px;
     }
 
     @media (max-width: 605px) {
       max-width: 377px;
-      top: 30px;
     }
 
-    @media (max-width: 400px) {
+    @media (max-width: @screen-phone) {
       max-width: 205px;
-      top: 20px;
+    }
 
-      .modal-body {
-        @media (max-height: 1020px) {
-          max-height: 855px;
-        }
-
-        @media (max-height: 950px) {
-          max-height: 760px;
-        }
-
-        @media (max-height: 840px) {
-          max-height: 670px;
-        }
-
-        @media (max-height: 750px) {
-          max-height: 580px;
-        }
-
-        @media (max-height: 640px) {
-          max-height: 485px;
-        }
-
-        @media (max-height: 545px) {
-          max-height: 395px;
-        }
-
-        @media (max-height: 465px) {
-          max-height: 298px;
-        }
-
-        @media (max-height: 375px) {
-          max-height: 210px;
-        }
-
-        @media (max-height: 285px) {
-          max-height: 120px;
-        }
-      }
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
+      height: ~"calc(100% - 100px)";
     }
 
     .input-modal-container {

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -58,7 +58,6 @@
 @screen-xs-height: 480px;
 @screen-s-height: 600px;
 @screen-m-height: 800px;
-@screen-sm-max-height: @screen-s-height;
 
 @tooltip-bg: #999;
 @pulldown-width: 320;
@@ -265,7 +264,7 @@ button.ga-icon, &.ga-btn-disabled, &.ngeo-btn-disabled {
     opacity: 1;
   }
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     font-size: 2.2em;
     width: 1em;
   }
@@ -466,7 +465,7 @@ input[type=text][readonly] {
   line-height: unit(@header-height - 5, px);
   font-weight: normal;
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
      line-height: unit(@small-header-height - 5, px);
   }
 }
@@ -476,7 +475,7 @@ input[type=text][readonly] {
   height: unit(@header-height, px);
   background-color: rgba(255, 255, 255, 0.9);
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     height: unit(@small-header-height, px);
     background: #fff;
   }
@@ -507,12 +506,12 @@ input[type=text][readonly] {
     padding-left: 10px;
     height: 30px;
 
-    @media (min-width: @screen-desktop) and (min-height: @screen-sm-max-height) {
+    @media (min-width: @screen-desktop) and (min-height: @screen-s-height) {
       top: 21px;
     }
   }
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     margin-top: 0;
     width: 260px;
     top: .7em;
@@ -566,7 +565,7 @@ input[type=text][readonly] {
   height: unit(@header-height, px);
   background: white no-repeat left center;
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     width: 44px;
     height: unit(@small-header-height, px);
   }
@@ -618,7 +617,7 @@ input[type=text][readonly] {
 #logo {
   display: inline-block;
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
 
     .fa-ga-logo-bund {
       font-size: 21px;
@@ -1329,7 +1328,7 @@ ul.panel-body-wide {
     margin-right: 5px;
     height: 40px;
     line-height: 40px;
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       height: 44px;
       line-height: 44px;
     }
@@ -1623,7 +1622,7 @@ input[type=range] {
     bottom: unit(@bt-bottom-sm, px);
   }
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     top: unit(@small-header-height, px);
   }
 
@@ -1828,7 +1827,7 @@ body:not(.embed) {
   left: -50px;
   .rotate(-45deg);
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     top: 108px;
   }
 

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -1,6 +1,7 @@
 @import "ga_bootstrap.less";
 @import "font-awesome-4.5.0/less/font-awesome.less";
 @import "bootstrap-datetimepicker.less";
+@import "window.less";
 @import "../components/map/style/map.less";
 @import "../components/map/style/cesiuminspector.less";
 @import "../components/geolocation/style/geolocation.less";
@@ -53,7 +54,12 @@
 @small-header-height: 50;
 @bt-bottom: 51;
 @bt-bottom-sm: 26;
-@screen-sm-max-height: 600px;
+
+@screen-xs-height: 480px;
+@screen-s-height: 600px;
+@screen-m-height: 800px;
+@screen-sm-max-height: @screen-s-height;
+
 @tooltip-bg: #999;
 @pulldown-width: 320;
 @control-btn-size: 44;
@@ -492,7 +498,7 @@ input[type=text][readonly] {
   margin-top: 12px;
   z-index: 10; /* Put search on top of the form */
 
-  @media (max-width: 992px) {
+  @media (max-width: @screen-desktop) {
     margin-top: 27px;
   }
 
@@ -501,7 +507,7 @@ input[type=text][readonly] {
     padding-left: 10px;
     height: 30px;
 
-    @media (min-width: 992px) and (min-height:600px) {
+    @media (min-width: @screen-desktop) and (min-height: @screen-sm-max-height) {
       top: 21px;
     }
   }
@@ -852,23 +858,21 @@ a .ga-icon-separator {
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     font-size: 12px;
-    @media (max-height: 800px) {
+
+    @media (max-height: @screen-m-height) {
       max-height: 300px;
     }
-    @media (max-height: 680px) {
-      max-height: 200px;
+
+    @media (max-height: @screen-s-height) {
+      max-height: 95px;
     }
-    @media (max-height: 550px) {
-      max-height: 150px;
-    }
-    @media (max-height: 480px) {
-      max-height: 100px;
-    }
+
     @media (max-width: @screen-phone) {
       background-color: rgba(255,255,255,0.9);
       font-size: 14px;
       max-height: none;
     }
+
     .panel-body {
       padding: 0;
     }
@@ -877,9 +881,9 @@ a .ga-icon-separator {
   &.selection-and-catalog-shown {
     .panel-body {
       max-height: 250px;
-      @media (max-height: 800px) {
+      @media (max-height: @screen-m-height) {
         max-height: 150px;
-    }
+      }
       @media (max-width: @screen-phone) {
         max-height: none;
       }
@@ -908,7 +912,7 @@ a .ga-icon-separator {
   .translate3d(0, -100%, 0);
   -ms-transform: translateY(-100%); /* IE 9*/
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     top: unit(@small-header-height, px);
   }
 
@@ -950,7 +954,7 @@ a .ga-icon-separator {
       vertical-align: middle;
     }
 
-    @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+    @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
       padding: 12px 10px 12px 0;
     }
   }
@@ -1083,7 +1087,7 @@ a .ga-icon-separator {
   max-width: 600px;
   max-height: none;
 
-  @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
+  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
     top: unit(@small-header-height, px);
   }
 }

--- a/src/style/window.less
+++ b/src/style/window.less
@@ -1,0 +1,59 @@
+/* These CSSs are used by the gaWindow service to determine the size of the window. */
+.ga-window {
+  
+  > div {
+    display: none;
+  }
+  
+  &.ga-window-width {
+
+    @media (max-width: @screen-phone) {
+      .ga-visible-xs {
+        display: block;
+      }
+    }
+
+    @media (min-width: (@screen-phone + 1)) and (max-width: @screen-tablet) {
+      .ga-visible-s {
+        display: block;
+      }
+    }
+    
+    @media (min-width: (@screen-tablet + 1)) and (max-width: @screen-desktop) {
+      .ga-visible-m {
+        display: block;
+      }
+    }
+   
+    @media (min-width: (@screen-desktop + 1)) {
+      .ga-visible-l {
+        display: block;
+      }
+    }
+  }
+
+  &.ga-window-height {
+    
+    @media (max-height: @screen-xs-height) {
+      .ga-visible-xs {
+        display: block;
+      }
+    }
+    
+    @media (min-height: (@screen-xs-height + 1)) and (max-height: @screen-s-height) {
+      .ga-visible-s {
+        display: block;
+      }
+    }
+    @media (min-height: (@screen-s-height + 1)) and (max-height: @screen-m-height) {
+      .ga-visible-m {
+        display: block;
+      }
+    }
+   @media (min-height: (@screen-m-height + 1)) {
+      .ga-visible-l {
+        display: block;
+      }
+    }
+  }
+}

--- a/test/specs/MapLoadService.spec.js
+++ b/test/specs/MapLoadService.spec.js
@@ -67,7 +67,7 @@ describe('ga_mapload_service', function() {
         expect(spyLog.callCount).to.be(1);
       });
     });
-    
+
     describe('all', function() {
 
       it('waits for last loaded tile until all messages are displayed', function() {
@@ -90,7 +90,7 @@ describe('ga_mapload_service', function() {
         expect(spyLog.callCount).to.be(1);
       });
     });
-    
+
     describe('2 layers', function() {
 
       it('waits for all layers loaded', function() {

--- a/test/specs/What3WordsService.spec.js
+++ b/test/specs/What3WordsService.spec.js
@@ -1,4 +1,4 @@
-describe('ga_what3words', function() {
+describe('ga_what3words_service', function() {
 
   describe('gaWhat3Words', function() {
     var gaWhat3Words;

--- a/test/specs/WindowsService.spec.js
+++ b/test/specs/WindowsService.spec.js
@@ -1,0 +1,84 @@
+describe('ga_window_service', function() {
+
+  describe('gaWindow', function() {
+    var gaWindow, $window, widthDiv, heightDiv;
+
+    beforeEach(function() {
+      inject(function($injector) {
+        $window = $injector.get('$window');
+        gaWindow = $injector.get('gaWindow');
+      });
+      widthDiv = $('.ga-window.ga-window-width');
+      heightDiv = $('.ga-window.ga-window-height');
+    });
+
+    afterEach(function() {
+      widthDiv.find('> div').hide();
+      heightDiv.find('> div').hide();
+    });
+
+    it('adds html elements', function() {
+      expect(widthDiv.length).to.be(1);
+      expect(heightDiv.length).to.be(1);
+      ['xs', 's', 'm', 'l'].forEach(function(alias) {
+        expect(widthDiv.find('.ga-visible-' + alias).length).to.be(1);
+        expect(heightDiv.find('.ga-visible-' + alias).length).to.be(1);
+      });
+    });
+
+    // The PhantomJS window is 400*300, so we can only test xs screen.
+    describe('#isWidth()', function() {
+
+      describe('using an xs screen', function() {
+        [
+          '<=xs', 'xs', '>=xs',
+          '<s', '<=s',
+          '<m', '<=m',
+          '<l', '<=l'
+        ].forEach(function(alias) {
+          it('returns true for alias \'' + alias + '\'', function() {
+             expect(gaWindow.isWidth(alias)).to.be(true);
+          });
+        });
+
+        [
+          '<xs', '>xs',
+          's', '>=s', '>s',
+          'm', '>=m', '>m',
+          'l', '>=l', '>l'
+        ].forEach(function(alias) {
+          it('returns false for alias \'' + alias + '\'', function() {
+             expect(gaWindow.isWidth(alias)).to.be(false);
+          });
+        });
+      });
+    });
+
+    describe('#isHeight()', function() {
+
+      describe('using an xs screen', function() {
+        [
+          '<=xs', 'xs', '>=xs',
+          '<s', '<=s',
+          '<m', '<=m',
+          '<l', '<=l'
+        ].forEach(function(alias) {
+          it('returns true for alias \'' + alias + '\'', function() {
+             expect(gaWindow.isHeight(alias)).to.be(true);
+          });
+        });
+
+        [
+          '<xs', '>xs',
+          's', '>=s', '>s',
+          'm', '>=m', '>m',
+          'l', '>=l', '>l'
+        ].forEach(function(alias) {
+          it('returns false for alias \'' + alias + '\'', function() {
+             expect(gaWindow.isHeight(alias)).to.be(false);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
[Test](https://mf-geoadmin3.int.bgdi.ch/fix_3571/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,&X=199907.27&Y=614422.32&zoom=3)

You can test:

   - A popup (a tooltip) stays in the window when you resize it.
   - The catalog is closing when you reduce the height of the window
   - The topics are well displayed on whichever window sizes 
   - When you draw a point, the popover window where you modify the color is well displayed on small screen
  
