### PR TITLE
WMTS serviceprovider is not mandatory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/ngeo"]
 	path = src/ngeo
-	url = https://github.com/camptocamp/ngeo
+	url = https://github.com/procrastinatio/ngeo

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/ngeo"]
 	path = src/ngeo
-	url = https://github.com/procrastinatio/ngeo
+	url = https://github.com/camptocamp/ngeo

--- a/src/components/map/WmtsService.js
+++ b/src/components/map/WmtsService.js
@@ -118,21 +118,22 @@ goog.require('ga_urlutils_service');
           };
           getCapLayer.sourceConfig = ol.source.WMTS.optionsFromCapabilities(
               getCapabilities, layerOptions);
-          if (getCapabilities.ServiceProvider) {
-            getCapLayer.attribution =
-                getCapabilities.ServiceProvider.ProviderName;
-            getCapLayer.attributionUrl =
-                getCapabilities.ServiceProvider.ProviderSite;
-          } else {
-            getCapLayer.attribution = '';
-            getCapLayer.attributionUrl = '';
-          }
           getCapLayer.capabilitiesUrl = getCapabilities.OperationsMetadata
               .GetCapabilities
               .DCP
               .HTTP
               .Get[0]
               .href;
+          if (getCapabilities.ServiceProvider) {
+            getCapLayer.attribution =
+                getCapabilities.ServiceProvider.ProviderName;
+            getCapLayer.attributionUrl =
+                getCapabilities.ServiceProvider.ProviderSite;
+          } else {
+            getCapLayer.attribution =
+                gaUrlUtils.getHostname(getCapLayer.capabilitiesUrl);
+            getCapLayer.attributionUrl = getCapLayer.capabilitiesUrl;
+          }
           getCapLayer.extent = getLayerExtentFromGetCap(getCapLayer,
               ol.proj.get(gaGlobalOptions.defaultEpsg));
         }

--- a/src/components/map/WmtsService.js
+++ b/src/components/map/WmtsService.js
@@ -118,10 +118,15 @@ goog.require('ga_urlutils_service');
           };
           getCapLayer.sourceConfig = ol.source.WMTS.optionsFromCapabilities(
               getCapabilities, layerOptions);
-          getCapLayer.attribution =
-              getCapabilities.ServiceProvider.ProviderName;
-          getCapLayer.attributionUrl =
-              getCapabilities.ServiceProvider.ProviderSite;
+          if (getCapabilities.ServiceProvider) {
+            getCapLayer.attribution =
+                getCapabilities.ServiceProvider.ProviderName;
+            getCapLayer.attributionUrl =
+                getCapabilities.ServiceProvider.ProviderSite;
+          } else {
+            getCapLayer.attribution = '';
+            getCapLayer.attributionUrl = '';
+          }
           getCapLayer.capabilitiesUrl = getCapabilities.OperationsMetadata
               .GetCapabilities
               .DCP

