### PR TITLE
Fix #3054: Use autoprefixer to generate prefixed css

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ KARMA=${NODE_BIN}/karma
 PHANTOMJS=${NODE_BIN}/phantomjs
 NG_ANNOTATE=${NODE_BIN}/ng-annotate
 BABEL=${NODE_BIN}/babel
+POSTCSS=${NODE_BIN}/postcss
 
 .PHONY: help
 help:
@@ -451,6 +452,7 @@ prd/lib/build.js: src/lib/polyfill.min.js \
 prd/style/app.css: $(SRC_LESS_FILES)
 	mkdir -p $(dir $@)
 	${LESSC} $(LESS_PARAMETERS) --clean-css src/style/app.less $@
+	${POSTCSS} $@ --use autoprefixer --replace --no-map
 
 prd/geoadmin.appcache: src/geoadmin.mako.appcache \
 			${MAKO_CMD} \
@@ -610,6 +612,7 @@ src/deps.js: $(SRC_JS_FILES) ${PYTHON_VENV}
 
 src/style/app.css: $(SRC_LESS_FILES)
 	${LESSC} $(LESS_PARAMETERS) src/style/app.less $@
+	${POSTCSS} $@ --use autoprefixer --replace --no-map
 
 src/index.html: src/index.mako.html \
 	    ${MAKO_CMD} \

--- a/package.json
+++ b/package.json
@@ -11,6 +11,13 @@
   },
   "author": "Swisstopo",
   "readmeFileName": "README.md",
+  "//": "http://browserl.ist/?q=IE+9%2C+IE+10%2C+Android+%3E%3D+4%2C+%3E+0.5%25+in+CH",
+  "browserslist": [
+    "IE 9",
+    "IE 10",
+    "Android >= 4",
+    "> 0.5% in CH"
+  ],
   "dependencies": {
     "angular": "1.6.4",
     "angular-translate": "2.15.1",
@@ -24,6 +31,7 @@
   },
   "devDependencies": {
     "angular-mocks": "1.6.4",
+    "autoprefixer": "6.7.7",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "bootstrap": "3.3.7",
@@ -39,6 +47,7 @@
     "less-plugin-clean-css": "~1.5.1",
     "mocha": "3.3.0",
     "ng-annotate": "1.2.1",
+    "postcss-cli": "3.2.0",
     "phantomjs-prebuilt": "2.1.14",
     "sinon": "2.1.0"
   }

