### PR TITLE
If multiple shop mapsheets exist, assure correct highlight

### DIFF
--- a/src/components/shop/ShopDirective.js
+++ b/src/components/shop/ShopDirective.js
@@ -128,10 +128,21 @@ goog.require('ga_price_filter');
               gaLayers.getOlLayerById(clipper)
             ];
             gaIdentify.get(scope.map, layers, scope.clipperGeometry, 1, true,
-                null, 1).then(function(response) {
+                null).then(function(response) {
               var results = response.data.results;
               if (results.length) {
-                scope.clipperFeatures[scope.orderType] = results[0];
+                var res = results[0];
+                //Might contain several results, try to match via id/layerid
+                if (results.length > 1) {
+                  for (var i = 0; i < results.length; i++) {
+                    res = results[i];
+                    if (scope.feature.featureId === res.featureId &&
+                        scope.feature.layerBodId === res.layerBodId) {
+                      break;
+                    }
+                  }
+                }
+                scope.clipperFeatures[scope.orderType] = res;
                 scope.addPreview();
                 scope.updatePrice();
               }


### PR DESCRIPTION
This is a (partial) fix for https://github.com/geoadmin/mf-chsdi3/issues/2618

The highlight of 'free' map sheets together with for-pay sheets was wrong when the free mapsheet could be had by more than 1 for-pay sheet. This PR assures that the highlight and the information in the popup is correct.

Note that this PR doesn't address the labeling issue, which would need to be addressed in the wms (if at all).

[Testlink](https://mf-geoadmin3.int.bgdi.ch/gjn_shop/index.html?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.pixelkarte-pk25.metadata&X=199475.00&Y=830400.00&zoom=4)