### PR TITLE
Clean the management of  the click on map

### DIFF
--- a/src/components/EventService.js
+++ b/src/components/EventService.js
@@ -10,7 +10,9 @@ goog.provide('ga_event_service');
 
       var isMouse = function(evt) {
         evt = evt.originalEvent || evt;
-        return MOUSE_REGEX.test(evt.pointerType || evt.type);
+        var type = evt.pointerType || evt.type;
+        // IE 10 return an integer as type.
+        return MOUSE_REGEX.test(type) || type === 4;
       };
 
       // Ensure actions on mouseover/out are only triggered by a mouse

--- a/src/components/contextpopup/ContextPopupDirective.js
+++ b/src/components/contextpopup/ContextPopupDirective.js
@@ -35,7 +35,7 @@ goog.require('ga_window_service');
           link: function(scope, element, attrs) {
             var heightUrl = scope.options.heightUrl;
             var qrcodeUrl = scope.options.qrcodeUrl;
-            var startPixel, holdPromise, isPopoverShown = false;
+            var holdPromise, isPopoverShown = false;
             var reframeCanceler = $q.defer();
             var heightCanceler = $q.defer();
             var map = scope.map;
@@ -191,7 +191,6 @@ goog.require('ga_window_service');
                   scope.hidePopover();
                 }
                 $timeout.cancel(holdPromise);
-                startPixel = undefined;
                 handler(event);
               });
               element.on('contextmenu', 'a', function(e) {
@@ -209,7 +208,6 @@ goog.require('ga_window_service');
                   return;
                 }
                 $timeout.cancel(holdPromise);
-                startPixel = event.pixel;
                 holdPromise = $timeout(function() {
                   handler(event);
                 }, 300, false);
@@ -219,20 +217,13 @@ goog.require('ga_window_service');
                   return;
                 }
                 $timeout.cancel(holdPromise);
-                startPixel = undefined;
               });
               map.on('pointermove', function(event) {
                 if (gaEvent.isMouse(event)) {
                   return;
                 }
-                if (startPixel) {
-                  var pixel = event.pixel;
-                  var deltaX = Math.abs(startPixel[0] - pixel[0]);
-                  var deltaY = Math.abs(startPixel[1] - pixel[1]);
-                  if (deltaX + deltaY > 6) {
-                    $timeout.cancel(holdPromise);
-                    startPixel = undefined;
-                  }
+                if (event.dragging) {
+                  $timeout.cancel(holdPromise);
                 }
               });
             }

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -50,6 +50,7 @@ goog.require('ga_window_service');
       '</span>';
 
       var map = new ol.Map({
+        moveTolerance: 5,
         controls: ol.control.defaults({
           attribution: false,
           rotate: false,

--- a/test/specs/EventService.spec.js
+++ b/test/specs/EventService.spec.js
@@ -14,13 +14,16 @@ describe('ga_event_service', function() {
       // Native events mock
       var mouseEvts = [
         $.Event('mousedown'),
-        $.Event('pointerdown', {pointerType: 'mouse'})
+        $.Event('pointerdown', {pointerType: 'mouse'}),
+        $.Event('pointerdown', {pointerType: 4})
       ];
 
       var notMouseEvts = [
         $.Event('touchstart'),
         $.Event('pointerdown', {pointerType: 'pen'}),
-        $.Event('pointerdown', {pointerType: 'touch'})
+        $.Event('pointerdown', {pointerType: 'touch'}),
+        $.Event('pointerdown', {pointerType: 2}),
+        $.Event('pointerdown', {pointerType: 3})
       ];
 
       // Jquery/ol events mock (with originalEvent stored)

--- a/test/specs/contextpopup/ContextPopupDirective.spec.js
+++ b/test/specs/contextpopup/ContextPopupDirective.spec.js
@@ -15,7 +15,8 @@ describe('ga_contextpopup_directive', function() {
     stopPropagation: function() {},
     preventDefault: function() {},
     pixel: [30, 60],
-    coordinate: [661673, 198192]
+    coordinate: [661673, 198192],
+    dragging: true // simulate move event
   };
   var mouseEvt = $.extend({type: 'mousedown'}, mapEvt);
   var mouseEvt2 = $.extend({type: 'mouseup'}, mapEvt2);


### PR DESCRIPTION
Fix #3884 

[test contextpopup  and click for tooltip](https://mf-geoadmin3.int.bgdi.ch/fix_3884/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.swissimage&X=166754.78&Y=634889.82&dev3d=true&zoom=4&debug&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,true,false,false&layers_timestamp=18641231,,,)

I've tested on ie 9 , ie 10,  safari iOS, chrome desktop.