### PR TITLE
MGRS should also coordinates with space lesen

### DIFF
--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -47,7 +47,7 @@ goog.require('ga_reframe_service');
         if (matchMGRS && matchMGRS.length == 1) {
           var mgrsStr = matchMGRS[0].split(' ').join('');
           if ((mgrsStr.length - MGRSMinimalPrecision) % 2 == 0) {
-            var wgs84 = $window.proj4.mgrs.toPoint(matchMGRS[0]);
+            var wgs84 = $window.proj4.mgrs.toPoint(mgrsStr);
             position = ol.proj.transform(wgs84, 'EPSG:4326', 'EPSG:21781');
             if (ol.extent.containsCoordinate(extent, position)) {
               return $q.when(roundCoordinates(position));

--- a/test/specs/search/SearchService.spec.js
+++ b/test/specs/search/SearchService.spec.js
@@ -163,8 +163,8 @@ describe('ga_search_service', function() {
     });
 
     it('supports MGRS and USGS grid 32TLT 8 0', function(done) {
-      getCoordinate(extent, '32TLT 8 0').then(function(position) {
-        expect(position).to.eql([527326.065, 198141.932]);
+      getCoordinate(extent, '32TLT 81 00').then(function(position) {
+        expect(position).to.eql([600319.427, 199594.862]);
         done();
       });
       $rootScope.$digest();


### PR DESCRIPTION
MGRS parser should supports coordinates with spaces

[Demo](https://mf-geoadmin3.int.bgdi.ch/mom_fix_mgrs/index.html)

Try with, e.g..

`32TLT 82135  00464` and `32TLT8213500464` (Münster Bern)

Fixes https://github.com/geoadmin/mf-geoadmin3/issues/3387