### PR TITLE
Includes all features if map is rotated

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -368,8 +368,12 @@ goog.require('ga_urlutils_service');
             feature = new ol.Feature(geometry);
           }
 
-          // Encode a feature if it intersects with the extent
-          if (geometry.intersectsExtent(getPrintRectangleCoords())) {
+          // Encode a feature if it intersects with the extent and
+          // if the map is not rotated
+          var rotation = $scope.map.getView().getRotation();
+
+          if (geometry.intersectsExtent(getPrintRectangleCoords()) ||
+            rotation != 0.0) {
             var encFeature = format.writeFeatureObject(feature);
             if (!encFeature.properties) {
               encFeature.properties = {};


### PR DESCRIPTION



See https://github.com/geoadmin/mf-geoadmin3/issues/3843

**To test**

Open this [Demo (avec KMLs)](https://mf-chsdi3.int.bgdi.ch/shorten/73b8447c67)
* Rotate the map
* Print

In the PDF you should have:
* Small cross
* Labels
* Arrow

KML to tests:
https://www.procrastinatio.org/kml/666routing.kml,https://www.procrastinatio.org/kml/666tracks.kml,https://www.procrastinatio.org/kml/666ziele.kml

*On screen*
![image](https://user-images.githubusercontent.com/1236739/26976409-fc2d188c-4d23-11e7-9ea2-defd52d77d36.png)

*On PDF*
![image](https://user-images.githubusercontent.com/1236739/26976443-1df5c78e-4d24-11e7-8f36-1063702eeed6.png)


*LUBIRE*
Pour générer de nouveau KML

* Open http://lubire.donatellis.ch/desktop.html
* Click on “Zielkarte erfassen”
* Ecrit 141411414 dans l’input Eff# 
* Click sur Darstellen
* Print



