### PR TITLE
Fix #3808: use direct url when sent to print server

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -151,6 +151,13 @@ goog.provide('ga_urlutils_service');
             for (var i = 0; i < CF_TO_NONCF.length; i++) {
               if (hostName == CF_TO_NONCF[i][0]) {
                 return url.replace(CF_TO_NONCF[i][0], CF_TO_NONCF[i][1]);
+              } else {
+                var reg = new RegExp(['^(http|https):\/\/service-proxy.',
+                    '(dev|int|prod).bgdi.ch\/(http|https)\/(.*)'].join(''));
+                var parts = reg.exec(url);
+                if (parts && parts.length == 5) {
+                  return parts[3] + '://' + parts[4];
+                }
               }
             }
           }

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -228,6 +228,12 @@ describe('ga_urlutils_service', function() {
         expect(gaUrlUtils.nonCloudFrontUrl('https://map.geo.admin.ch/asd')).to.be('https://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin/asd');
         expect(gaUrlUtils.nonCloudFrontUrl('map.geo.admin.ch')).to.be('map.geo.admin.ch');
         expect(gaUrlUtils.nonCloudFrontUrl('https://mf-geoadmin3.int.bgdi.ch/asd')).to.be('https://s3-eu-west-1.amazonaws.com/mf-geoadmin3-int-dublin/asd');
+        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.dev.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.dev.bgdi.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.int.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.int.bgdi.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.prod.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.prod.bgdi.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
       });
     });
 


### PR DESCRIPTION
[TestLink](https://mf-geoadmin3.int.bgdi.ch/gal_exterternal_graphics/index.html?selectedNode=LT1_1&Y=741652.45&X=190634.02&zoom=5&bgLayer=ch.swisstopo.pixelkarte-farbe&lang=fr&topic=ech&layers=KML%7C%7Chttp:%2F%2Fwww.mapplus.ch%2Fmapimage%2Fkml_mapplus_c4a9rmf3a8v77kvs2bd13erpr1.kml)