### PR TITLE
Auto Update KML at given interval

### DIFF
--- a/src/components/map/KmlService.js
+++ b/src/components/map/KmlService.js
@@ -109,8 +109,8 @@ goog.require('ngeo.fileService');
           angular.forEach(networkLinks, function(networkLink) {
             if (gaUrlUtils.isValid(networkLink.href)) {
               all.push($http.get(networkLink.href).then(function(response) {
-                return readFeatures(response.data,
-                                    projection).then(function(newFeatures) {
+                return readFeatures(response.data, projection).then(
+                    function(newFeatures) {
                   features = features.concat(newFeatures);
                 });
               }));

--- a/src/components/map/PermalinkLayersService.js
+++ b/src/components/map/PermalinkLayersService.js
@@ -251,7 +251,8 @@ goog.require('ga_wmts_service');
                   }
                   layer.time = timestamp;
                 }
-                if (params && layer.getSource().updateParams) {
+                if (params && layer.getSource &&
+                    layer.getSource().updateParams) {
                   layer.getSource().updateParams(params);
                 }
                 map.addLayer(layer);
@@ -261,7 +262,7 @@ goog.require('ga_wmts_service');
 
               // KML layer
               var url = layerSpec.replace('KML||', '');
-              var delay = params ? parseInt(params['updateDelay']) : NaN;
+              var delay = params ? parseInt(params.updateDelay) : NaN;
               if (!isNaN(delay)) {
                 delay = (delay < 3) ? 3 : delay;
               }

--- a/src/components/map/PermalinkLayersService.js
+++ b/src/components/map/PermalinkLayersService.js
@@ -261,11 +261,16 @@ goog.require('ga_wmts_service');
 
               // KML layer
               var url = layerSpec.replace('KML||', '');
+              var delay = params ? parseInt(params['updateDelay']) : NaN;
+              if (!isNaN(delay)) {
+                delay = (delay < 3) ? 3 : delay;
+              }
               try {
                 gaKml.addKmlToMapForUrl(map, url,
                   {
                     opacity: opacity || 1,
-                    visible: visible
+                    visible: visible,
+                    updateDelay: isNaN(delay) ? undefined : delay * 1000
                   },
                   index + 1);
                 mustReorder = true;

--- a/test/specs/map/PermalinkLayersService.spec.js
+++ b/test/specs/map/PermalinkLayersService.spec.js
@@ -102,11 +102,12 @@ describe('ga_permalinklayers_service', function() {
           activatedLayers: ['foo3', 'bar3']
         };
 
-    var createManager = function(topicToLoad, layersParam, opacityParam, visParam, timeParam) {
+    var createManager = function(topicToLoad, layersParam, opacityParam, visParam, timeParam, paramsParam) {
       layersPermalink = layersParam || layersPermalink;
       layersOpacityPermalink = opacityParam || layersOpacityPermalink;
       layersVisPermalink = visParam || layersVisPermalink;
       layersTimePermalink = timeParam || layersTimePermalink;
+      layersParamsPermalink = paramsParam || layersParamsPermalink;
 
       inject(function($injector) {
         manager = $injector.get('gaPermalinkLayersManager');
@@ -169,6 +170,7 @@ describe('ga_permalinklayers_service', function() {
               layers_opacity: layersOpacityPermalink,
               layers_visibility: layersVisPermalink,
               layers_timestamp: layersTimePermalink,
+              layers_params: layersParamsPermalink,
               mobile: false
             };
             return params;
@@ -178,6 +180,7 @@ describe('ga_permalinklayers_service', function() {
             layersOpacityPermalink = params.layers_opacity || layersOpacityPermalink;
             layersVisPermalink = params.layers_visibility || layersVisPermalink;
             layersTimePermalink = params.layers_timestamp || layersTimePermalink;
+            layersParamsPermalink = params.layers_params || layersParamsPermalink;
           },
           deleteParam: function(param) {
             if (param == 'layers') {
@@ -188,6 +191,8 @@ describe('ga_permalinklayers_service', function() {
               layersVisPermalink = undefined;
             } else if (param == 'layers_timestamp') {
               layersTimePermalink = undefined;
+            } else if (param == 'layers_params') {
+              layersParamsPermalink = undefined;
             }
             delete params[param];
           }
@@ -213,6 +218,7 @@ describe('ga_permalinklayers_service', function() {
       layersOpacityPermalink = undefined;
       layersVisPermalink = undefined;
       layersTimePermalink = undefined;
+      layersParamsPermalink = undefined;
       topic = undefined;
     });
 
@@ -228,11 +234,12 @@ describe('ga_permalinklayers_service', function() {
 
       it('an external KML layer', function() {
         var id = 'KML||http://foo.ch/bar.kml';
-        createManager(topicLoaded, id, '0.3', 'false');
+        createManager(topicLoaded, id, '0.3', 'false', undefined, 'updateDelay=3');
         expect(map.getLayers().getLength()).to.be(1);
         expect(permalink.getParams().layers).to.be(id);
         expect(permalink.getParams().layers_opacity).to.be('0.3');
         expect(permalink.getParams().layers_visibility).to.be('false');
+        expect(permalink.getParams().layers_params).to.be('updateDelay=3');
       });
 
       it('an external WMS layer', function() {


### PR DESCRIPTION
With integrated GeoJSON layers, we can specify an updateDelay to reload the data from source and update the display accordingly. This allows for 'real time' data to be displayed.

This PR adds the same capability to any KML integrated via the PL. It allows to specify a layers_params updateDelay parameter, which, in seconds, specifies the update rate. No lower than 3 seconds is currently allowed. It can be specified as follows:

`layers_params=updateDelay=3`

Note that it follows the same logic as all other layer related parameters. If multiple layers are added, the layers_params must be separated by commas. `layers_params=,updateDelay=3`. Also, layers_params is already used in other contexts, as emapis.

The new `updateDelay` parameter, for now, if not officially communicated. It might be used for some external projects during the summer.

To test, open 2 separate tabs, side-by-side. On the left, past the viewer:
https://mf-chsdi3.int.bgdi.ch/shorten/732851ac87

On the right, paste the editor:
https://mf-chsdi3.int.bgdi.ch/shorten/7327dd87f5

Edit on the right and see your changes appear on the left after a certain delay.