### PR TITLE
Don't use AWS based proxy

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -60,9 +60,7 @@ goog.provide('ga_urlutils_service');
           var parts = /^(http|https)(:\/\/)(.+)/.exec(url);
           var protocol = parts[1];
           var resource = parts[3];
-          // proxy is RESTFful, <service>/<protocol>/<resource>
-          return gaGlobalOptions.proxyUrl + protocol + '/' +
-              encodeURIComponent(resource);
+          return gaGlobalOptions.proxyUrl + encodeURIComponent(url);
         };
 
         this.proxifyUrlInstant = function(url) {

--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -65,14 +65,6 @@ goog.require('ngeo.fileService');
           /<href>http(?!(s:\/\/maps\.(google|gstatic)\.com[a-zA-Z\d\.\-\/_]*\.png|s?:\/\/[a-z\d\.\-]*(bgdi|geo.admin)\.ch))/g,
           '<href>' + gaGlobalOptions.proxyUrl + 'http'
         );
-        // We still need to convert <href>https://proxy.admin.ch/https:// to
-        // <href>https://proxy.admin.ch/https/
-        kml = kml.replace(
-          new RegExp('<href>' + gaGlobalOptions.proxyUrl + 'http://', 'g'),
-          '<href>' + gaGlobalOptions.proxyUrl + 'http/')
-            .replace(
-          new RegExp('<href>' + gaGlobalOptions.proxyUrl + 'https://', 'g'),
-          '<href>' + gaGlobalOptions.proxyUrl + 'https/');
 
         // Replace all http hrefs from *.geo.admin.ch or *.bgdi.ch by https
         // Test regex here: http://regex101.com/r/fY7wB3/5

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -802,7 +802,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           mapUrl: location.origin + pathname,
           apiUrl: apiUrl,
           printUrl: printUrl,