--- a/src/components/backgroundselector/style/backgroundselector.less
+++ b/src/components/backgroundselector/style/backgroundselector.less
@@ -1,5 +1,5 @@
 [ga-background-selector] {
-  .user-select(none);
+  user-select: none;
 
   .ga-bg-layer-bt, .ga-bg-layer, .ga-bg-layer-bt-close {
     bottom: unit(@bt-bottom, px);
@@ -9,7 +9,7 @@
     background: #fff data-uri('bg-layersx2.jpg') no-repeat 0 center;
     background-size: 275px 58px;
     border: 3px solid;
-    .transition-transform(~".5s,  bottom .5s, width .5s");
+    transition: transform .5s,  bottom .5s, width .5s;
 
     @media (max-width: @screen-tablet) {
       bottom: unit(@bt-bottom-sm, px);
@@ -93,22 +93,22 @@
     &.ga-open {
 
       .ga-swissimage {
-        .translate3d(0, -49px, 0);
+        transform: translate3d(0, -49px, 0);
         -ms-transform: translateY(-49px); /* IE 9*/
       }
 
       .ga-pixelkarte-farbe {
-        .translate3d(0, -98px, 0);
+        transform: translate3d(0, -98px, 0);
         -ms-transform: translateY(-98px); /* IE 9*/
       }
 
       .ga-pixelkarte-grau {
-        .translate3d(0, -147px, 0);
+        transform: translate3d(0, -147px, 0);
         -ms-transform: translateY(-147px); /* IE 9*/
       }
 
       .ga-voidLayer {
-        .translate3d(0, -196px, 0);
+        transform: translate3d(0, -196px, 0);
         -ms-transform: translateY(-196px); /* IE 9*/
       }
     }
@@ -153,22 +153,22 @@
       }
 
       .ga-swissimage {
-        .translate3d(-25px, 0 , 0);
+        transform: translate3d(-25px, 0 , 0);
         -ms-transform: translateX(-25px); /* IE 9*/
       }
 
       .ga-pixelkarte-farbe {
-        .translate3d(-126px, 0 , 0);
+        transform: translate3d(-126px, 0 , 0);
         -ms-transform: translateX(-126px); /* IE 9*/
       }
 
       .ga-pixelkarte-grau {
-        .translate3d(-227px, 0 , 0);
+        transform: translate3d(-227px, 0 , 0);
         -ms-transform: translateX(-227px); /* IE 9*/
       }
 
       .ga-voidLayer {
-        .translate3d(-328px, 0 , 0);
+        transform: translate3d(-328px, 0 , 0);
          -ms-transform: translateX(-328px); /* IE 9*/
       }
     }

--- a/src/components/controls3d/style/controls3d.less
+++ b/src/components/controls3d/style/controls3d.less
@@ -1,5 +1,5 @@
 [ga-controls3d] {
-  .user-select(none);
+  user-select: none;
   position: absolute;
   text-align: center;
   right: 0;
@@ -51,7 +51,7 @@
   .ga-indicator {
     width: 64px;
     height: 64px;
-    .transition(none);
+    transition: none;
     background-size: 64px;
 
     i {
@@ -103,7 +103,7 @@
     font-size: 11px;
     text-align: left;
     padding: 7px;
-    .box-shadow(0 5px 10px rgba(0, 0, 0, 0.2));
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
     background-color: #fff;
     border: 1px solid rgba(0, 0, 0, 0.2);
     border-radius: 6px;

--- a/src/components/draw/style/drawstyle.less
+++ b/src/components/draw/style/drawstyle.less
@@ -87,7 +87,7 @@
       position: absolute;
       top: 0px;
       right: 0px;
-      .transition-transform(0.5s ease);
+      transition: transform 0.5s ease;
     }
 
     > :not(button) {

--- a/src/components/layermanager/style/layermanager.less
+++ b/src/components/layermanager/style/layermanager.less
@@ -7,8 +7,8 @@
     height: 6em;
     padding: 0;
     overflow: hidden;
-    .transition(height .35s ease);
-    .user-select(none);
+    transition: height .35s ease;
+    user-select: none;
   }
 
   .slip-reordering {
@@ -152,7 +152,7 @@
     left: 0;
     background: #fff;
     border-left: 3px solid #666;
-    .transition(top .35s ease);
+    transition: top .35s ease;
 
     label {
       font-size: 0.9em;
@@ -183,8 +183,8 @@
     display: block;
     position: absolute;
     right: 0;
-    .transition-transform(.35s ease);
-    .rotate(0deg);
+    transition: transform .35s ease;
+    transform: rotate(0deg);
     color: red;
   }
 

--- a/src/components/map/style/cesiuminspector.less
+++ b/src/components/map/style/cesiuminspector.less
@@ -65,9 +65,6 @@
     border-radius: 5px;
     padding: 3px 7px;
     cursor: pointer;
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
     user-select: none;
     margin: 0 auto;
   }
@@ -100,8 +97,6 @@
 
   .cesium-cesiumInspector-section {
       margin-bottom: 10px;
-      -webkit-transition: max-height 0.25s;
-      -moz-transition: max-height 0.25s;
       transition: max-height 0.25s;
   }
 

--- a/src/components/map/style/map.less
+++ b/src/components/map/style/map.less
@@ -5,7 +5,7 @@
   z-index: 0;
 
   .ol-viewport .ol-unselectable {
-    .ga-user-select(none);
+    user-select: none;
   }
   
   .ol-dragbox {

--- a/src/components/offline/style/offline.less
+++ b/src/components/offline/style/offline.less
@@ -21,11 +21,9 @@
   button {
     transition: all ease 1s;
     transform: rotateY(360deg);
-    -webkit-transform: rotateY(-360deg);
 
     &.ga-btn-active {
       transform: rotateY(360deg);
-      -webkit-transform: rotateY(360deg);
 
       .fa-ga-offline {
         color: #ed1c24;
@@ -115,7 +113,7 @@
     border: @circle-half-px solid #666;
     border-radius: 50%;
     position: absolute;
-    .transition-transform(1s ease);
+    transition: transform 1s ease;
   }
 
 }

--- a/src/components/popup/style/popup.less
+++ b/src/components/popup/style/popup.less
@@ -196,7 +196,7 @@
       display: none;
     }
 
-    .transition(bottom 1s ease);
+    transition: bottom 1s ease;
 
     .popover-title {
       padding-right: 30px;

--- a/src/components/query/style/query.less
+++ b/src/components/query/style/query.less
@@ -20,10 +20,7 @@
     color: #555;
     background-color: #FFF;
     border: 1px solid #CCC;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0,
-    0.075);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-    -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
     transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
     height: 30px;
     padding: 5px 10px;

--- a/src/components/slider/style/slider.less
+++ b/src/components/slider/style/slider.less
@@ -14,27 +14,14 @@
       width: 100%;
       height: 100%;
       z-index: 0;
-      -webkit-border-radius: 1em/1em;
       border-radius: 1em/1em;
-      background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #c0c0c0), color-stop(1, #8d8d8d));
-      background: -webkit-linear-gradient(top, #c0c0c0 0, #8d8d8d 100%);
-      background: -moz-linear-gradient(top, #c0c0c0 0, #8d8d8d 100%);
-      background: -o-linear-gradient(top, #c0c0c0 0, #8d8d8d 100%);
-      background: -ms-linear-gradient(top, #c0c0c0 0, #8d8d8d 100%);
       background: linear-gradient(top, #c0c0c0 0, #8d8d8d 100%);
-      -webkit-box-shadow: inset 2px 2px 5px;
       box-shadow: inset 2px 2px 5px;
 
       &.ga-slider-selection {
         width: 0%;
         z-index: 1;
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #13b6ff), color-stop(1, #00a8f3));
-        background: -webkit-linear-gradient(top, #13b6ff 0, #00a8f3 100%);
-        background: -moz-linear-gradient(top, #13b6ff 0, #00a8f3 100%);
-        background: -o-linear-gradient(top, #13b6ff 0, #00a8f3 100%);
-        background: -ms-linear-gradient(top, #13b6ff 0, #00a8f3 100%);
         background: linear-gradient(top, #13b6ff 0, #00a8f3 100%);
-        -webkit-box-shadow: none;
         box-shadow: none;
       }
     }
@@ -47,10 +34,8 @@
       background-color: #fff;
       border: 1px solid #000;
       z-index: 2;
-      -webkit-border-radius: 1em/1em;
       border-radius: 1em/1em;
       touch-action: none;
-      -ms-touch-action: none;
             
       &:after {
         content: '';
@@ -60,7 +45,6 @@
         position: absolute;
         top: 6px;
         left: 6px;
-        -webkit-border-radius: 1em/1em;
         border-radius: 1em/1em;
       }
       

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -67,15 +67,6 @@
   display: none;
 }
 
-.ga-user-select(@val) {
-  user-select: @val;
-  -ms-user-select: @val;
-  -moz-user-select: @val;
-  -khtml-user-select: @val;
-  -webkit-user-select: @val;
-  -webkit-touch-callout: @val;
-}
-
 html, body {
   height: 100%;
   width: 100%;
@@ -272,7 +263,7 @@ button.ga-btn, button.ngeo-btn, .ol-control button {
   }
 
   &:not([disabled]) {
-    .transition-transform(.2s);
+    transition: transform .2s;
 
     &:hover {
       opacity: 0.7;
@@ -407,7 +398,7 @@ button.ga-btn, button.ngeo-btn, .ol-control button {
 }
 
 input[type=search] {
-  -webkit-appearance: none;
+  appearance: none;
 }
 select, input[type=text], input[type=email], input[type=search] {
   .form-control;
@@ -423,7 +414,7 @@ input[type=text][readonly] {
   margin: 0;
   transition: 1s ease;
   transition-property: top, height;
-  .box-shadow(6px 6px 12px rgba(0, 0, 0, 0.175));
+  box-shadow: 6px 6px 12px rgba(0, 0, 0, 0.175);
 }
 
 .ga-menu-bt {
@@ -453,7 +444,7 @@ input[type=text][readonly] {
   position: absolute;
   text-align: center;
   top: unit(-@header-height, px);
-  .transition-transform(.5s);
+  transition: transform .5s;
   z-index: 200;
   padding: 0;
   margin: 0;
@@ -804,8 +795,8 @@ a .ga-icon-separator {
       top: 0;
       background: #000;
       opacity: 0;
-      .translate3d(-100%, 0, 0);
-      .transition-transform(~"0s .3s, opacity .3s");
+      transform: translate3d(-100%, 0, 0);
+      transition: transform 0s .3s, opacity .3s;
       -ms-transform: translateX(-100%); /* IE 9*/
     }
   }
@@ -813,8 +804,8 @@ a .ga-icon-separator {
   &.ga-pulldown-shown .ga-pulldown-shadow {
     @media (max-width: @screen-phone) {
       opacity: 0.5;
-      .transition(opacity .3s);
-      .translate3d(0, 0, 0);
+      transition: opacity .3s;
+      transform: translate3d(0, 0, 0);
       -ms-transform: translateX(0); /* IE 9*/
     }
   }
@@ -825,7 +816,7 @@ a .ga-icon-separator {
     height: 14px;
     margin: 0 7px 0 12px;
     text-align: center;
-    .transition-transform(.2s);
+    transition: transform .2s;
     vertical-align: -2px;
   }
 
@@ -903,9 +894,9 @@ a .ga-icon-separator {
   width: unit(@pulldown-width, px);
   z-index: 600;
   top: unit(@header-height, px);
-  .box-shadow(6px 6px 12px rgba(0, 0, 0, 0.175));
-  .transition-transform(~".3s, width 0s .3s, top 1s");
-  .translate3d(0, -100%, 0);
+  box-shadow: 6px 6px 12px rgba(0, 0, 0, 0.175);
+  transition: transform .3s, width 0s .3s, top 1s;
+  transform: translate3d(0, -100%, 0);
   -ms-transform: translateY(-100%); /* IE 9*/
 
   @media (max-width: @screen-tablet), (max-height: @screen-sm-max-height) {
@@ -920,7 +911,7 @@ a .ga-icon-separator {
     max-height: 100%;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
-    .translate3d(100%, 0, 0);
+    transform: translate3d(100%, 0, 0);
 
     #shareHeading {
       display: none;
@@ -958,7 +949,7 @@ a .ga-icon-separator {
   .panel > .accordion-toggle {
     border-bottom: 1px solid #c7c7c7;
     font-weight: bold;
-    .transition(background-color .35s ease);
+    transition: background-color .35s ease;
 
     &.collapsed {
       background-color: #999;
@@ -977,13 +968,13 @@ a .ga-icon-separator {
 }
 
 .ga-pulldown-shown #pulldown-content {
-  .transition-transform(.3s);
-  .translate3d(0, 0, 0);
+  transition: transform .3s;
+  transform: translate3d(0, 0, 0);
   -ms-transform: translateY(0); /* IE 9*/
 
   @media (max-width: @screen-phone) {
     width: 96%;
-    .transition-delay(.1s); /* delay of .1s needed for Safari */
+    transition-delay: .1s; /* delay of .1s needed for Safari */
   }
 }
 
@@ -1001,12 +992,12 @@ a .ga-icon-separator {
   border-color: #474949;
   color: #fff;
   font-weight: bold;
-  .box-shadow(6px 6px 12px rgba(0, 0, 0, 0.175));
+  box-shadow: 6px 6px 12px rgba(0, 0, 0, 0.175);
 
   .fa-caret-down {
     display: inline-block;
     vertical-align: middle;
-    .transition-transform(.2s ease);
+    transition: transform .2s ease;
   }
 
   .ga-hidden-collapsed, .ga-visible-mobile {
@@ -1409,16 +1400,11 @@ ul.panel-body-wide {
 }
 
 // ***** MOBILE LOADER
-@-webkit-keyframes loader {
-  0% { width: 0%; }
-  100% { width: 100%; }
-}
 @keyframes loader {
   0% { width: 0%; }
   100% { width: 100%; }
 }
 .ga-spin() {
-  -webkit-animation: spin 2s infinite linear;
   animation: spin 2s infinite linear;
 }
 
@@ -1440,7 +1426,6 @@ ul.panel-body-wide {
 
 .online.ga-wait-cursor {
   #loader {
-    -webkit-animation: loader 1s infinite;
     animation: loader 1s infinite;
     opacity: 1;
   }
@@ -1461,7 +1446,7 @@ ul.panel-body-wide {
   top: auto;
   width: 200px;
   margin-left: -100px;
-  .transition(opacity 1s ease);
+  transition: opacity 1s ease;
   &.bottom {
     bottom: auto;
     top: 0;
@@ -1553,9 +1538,7 @@ input[type=range] {
 .webkit .ga-checkbox {
 
   input[type=checkbox] {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    -ms-appearance: none;
+    appearance: none;
     border: 0;
     background: white;
     vertical-align: -3px;
@@ -1605,15 +1588,15 @@ input[type=range] {
 }
 
 #buttonGroup {
-  .user-select(none);
+  user-select: none;
   pointer-events: none;
   position: absolute;
   top: unit(@header-height, px);
   right: unit(@control-btns-right, px);
   bottom: unit(@bt-bottom, px);
   z-index: 1000;
-  .transition(1s);
-  .transition-property(~"top, bottom");
+  transition: 1s;
+  transition-property: top, bottom;
 
   @media (max-width: @screen-tablet) {
     bottom: unit(@bt-bottom-sm, px);
@@ -1736,7 +1719,7 @@ body:not(.embed) {
     > div {
       position: relative;
       padding: 2px 5px;
-      .box-shadow(rgba(0, 0, 0, .29) 0px 1px 4px -1px);
+      box-shadow: rgba(0, 0, 0, .29) 0px 1px 4px -1px;
       border-radius: 4px;
       background-color: white;
       font-weight: bold;

--- a/src/style/offline.less
+++ b/src/style/offline.less
@@ -2,7 +2,7 @@
   @header-height-px: unit(@header-height, px);
 
   .ga-offline-msg {
-    .translate3d(0, @header-height-px, 0);
+    transform: translate3d(0, @header-height-px, 0);
   }
 
   #pulldown,

--- a/src/style/print.less
+++ b/src/style/print.less
@@ -7,7 +7,6 @@
 
   .popover {
     box-shadow: none;
-    -webkit-box-shadow: none;
   }
 
   #header {


### PR DESCRIPTION
Before we used [vendor mixins of bootstrap](http://getbootstrap.com/css/#less-mixins-vendor) to generat css for specifix old browsers.

With this PR we remove the use of bs mixins and let [autoprefixer](https://github.com/postcss/autoprefixer) decides which css must be prefixed depending on the [browserslist](https://github.com/ai/browserslist) specified in the package.json file.

For example you can test on old browsers:
    - mobile menu opening
    - background selector list opening

[Test](https://mf-geoadmin3.int.bgdi.ch/fix_3054/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&dev3d=true&debug)