--- a/test/data/simple-wmts.xml
+++ b/test/data/simple-wmts.xml
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+	xmlns:ows="http://www.opengis.net/ows/1.1"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:gml="http://www.opengis.net/gml"
+	xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+	version="1.0.0">
+  <!-- Service Identification --> 
+ <ows:ServiceIdentification>
+	<ows:Title>tiled95_Uebersichtsplan1978</ows:Title>
+	<ows:ServiceType>OGC WMTS</ows:ServiceType>
+	<ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+</ows:ServiceIdentification> <!-- Operations Metadata --> <ows:OperationsMetadata>
+	<ows:Operation name="GetCapabilities">
+		<ows:DCP>
+			<ows:HTTP>
+				<ows:Get xlink:href="http://www.gis.stadt-zuerich.ch/maps/rest/services/tiled95/Uebersichtsplan1978/MapServer/WMTS/1.0.0/WMTSCapabilities.xml">
+					<ows:Constraint name="GetEncoding">
+						<ows:AllowedValues>
+							<ows:Value>RESTful</ows:Value>
+						</ows:AllowedValues>
+					</ows:Constraint>
+				</ows:Get>
+                <!-- add KVP binding in 10.1 -->
+                <ows:Get xlink:href="http://www.gis.stadt-zuerich.ch/maps/rest/services/tiled95/Uebersichtsplan1978/MapServer/WMTS?">
+                  <ows:Constraint name="GetEncoding">
+                    <ows:AllowedValues>
+                      <ows:Value>KVP</ows:Value>
+                    </ows:AllowedValues>
+                  </ows:Constraint>
+                </ows:Get>
+    		</ows:HTTP>
+    </ows:DCP>
+	</ows:Operation>
+	<ows:Operation name="GetTile">
+		<ows:DCP>
+			<ows:HTTP>
+				<ows:Get xlink:href="http://www.gis.stadt-zuerich.ch/maps/rest/services/tiled95/Uebersichtsplan1978/MapServer/WMTS/tile/1.0.0/">
+					<ows:Constraint name="GetEncoding">
+						<ows:AllowedValues>
+							<ows:Value>RESTful</ows:Value>
+						</ows:AllowedValues>
+					</ows:Constraint>
+				</ows:Get>
+                <ows:Get xlink:href="http://www.gis.stadt-zuerich.ch/maps/rest/services/tiled95/Uebersichtsplan1978/MapServer/WMTS?">
+                  <ows:Constraint name="GetEncoding">
+                    <ows:AllowedValues>
+                      <ows:Value>KVP</ows:Value>
+                    </ows:AllowedValues>
+                  </ows:Constraint>
+                </ows:Get>
+            </ows:HTTP>
+		</ows:DCP>
+	</ows:Operation>
+</ows:OperationsMetadata> 
+<Contents>
+  <!--Layer-->  
+  <Layer>
+    <ows:Title>tiled95_Uebersichtsplan1978</ows:Title> 
+    <ows:Identifier>tiled95_Uebersichtsplan1978</ows:Identifier>
+    
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::2056">
+	  
+			<ows:LowerCorner>2674687.008200001 1240499.9999999956</ows:LowerCorner>
+			<ows:UpperCorner>2690626.3337524254 1255500.9036500014</ows:UpperCorner>
+		
+      </ows:BoundingBox>  
+      
+    <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+      <ows:LowerCorner>8.427483689648799 47.31050733317184</ows:LowerCorner>
+      <ows:UpperCorner>8.641327493819169 47.44743381719564</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+    <Style isDefault="true">
+      <ows:Title>Default Style</ows:Title>
+      <ows:Identifier>default</ows:Identifier>
+    </Style>
+    <Format>image/jpg</Format>
+    <TileMatrixSetLink>
+      <TileMatrixSet>default028mm</TileMatrixSet>
+    </TileMatrixSetLink>
+
+        
+    <ResourceURL format="image/jpg" resourceType="tile" template="http://www.gis.stadt-zuerich.ch/maps/rest/services/tiled95/Uebersichtsplan1978/MapServer/WMTS/tile/1.0.0/tiled95_Uebersichtsplan1978/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg" />
+  </Layer> 
+   <!--TileMatrixSet-->
+   <TileMatrixSet>
+     <ows:Title>TileMatrix using 0.28mm</ows:Title>
+     <ows:Abstract>The tile matrix set that has scale values calculated based on the dpi defined by OGC specification (dpi assumes 0.28mm as the physical distance of a pixel).</ows:Abstract> 
+     <ows:Identifier>default028mm</ows:Identifier>
+     <ows:SupportedCRS>urn:ogc:def:crs:EPSG::2056</ows:SupportedCRS>
+      
+          <TileMatrix>
+          <ows:Identifier>0</ows:Identifier>
+          
+          <ScaleDenominator>241905.24571522293</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>868</MatrixWidth> 
+            <MatrixHeight>882</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>1</ows:Identifier>
+          
+          <ScaleDenominator>120952.62285761147</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>1735</MatrixWidth> 
+            <MatrixHeight>1764</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>2</ows:Identifier>
+          
+          <ScaleDenominator>60476.31142880573</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>3470</MatrixWidth> 
+            <MatrixHeight>3527</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>3</ows:Identifier>
+          
+          <ScaleDenominator>30238.155714402867</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>6939</MatrixWidth> 
+            <MatrixHeight>7053</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>4</ows:Identifier>
+          
+          <ScaleDenominator>15119.077857201433</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>13877</MatrixWidth> 
+            <MatrixHeight>14106</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>5</ows:Identifier>
+          
+          <ScaleDenominator>7559.538928600717</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>27754</MatrixWidth> 
+            <MatrixHeight>28212</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>6</ows:Identifier>
+          
+          <ScaleDenominator>3779.7694643003583</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>55507</MatrixWidth> 
+            <MatrixHeight>56424</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>7</ows:Identifier>
+          
+          <ScaleDenominator>1889.8847321501792</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>111013</MatrixWidth> 
+            <MatrixHeight>112847</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>8</ows:Identifier>
+          
+          <ScaleDenominator>944.9423660750896</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>222025</MatrixWidth> 
+            <MatrixHeight>225694</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>9</ows:Identifier>
+          
+          <ScaleDenominator>472.4711830375448</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>444050</MatrixWidth> 
+            <MatrixHeight>451387</MatrixHeight>
+          
+          </TileMatrix>
+          
+          <TileMatrix>
+          <ows:Identifier>10</ows:Identifier>
+          
+          <ScaleDenominator>236.2355915187724</ScaleDenominator>
+          
+          <TopLeftCorner>-2.73864E7 3.18145E7</TopLeftCorner>  
+          <TileWidth>512</TileWidth> 
+          <TileHeight>512</TileHeight>
+            
+            <MatrixWidth>888100</MatrixWidth> 
+            <MatrixHeight>902774</MatrixHeight>
+          
+          </TileMatrix>
+          
+   </TileMatrixSet>
+   
+</Contents>
+<ServiceMetadataURL xlink:href="http://www.gis.stadt-zuerich.ch/maps/rest/services/tiled95/Uebersichtsplan1978/MapServer/WMTS/1.0.0/WMTSCapabilities.xml" /> 
+</Capabilities>

