### PR TITLE
Avoid using CF addresses for resources in print

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -9,6 +9,15 @@ goog.provide('ga_urlutils_service');
 
       var UrlUtils = function(shortenUrl) {
 
+        // Ugly hack because print can't work with most CF distributions. So
+        // we tap s3 backend directly
+        var CF_TO_NONCF = [
+         ['map.geo.admin.ch',
+          's3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin'],
+         ['mf-geoadmin3.int.bgdi.ch',
+          's3-eu-west-1.amazonaws.com/mf-geoadmin3-int-dublin']
+        ];
+
         // from Angular
         // https://github.com/angular/angular.js/blob/v1.4.8/src/ng/directive/input.js#L15
         var URL_REGEXP = new RegExp('^(blob:)?(ftp|http|https):\\/\\/' +
@@ -133,6 +142,19 @@ goog.provide('ga_urlutils_service');
 
         this.getHostname = function(str) {
           return decodeURIComponent(str).match(/:\/\/(.[^/]+)/)[1].toString();
+        };
+
+        // If it's cloudfron URL, replace it with non-CF one
+        this.nonCloudFrontUrl = function(url) {
+          if (this.isValid(url)) {
+            var hostName = this.getHostname(url);
+            for (var i = 0; i < CF_TO_NONCF.length; i++) {
+              if (hostName == CF_TO_NONCF[i][0]) {
+                return url.replace(CF_TO_NONCF[i][0], CF_TO_NONCF[i][1]);
+              }
+            }
+          }
+          return url;
         };
 
         this.append = function(url, paramString) {

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -630,7 +630,8 @@ goog.require('ga_urlutils_service');
             'type': 'Vector',
             'styles': {
               '1': { // Style for marker position
-                'externalGraphic': $scope.options.markerUrl,
+                'externalGraphic':
+                  gaUrlUtils.nonCloudFrontUrl($scope.options.markerUrl),
                 'graphicWidth': 20,
                 'graphicHeight': 30,
                 // the icon is not perfectly centered in the image

--- a/src/components/print/PrintStyleService.js
+++ b/src/components/print/PrintStyleService.js
@@ -1,13 +1,18 @@
 goog.provide('ga_printstyle_service');
+
+goog.require('ga_urlutils_service');
+
 (function() {
 
-  var module = angular.module('ga_printstyle_service', [])
+  var module = angular.module('ga_printstyle_service', [
+    'ga_urlutils_service'
+  ])
       .provider('gaPrintStyle', gaPrintStyle);
 
   function gaPrintStyle() {
-    this.$get = function() {
+    this.$get = function(gaUrlUtils) {
       return {
-        olStyleToPrintLiteral: olStyleToPrintLiteral,
+        olStyleToPrintLiteral: getolStyleToPrintLiteral(gaUrlUtils),
         olPointToPolygon: olPointToPolygon,
         olCircleToPolygon: olCircleToPolygon
       };
@@ -90,154 +95,159 @@ goog.provide('ga_printstyle_service');
     return new ol.geom.Polygon([points]);
   }
 
-  // Transform a ol.style.Style to a print literal object
-  function olStyleToPrintLiteral(style, dpi) {
-    /**
-     * ol.style.Style properties:
-     *
-     *  fill: ol.style.Fill :
-     *    fill: String
-     *  image: ol.style.Image:
-     *    anchor: array[2]
-     *    rotation
-     *    size: array[2]
-     *    src: String
-     *  stroke: ol.style.Stroke:
-     *    color: String
-     *    lineCap
-     *    lineDash
-     *    lineJoin
-     *    miterLimit
-     *    width: Number
-     *  text
-     *  zIndex
-     */
+  function getolStyleToPrintLiteral(gaUrlUtils) {
+    return olStyleToPrintLiteral;
+    // Transform a ol.style.Style to a print literal object
+    function olStyleToPrintLiteral(style, dpi) {
+      /**
+       * ol.style.Style properties:
+       *
+       *  fill: ol.style.Fill :
+       *    fill: String
+       *  image: ol.style.Image:
+       *    anchor: array[2]
+       *    rotation
+       *    size: array[2]
+       *    src: String
+       *  stroke: ol.style.Stroke:
+       *    color: String
+       *    lineCap
+       *    lineDash
+       *    lineJoin
+       *    miterLimit
+       *    width: Number
+       *  text
+       *  zIndex
+       */
 
-    /**
-     * Print server properties:
-     *
-     * fillColor
-     * fillOpacity
-     * strokeColor
-     * strokeOpacity
-     * strokeWidth
-     * strokeLinecap
-     * strokeLinejoin
-     * strokeDashstyle
-     * pointRadius
-     * label
-     * fontFamily
-     * fontSize
-     * fontWeight
-     * fontColor
-     * labelAlign
-     * labelXOffset
-     * labelYOffset
-     * labelOutlineColor
-     * labelOutlineWidth
-     * graphicHeight
-     * graphicOpacity
-     * graphicWidth
-     * graphicXOffset
-     * graphicYOffset
-     * zIndex
-     */
-    if (!style || !(style instanceof ol.style.Style) || !dpi) {
-      return;
-    }
-    var literal = {
-      zIndex: style.getZIndex()
-    };
-    var fill = style.getFill();
-    var stroke = style.getStroke();
-    var textStyle = style.getText();
-    var imageStyle = style.getImage();
+      /**
+       * Print server properties:
+       *
+       * fillColor
+       * fillOpacity
+       * strokeColor
+       * strokeOpacity
+       * strokeWidth
+       * strokeLinecap
+       * strokeLinejoin
+       * strokeDashstyle
+       * pointRadius
+       * label
+       * fontFamily
+       * fontSize
+       * fontWeight
+       * fontColor
+       * labelAlign
+       * labelXOffset
+       * labelYOffset
+       * labelOutlineColor
+       * labelOutlineWidth
+       * graphicHeight
+       * graphicOpacity
+       * graphicWidth
+       * graphicXOffset
+       * graphicYOffset
+       * zIndex
+       */
+      if (!style || !(style instanceof ol.style.Style) || !dpi) {
+        return;
+      }
+      var literal = {
+        zIndex: style.getZIndex()
+      };
+      var fill = style.getFill();
+      var stroke = style.getStroke();
+      var textStyle = style.getText();
+      var imageStyle = style.getImage();
 
-    if (imageStyle) {
-      var size, anchor, scale = imageStyle.getScale();
-      literal.rotation = imageStyle.getRotation();
+      if (imageStyle) {
+        var size, anchor, scale = imageStyle.getScale();
+        literal.rotation = imageStyle.getRotation();
 
-      if (imageStyle instanceof ol.style.Icon) {
-        size = imageStyle.getSize();
-        anchor = imageStyle.getAnchor();
-        literal.externalGraphic = imageStyle.getSrc();
-        literal.fillOpacity = 1;
-      } else if (imageStyle instanceof ol.style.Circle ||
-          imageStyle instanceof ol.style.RegularShape) {
-        fill = imageStyle.getFill();
-        stroke = imageStyle.getStroke();
-        var radius = imageStyle.getRadius();
-        var width = adjustDist(2 * radius, dpi);
-        if (stroke) {
-          width += adjustDist(stroke.getWidth() + 1, dpi);
+        if (imageStyle instanceof ol.style.Icon) {
+          size = imageStyle.getSize();
+          anchor = imageStyle.getAnchor();
+          literal.externalGraphic =
+            gaUrlUtils.nonCloudFrontUrl(imageStyle.getSrc());
+          literal.fillOpacity = 1;
+        } else if (imageStyle instanceof ol.style.Circle ||
+            imageStyle instanceof ol.style.RegularShape) {
+          fill = imageStyle.getFill();
+          stroke = imageStyle.getStroke();
+          var radius = imageStyle.getRadius();
+          var width = adjustDist(2 * radius, dpi);
+          if (stroke) {
+            width += adjustDist(stroke.getWidth() + 1, dpi);
+          }
+          size = [width, width];
+          anchor = [width / 2, width / 2];
+          literal.pointRadius = radius;
         }
-        size = [width, width];
-        anchor = [width / 2, width / 2];
-        literal.pointRadius = radius;
+
+        if (size) {
+          // Print server doesn't handle correctly 0 values for the size
+          literal.graphicWidth = adjustDist((size[0] * scale || 0.1), dpi);
+          literal.graphicHeight = adjustDist((size[1] * scale || 0.1), dpi);
+        }
+        if (anchor) {
+          literal.graphicXOffset = adjustDist(-anchor[0] * scale, dpi);
+          literal.graphicYOffset = adjustDist(-anchor[1] * scale, dpi);
+        }
+
       }
 
-      if (size) {
-        // Print server doesn't handle correctly 0 values for the size
-        literal.graphicWidth = adjustDist((size[0] * scale || 0.1), dpi);
-        literal.graphicHeight = adjustDist((size[1] * scale || 0.1), dpi);
-      }
-      if (anchor) {
-        literal.graphicXOffset = adjustDist(-anchor[0] * scale, dpi);
-        literal.graphicYOffset = adjustDist(-anchor[1] * scale, dpi);
+      if (fill) {
+        var color = ol.color.asArray(fill.getColor());
+        literal.fillColor = toHexa(color);
+        literal.fillOpacity = color[3];
+      } else if (!literal.fillOpacity) {
+        literal.fillOpacity = 0; // No fill
       }
 
-    }
+      if (stroke) {
+        var color = ol.color.asArray(stroke.getColor());
+        literal.strokeWidth = adjustDist(stroke.getWidth(), dpi);
+        literal.strokeColor = toHexa(color);
+        literal.strokeOpacity = color[3];
+        literal.strokeLinecap = stroke.getLineCap() || 'round';
+        literal.strokeLinejoin = stroke.getLineJoin() || 'round';
 
-    if (fill) {
-      var color = ol.color.asArray(fill.getColor());
-      literal.fillColor = toHexa(color);
-      literal.fillOpacity = color[3];
-    } else if (!literal.fillOpacity) {
-      literal.fillOpacity = 0; // No fill
-    }
-
-    if (stroke) {
-      var color = ol.color.asArray(stroke.getColor());
-      literal.strokeWidth = adjustDist(stroke.getWidth(), dpi);
-      literal.strokeColor = toHexa(color);
-      literal.strokeOpacity = color[3];
-      literal.strokeLinecap = stroke.getLineCap() || 'round';
-      literal.strokeLinejoin = stroke.getLineJoin() || 'round';
-
-      if (stroke.getLineDash()) {
-        literal.strokeDashstyle = 'dash';
-      }
-      // TO FIX: Not managed by the print server
-      // literal.strokeMiterlimit = stroke.getMiterLimit();
-    } else {
-      literal.strokeOpacity = 0; // No Stroke
-    }
-
-    if (textStyle && textStyle.getText()) {
-      literal.label = textStyle.getText();
-      literal.labelAlign = textStyle.getTextAlign();
-
-      if (textStyle.getFill()) {
-        var fillColor = ol.color.asArray(textStyle.getFill().getColor());
-        literal.fontColor = toHexa(fillColor);
+        if (stroke.getLineDash()) {
+          literal.strokeDashstyle = 'dash';
+        }
+        // TO FIX: Not managed by the print server
+        // literal.strokeMiterlimit = stroke.getMiterLimit();
+      } else {
+        literal.strokeOpacity = 0; // No Stroke
       }
 
-      if (textStyle.getFont()) {
-        var fontValues = textStyle.getFont().split(' ');
-        // Fonts managed by print server: COURIER, HELVETICA, TIMES_ROMAN
-        literal.fontFamily = fontValues[2].toUpperCase();
-        literal.fontSize = parseInt(fontValues[1]);
-        literal.fontWeight = fontValues[0];
+      if (textStyle && textStyle.getText()) {
+        literal.label = textStyle.getText();
+        literal.labelAlign = textStyle.getTextAlign();
+
+        if (textStyle.getFill()) {
+          var fillColor = ol.color.asArray(textStyle.getFill().getColor());
+          literal.fontColor = toHexa(fillColor);
+        }
+
+        if (textStyle.getFont()) {
+          var fontValues = textStyle.getFont().split(' ');
+          // Fonts managed by print server: COURIER, HELVETICA, TIMES_ROMAN
+          literal.fontFamily = fontValues[2].toUpperCase();
+          literal.fontSize = parseInt(fontValues[1]);
+          literal.fontWeight = fontValues[0];
+        }
+
+        /* TO FIX: Not managed by the print server
+        if (textStyle.getStroke()) {
+          var strokeColor = ol.color.asArray(textStyle.getStroke().getColor());
+          literal.labelOutlineColor = toHexa(strokeColor);
+          literal.labelOutlineWidth = textStyle.getStroke().getWidth();
+        }*/
       }
 
-      /* TO FIX: Not managed by the print server
-      if (textStyle.getStroke()) {
-        var strokeColor = ol.color.asArray(textStyle.getStroke().getColor());
-        literal.labelOutlineColor = toHexa(strokeColor);
-        literal.labelOutlineWidth = textStyle.getStroke().getWidth();
-      }*/
-    }
+      return literal;
+    };
 
-    return literal;
   };
 })();

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -218,6 +218,21 @@ describe('ga_urlutils_service', function() {
       });
     });
 
+
+    describe('#nonCloudFrontUrl()', function() {
+      it('verifies cloudfront url transformation valid', function() {
+        expect(gaUrlUtils.nonCloudFrontUrl('http://public.geo.admin.ch')).to.be('http://public.geo.admin.ch');
+        expect(gaUrlUtils.nonCloudFrontUrl('http://map.geo.admin.ch')).to.be('http://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin');
+        expect(gaUrlUtils.nonCloudFrontUrl('http://map.geo.admin.ch/')).to.be('http://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin/');
+        expect(gaUrlUtils.nonCloudFrontUrl('http://map.geo.admin.ch/asd')).to.be('http://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin/asd');
+        expect(gaUrlUtils.nonCloudFrontUrl('https://map.geo.admin.ch/asd')).to.be('https://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin/asd');
+        expect(gaUrlUtils.nonCloudFrontUrl('map.geo.admin.ch')).to.be('map.geo.admin.ch');
+        expect(gaUrlUtils.nonCloudFrontUrl('https://mf-geoadmin3.int.bgdi.ch/asd')).to.be('https://s3-eu-west-1.amazonaws.com/mf-geoadmin3-int-dublin/asd');
+      });
+    });
+
+
+
     describe('#append()', function() {
       it('appends parameter string', function() {
         var url = 'http://wms.admin.ch';


### PR DESCRIPTION
Here's a fix for https://github.com/geoadmin/mf-geoadmin3/issues/3794

It assures that we don't use CloudFront addresses for our markes in the print. It uses the direct S3 bucket URLS. Not that CloudFront might not be the issue, see https://github.com/geoadmin/service-print/issues/29#issuecomment-299209328

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_marker/index.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers_visibility=false&layers_timestamp=18641231&lang=de&X=137981&Y=631628&zoom=5&crosshair=marker)