-          proxyUrl: proxyUrl,
+          proxyUrl: apiUrl + '/ogcproxy?url=',
           mapproxyUrl: mapproxyUrl,
           vectorTilesUrl: vectorTilesUrl,
           shopUrl: shopUrl,

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -91,7 +91,7 @@ describe('ga_urlutils_service', function() {
     describe('#proxifyUrlInstant()', function() {
       it('applies proxy correctly', function() {
         expect(gaUrlUtils.proxifyUrlInstant('http://data.geo.admin.ch')).to.be(
-            gaGlobalOptions.proxyUrl + 'http/data.geo.admin.ch');
+            gaGlobalOptions.proxyUrl + 'http%3A%2F%2Fdata.geo.admin.ch');
         expect(gaUrlUtils.proxifyUrlInstant('https://data.geo.admin.ch')).to.be(
             'https://data.geo.admin.ch');
         expect(gaUrlUtils.proxifyUrlInstant('blob:https://myblob.ch/7a910681-938c-4011-8d75-2b64035a40a7')).to.be(
@@ -103,7 +103,7 @@ describe('ga_urlutils_service', function() {
       it('applies proxy correctly', function() {
         var cProxy = gaUrlUtils.getCesiumProxy();
         expect(cProxy.getURL('http://dummyresource.com')).to.be(
-            gaGlobalOptions.proxyUrl + 'http/dummyresource.com');
+            gaGlobalOptions.proxyUrl + 'http%3A%2F%2Fdummyresource.com');
         cProxy = gaUrlUtils.getCesiumProxy();
         expect(cProxy.getURL('https://data.geo.admin.ch')).to.be(
             'https://data.geo.admin.ch');
@@ -119,7 +119,7 @@ describe('ga_urlutils_service', function() {
 
       it('applies a proxy correctly on http://data.geo.admin.ch', function(done) {
         gaUrlUtils.proxifyUrl('http://data.geo.admin.ch').then(function(url) {
-          expect(url).to.be(gaGlobalOptions.proxyUrl + 'http/data.geo.admin.ch');
+          expect(url).to.be(gaGlobalOptions.proxyUrl + 'http%3A%2F%2Fdata.geo.admin.ch');
           done();
         });
         $rootScope.$digest();
@@ -127,7 +127,7 @@ describe('ga_urlutils_service', function() {
 
       it('applies a proxy correctly on http://ineedaproxybadly.ch', function(done) {
         gaUrlUtils.proxifyUrl('http://ineedaproxybadly.ch').then(function(url) {
-          expect(url).to.be(gaGlobalOptions.proxyUrl + 'http/ineedaproxybadly.ch');
+          expect(url).to.be(gaGlobalOptions.proxyUrl + 'http%3A%2F%2Fineedaproxybadly.ch');
           done();
         });
         $rootScope.$digest();

--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -660,7 +660,7 @@ describe('ga_kml_service', function() {
           var feat = olLayer.getSource().getFeatures()[0];
           var style = feat.getStyleFunction().call(feat)[0];
           expect(style.getImage()).to.be.an(ol.style.Icon);
-          expect(style.getImage().getSrc()).to.eql('https://proxy.geo.admin.ch/http/voila.fr/ki.png');
+          expect(style.getImage().getSrc()).to.eql('https://proxy.geo.admin.ch/http://voila.fr/ki.png');
           expect(style.getImage().getScale()).to.eql(1);
           expect(style.getImage().getRotateWithView()).to.eql(false);
           expect(style.getImage().getAnchor()).to.eql(null);
@@ -670,7 +670,7 @@ describe('ga_kml_service', function() {
           feat = olLayer.getSource().getFeatures()[1];
           style = feat.getStyleFunction().call(feat)[0];
           expect(style.getImage()).to.be.an(ol.style.Icon);
-          expect(style.getImage().getSrc()).to.eql('https://proxy.geo.admin.ch/http/voila.fr/ki.png');
+          expect(style.getImage().getSrc()).to.eql('https://proxy.geo.admin.ch/http://voila.fr/ki.png');
           expect(style.getImage().getScale()).to.eql(0.7);
           expect(style.getImage().getRotateWithView()).to.eql(false);
           expect(style.getImage().getAnchor()).to.eql(null);
@@ -1038,7 +1038,7 @@ describe('ga_kml_service', function() {
         prtl = 'http';
         gaKmlMock = sinon.mock(gaKml);
         url = 'test.kml';
-        encoded = gaGlobalOptions.proxyUrl + prtl + '/' +
+        encoded = gaGlobalOptions.proxyUrl + prtl + '%3A%2F%2F' +
             encodeURIComponent(url);
       });
 

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -980,7 +980,7 @@ describe('ga_map_service', function() {
         expect(args[0]).to.be('http://foo.kml');
         expect(args[1].camera).to.be(scene.camera);
         expect(args[1].canvas).to.be(scene.canvas);
-        expect(args[1].proxy.getURL('http://foo.kml')).to.be('http://proxy.geo.admin.ch/http/foo.kml');
+        expect(args[1].proxy.getURL('http://foo.kml')).to.be('http://proxy.geo.admin.ch/http%3A%2F%2Ffoo.kml');
         spy.restore();
       });
     });
@@ -1140,7 +1140,7 @@ describe('ga_map_service', function() {
 
         it('returns a GeoJSON layer', function() {
           $httpBackend.expectGET('http://mystyle.json').respond({});
-          $httpBackend.expectGET(gaGlobalOptions.proxyUrl + 'http/my.json').respond({
+          $httpBackend.expectGET(gaGlobalOptions.proxyUrl + 'http%3A%2F%2Fmy.json').respond({
             'features': [{
               'type': 'Feature',
               'geometry': {

--- a/test/specs/map/WmsService.spec.js
+++ b/test/specs/map/WmsService.spec.js
@@ -85,7 +85,7 @@ describe('ga_wms_service', function() {
 
       if (options.useThirdPartyData) {
         expect(prov.proxy.getURL('http://wms.ch')).to.be(
-            gaGlobalOptions.proxyUrl + 'http/wms.ch');
+            gaGlobalOptions.proxyUrl + 'http%3A%2F%2Fwms.ch');
       } else {
         expect(prov.proxy.getURL('https://wms.geo.admin.ch')).to.be(
             'https://wms.geo.admin.ch');


### PR DESCRIPTION
For today's deploy, we don't want to use the AWS backed ogcproxy.

This PR keeps the CORS testing in place, but will use the existing OGC proxy service of the API

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_tempproxy/index.html)