### PR TITLE
Revert hack caused by print bug

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -644,7 +644,7 @@ goog.require('ga_urlutils_service');
             'styles': {
               '1': { // Style for marker position
                 'externalGraphic':
-                  gaUrlUtils.nonCloudFrontUrl($scope.options.markerUrl),
+                  gaUrlUtils.unProxifyUrl($scope.options.markerUrl),
                 'graphicWidth': 20,
                 'graphicHeight': 30,
                 // the icon is not perfectly centered in the image
@@ -653,7 +653,7 @@ goog.require('ga_urlutils_service');
                 'graphicYOffset': -30
               }, '2': { // Style for measure tooltip
                 'externalGraphic':
-                  gaUrlUtils.nonCloudFrontUrl($scope.options.bubbleUrl),
+                  gaUrlUtils.unProxifyUrl($scope.options.bubbleUrl),
                 'graphicWidth': 97,
                 'graphicHeight': 27,
                 'graphicXOffset': -48,

--- a/src/components/print/PrintStyleService.js
+++ b/src/components/print/PrintStyleService.js
@@ -168,7 +168,7 @@ goog.require('ga_urlutils_service');
           size = imageStyle.getSize();
           anchor = imageStyle.getAnchor();
           literal.externalGraphic =
-            gaUrlUtils.nonCloudFrontUrl(imageStyle.getSrc());
+            gaUrlUtils.unProxifyUrl(imageStyle.getSrc());
           literal.fillOpacity = 1;
         } else if (imageStyle instanceof ol.style.Circle ||
             imageStyle instanceof ol.style.RegularShape) {

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -224,21 +224,16 @@ describe('ga_urlutils_service', function() {
     });
 
 
-    describe('#nonCloudFrontUrl()', function() {
-      it('verifies cloudfront url transformation valid', function() {
-        expect(gaUrlUtils.nonCloudFrontUrl('http://public.geo.admin.ch')).to.be('http://public.geo.admin.ch');
-        expect(gaUrlUtils.nonCloudFrontUrl('http://map.geo.admin.ch')).to.be('http://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin');
-        expect(gaUrlUtils.nonCloudFrontUrl('http://map.geo.admin.ch/')).to.be('http://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin/');
-        expect(gaUrlUtils.nonCloudFrontUrl('http://map.geo.admin.ch/asd')).to.be('http://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin/asd');
-        expect(gaUrlUtils.nonCloudFrontUrl('https://map.geo.admin.ch/asd')).to.be('https://s3-eu-west-1.amazonaws.com/mf-geoadmin3-prod-dublin/asd');
-        expect(gaUrlUtils.nonCloudFrontUrl('map.geo.admin.ch')).to.be('map.geo.admin.ch');
-        expect(gaUrlUtils.nonCloudFrontUrl('https://mf-geoadmin3.int.bgdi.ch/asd')).to.be('https://s3-eu-west-1.amazonaws.com/mf-geoadmin3-int-dublin/asd');
-        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.dev.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
-        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.dev.bgdi.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
-        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.int.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
-        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.int.bgdi.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
-        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.prod.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
-        expect(gaUrlUtils.nonCloudFrontUrl('https://service-proxy.prod.bgdi.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
+    describe('#unProxifyUrl()', function() {
+      it('verifies unproxify url transformation valid', function() {
+        expect(gaUrlUtils.unProxifyUrl('https://service-proxy.dev.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.unProxifyUrl('https://service-proxy.dev.bgdi.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.unProxifyUrl('https://service-proxy.int.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.unProxifyUrl('https://service-proxy.int.bgdi.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.unProxifyUrl('https://service-proxy.prod.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.unProxifyUrl('https://service-proxy.prod.bgdi.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.unProxifyUrl('https://proxy.geo.admin.ch/http/dummy/somepath/myimage.png')).to.be('http://dummy/somepath/myimage.png');
+        expect(gaUrlUtils.unProxifyUrl('https://proxy.geo.admin.ch/https/dummy/somepath/myimage.png')).to.be('https://dummy/somepath/myimage.png');
       });
     });
 


### PR DESCRIPTION
This is a consolidation of https://github.com/geoadmin/mf-geoadmin3/pull/3804/, https://github.com/geoadmin/mf-geoadmin3/pull/3815 and https://github.com/geoadmin/mf-geoadmin3/pull/3817

As said in  https://github.com/geoadmin/mf-geoadmin3/pull/3817, I think it makes sense to keep the unproxify function and send the non-proxy URLs to the print server. They are not impacted with CORS limitations and it decreases our load on the proxy service.

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_revertprint/index.html)

@oterral @procrastinatio @loicgasser If you agree, we can close the other three pull requests and merge this once the print is ready.