### PR TITLE
Print extent for rotated map

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -370,10 +370,8 @@ goog.require('ga_urlutils_service');
 
           // Encode a feature if it intersects with the extent and
           // if the map is not rotated
-          var rotation = $scope.map.getView().getRotation();
 
-          if (geometry.intersectsExtent(getPrintRectangleCoords()) ||
-            rotation != 0.0) {
+          if (geometry.intersectsExtent(getPrintRectangleCoords())) {
             var encFeature = format.writeFeatureObject(feature);
             if (!encFeature.properties) {
               encFeature.properties = {};
@@ -847,18 +845,17 @@ goog.require('ga_urlutils_service');
           displayCoords[3]]);
       var topRight = $scope.map.getCoordinateFromPixel([displayCoords[2],
           displayCoords[1]]);
+      //
+      var topLeft = $scope.map.getCoordinateFromPixel([displayCoords[0],
+          displayCoords[1]]);
+      var bottomRight = $scope.map.getCoordinateFromPixel([displayCoords[2],
+          displayCoords[3]]);
+
       // Always returns an extent [minX, minY, maxX, maxY]
-      if (bottomLeft[0] > topRight[0]) {
-        var tmp = bottomLeft[0];
-        bottomLeft[0] = topRight[0];
-        topRight[0] = tmp;
-      }
-      if (bottomLeft[1] > topRight[1]) {
-        var tmp = bottomLeft[1];
-        bottomLeft[1] = topRight[1];
-        topRight[1] = tmp;
-      }
-      return bottomLeft.concat(topRight);
+      var printPoly = new ol.geom.Polygon([[bottomLeft, topLeft, topRight,
+          bottomRight, bottomLeft]]);
+
+      return printPoly.getExtent();
     };
 
     var getPrintRectangleCenterCoord = function() {

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -845,7 +845,6 @@ goog.require('ga_urlutils_service');
           displayCoords[3]]);
       var topRight = $scope.map.getCoordinateFromPixel([displayCoords[2],
           displayCoords[1]]);
-      //
       var topLeft = $scope.map.getCoordinateFromPixel([displayCoords[0],
           displayCoords[1]]);
       var bottomRight = $scope.map.getCoordinateFromPixel([displayCoords[2],


### PR DESCRIPTION

As long as we use an `ol.extent` to define the print extent, this is the best approximation we can do. When rotated it is a bit larger than need, but at least correct (brown rectangle with the same orientation as the map and the whole print extent is colored brown, so it is ok)


![map-rotated-correct](https://user-images.githubusercontent.com/1236739/27030452-97f3b560-4f6c-11e7-872d-e9093cbe91ec.png)

compare with this:

![map-rotated](https://user-images.githubusercontent.com/1236739/27021456-b40e3bae-4f48-11e7-965d-c69465f1a9b6.png)


Try this [demo with many points](https://mf-chsdi3.int.bgdi.ch/shorten/73c741a86e).
- Rotate the map (45° is the worst angle)
- Print
- All features, especially in the top left and bottom right corner should be present.


