### PR TITLE
Fixing the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "corejs-typeahead": "v1.1.1"
   },
   "devDependencies": {
+    "caniuse-db": "1.0.30000708",
     "angular-mocks": "1.6.4",
     "autoprefixer": "6.7.7",
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
The new version of caniuse-db causes the build to fail.

Therefore, we need to fix the version to a known working one.

To be reverted once caniuse-db is updated again.

Self-merge because of urgency.