--- a/test/specs/map/WmtsService.spec.js
+++ b/test/specs/map/WmtsService.spec.js
@@ -168,6 +168,30 @@ describe('ga_wmts_service', function() {
       });
     });
 
+    describe('#getGetCapabilitiesServiceProvider()', function() {
+      var getCapabilities;
+      var identifier = 'tiled95_Uebersichtsplan1978';
+
+      before(function(done) {
+        $.get('base/test/data/simple-wmts.xml', function(response) {
+          getCapabilities = new ol.format.WMTSCapabilities().read(response);
+          done();
+        });
+      });
+
+      it('returns options for the proper layer', function() {
+        // We need to set the extent of the projection
+        var defaultProjection = ol.proj.get(gaGlobalOptions.defaultEpsg);
+        defaultProjection.setExtent(gaGlobalOptions.defaultEpsgExtent);
+
+        var options = gaWmts.getLayerOptionsFromIdentifier(getCapabilities, identifier);
+        expect(options.capabilitiesUrl).to.be('http://www.gis.stadt-zuerich.ch/' +
+          'maps/rest/services/tiled95/Uebersichtsplan1978/MapServer/WMTS/1.0.0/WMTSCapabilities.xml');
+        expect(options.label).to.be('tiled95_Uebersichtsplan1978');
+        expect(options.sourceConfig.attributions[0]).to.contain('www.gis.stadt-zuerich.ch');
+        expect(options.layer).to.be(identifier);
+      });
+    });
     describe('#getLayerOptionsFromIdentifier()', function() {
       var getCapabilities;
       var identifier = 'ch.are.alpenkonvention';


### PR DESCRIPTION
Most ArcGis Service have not `ServiceProvider` (which is not mandatory according to OGC OWS 1.1)

e.g. Try to load one of the following service 
https://ge.ch/sitgags2/rest/services/RASTER/ORTHOPHOTOS_2016/MapServer/WMTS
or
http://www.gis.stadt-zuerich.ch/maps/rest/services/tiled95/Uebersichtsplan1978/MapServer/WMTS/1.0.0/WMTSCapabilities.xml

in [Demo](https://mf-geoadmin3.int.bgdi.ch/mom_wmts/index.html)

Another demo, comprison orthophotos [Geneva/swisstopo](https://mf-chsdi3.int.bgdi.ch/shorten/73a8bab266)

Fixes https://github.com/geoadmin/mf-geoadmin3/issues/3836

Before merging, check to following
 - [x] Merged: `https://github.com/camptocamp/ngeo/pull/2674`
 - [x] `ngeo` version updated 
 - [x] Revert `.gitmodule`to original value