### PR TITLE
Fix 3910 and impove printing orderof overlays

### DIFF
--- a/src/components/draw/DrawDirective.js
+++ b/src/components/draw/DrawDirective.js
@@ -61,7 +61,8 @@ goog.require('ga_styles_service');
         element: tooltipElement,
         offset: [15, 15],
         positioning: 'top-left',
-        stopEvent: true
+        stopEvent: true,
+        insertFirst: false
       });
       return tooltip;
     };

--- a/src/components/measure/MeasureService.js
+++ b/src/components/measure/MeasureService.js
@@ -98,6 +98,7 @@ goog.require('ga_measure_filter');
             element: tooltipElement,
             offset: [0, -7],
             positioning: 'bottom-center',
+            insertFirst: false,
             stopEvent: angular.isDefined(stopEvent) ?
                 stopEvent : true // for copy/paste
           });

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -331,15 +331,26 @@ goog.require('ga_urlutils_service');
       // FIXME this is a temporary solution
       var overlays = $scope.map.getOverlays();
 
+      // On OL, overlays which stop events are displayed on top of overlays
+      // which don't. So we need to do the same for the print to keep order of
+      // display.
+      var ovStop = [];
+      var ov = [];
       overlays.forEach(function(overlay) {
         var encOverlayLayer = gaPrintLayer.encodeOverlay(overlay,
             resolution, $scope.options);
 
         if (encOverlayLayer) {
-            encLayers.push(encOverlayLayer);
+          var container = $(overlay.getElement()).parent().parent();
+          if (container.hasClass('ol-overlaycontainer-stopevent')) {
+            ovStop.push(encOverlayLayer);
+          } else {
+            ov.push(encOverlayLayer);
+          }
         }
       });
-
+      encLayers = encLayers.concat(ov);
+      encLayers = encLayers.concat(ovStop);
 
       // Get the short link
       var shortLink;

--- a/src/components/print/PrintLayerService.js
+++ b/src/components/print/PrintLayerService.js
@@ -13,7 +13,7 @@ goog.require('ga_urlutils_service');
     'pascalprecht.translate'
   ]);
 
-  module.provider('gaPrintLayer', function gaPrintLayer() {
+  module.provider('gaPrintLayer', function() {
 
     this.$get = function($document, $translate, gaGlobalOptions,
         gaLayers, gaTime, gaLang, gaPrintStyle, gaMapUtils,
@@ -40,7 +40,6 @@ goog.require('ga_urlutils_service');
 
   var pdfLegendString = '_big.pdf';
   var POINTS_PER_INCH = 72; //PostScript points 1/72"
-  var MM_PER_INCHES = 25.4;
   var UNITS_RATIO = 39.37; // inches per meter
   var styleId = 0;
   var format = new ol.format.GeoJSON();
@@ -113,7 +112,7 @@ goog.require('ga_urlutils_service');
             '3': { // Style for intermeediate measure tooltip
               'label': $elt.text(),
               'labelXOffset': 0,
-              'labelYOffset': 18,
+              'labelYOffset': 10,
               'fontColor': '#ffffff',
               'fontSize': 8,
               'fontWeight': 'normal',

--- a/src/components/print/PrintLayerService.js
+++ b/src/components/print/PrintLayerService.js
@@ -89,8 +89,7 @@ goog.require('ga_urlutils_service');
           'type': 'Vector',
           'styles': {
             '1': { // Style for marker position
-              'externalGraphic':
-                gaUrlUtils.nonCloudFrontUrl(options.markerUrl),
+              'externalGraphic': options.markerUrl,
               'graphicWidth': 20,
               'graphicHeight': 30,
               // the icon is not perfectly centered in the image
@@ -99,8 +98,7 @@ goog.require('ga_urlutils_service');
               'graphicYOffset': -30
             },
             '2': { // Style for measure tooltip
-              'externalGraphic':
-                gaUrlUtils.nonCloudFrontUrl(options.bubbleUrl),
+              'externalGraphic': options.bubbleUrl,
               'graphicWidth': 97,
               'graphicHeight': 27,
               'graphicXOffset': -48,


### PR DESCRIPTION
Fix #3910 

[Test](https://mf-geoadmin3.int.bgdi.ch/fix_3910/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=197773.68&Y=644232.36&dev3d=true&zoom=2&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttps:%2F%2Fpublic.dev.bgdi.ch%2Fuub06H_WSZWewUoRbmve_g&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,)