### PR TITLE
Remove mapproxy URLS, use col/row correctly

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -402,10 +402,9 @@ goog.require('ga_urlutils_service');
         return domainsArray;
       };
 
-      var Layers = function(dfltWmsSubdomains, dfltWmtsNativeSubdomains,
-          dfltWmtsMapProxySubdomains, dfltVectorTilesSubdomains,
-          wmsUrlTemplate, wmtsGetTileUrlTemplate,
-          wmtsMapProxyGetTileUrlTemplate, terrainTileUrlTemplate,
+      var Layers = function(dfltWmsSubdomains, dfltWmtsSubdomains,
+          dfltVectorTilesSubdomains, wmsUrlTemplate,
+          wmtsGetTileUrlTemplate, terrainTileUrlTemplate,
           vectorTilesUrlTemplate, layersConfigUrlTemplate,
           legendUrlTemplate, imageryMetadataUrl) {
         var layers;
@@ -438,13 +437,12 @@ goog.require('ga_urlutils_service');
           return urls;
         };
 
-        var getWmtsGetTileTpl = function(layer, time, tileMatrixSet,
-            format, useNativeTpl) {
-          var tpl;
-          if (useNativeTpl) {
-              tpl = wmtsGetTileUrlTemplate;
-          } else {
-              tpl = wmtsMapProxyGetTileUrlTemplate;
+        var getWmtsGetTileTpl = function(layer, time, tileMatrixSet, format) {
+          var tpl = wmtsGetTileUrlTemplate;
+          if (tileMatrixSet == '2056') {
+            tpl = tpl.replace('{z}', '{TileMatrix}').
+                     replace('{x}', '{TileCol}').
+                     replace('{y}', '{TileRow}');
           }
           var url = tpl.replace('{Layer}', layer).replace('{Format}', format);
           if (time) {
@@ -707,13 +705,10 @@ goog.require('ga_urlutils_service');
             return providers;
           }
           if (config3d.type == 'wmts') {
-            var hasNativeTiles = !!config.config3d;
             params = {
-              url: getWmtsGetTileTpl(requestedLayer, timestamp,
-                  '4326', format, hasNativeTiles),
+              url: getWmtsGetTileTpl(requestedLayer, timestamp, '4326', format),
               tileSize: 256,
-              subdomains: hasNativeTiles ? h2(dfltWmtsNativeSubdomains) :
-                  h2(dfltWmtsMapProxySubdomains)
+              subdomains: h2(dfltWmtsSubdomains)
             };
           } else if (config3d.type == 'wms') {
             var tileSize = 512;
@@ -814,10 +809,7 @@ goog.require('ga_urlutils_service');
           if (layer.type == 'wmts') {
             if (!olSource) {
               var wmtsTplUrl = getWmtsGetTileTpl(layer.serverLayerName, null,
-                  '2056', layer.format, true)
-                  .replace('{z}', '{TileMatrix}')
-                  .replace('{x}', '{TileRow}')
-                  .replace('{y}', '{TileCol}');
+                  '2056', layer.format);
               olSource = layer.olSource = new ol.source.WMTS({
                 dimensions: {
                   'Time': timestamp
@@ -833,7 +825,7 @@ goog.require('ga_urlutils_service');
                 tileGrid: gaTileGrid.get(layer.resolutions,
                     layer.minResolution),
                 tileLoadFunction: tileLoadFunction,
-                urls: getImageryUrls(wmtsTplUrl, h2(dfltWmtsNativeSubdomains)),
+                urls: getImageryUrls(wmtsTplUrl, h2(dfltWmtsSubdomains)),
                 crossOrigin: crossOrigin
               });
             }
@@ -1091,10 +1083,9 @@ goog.require('ga_urlutils_service');
         };
       };
 
-      return new Layers(this.dfltWmsSubdomains, this.dfltWmtsNativeSubdomains,
-          this.dfltWmtsMapProxySubdomains, this.dfltVectorTilesSubdomains,
-          this.wmsUrlTemplate, this.wmtsGetTileUrlTemplate,
-          this.wmtsMapProxyGetTileUrlTemplate, this.terrainTileUrlTemplate,
+      return new Layers(this.dfltWmsSubdomains, this.dfltWmtsSubdomains,
+          this.dfltVectorTilesSubdomains, this.wmsUrlTemplate,
+          this.wmtsGetTileUrlTemplate, this.terrainTileUrlTemplate,
           this.vectorTilesUrlTemplate, this.layersConfigUrlTemplate,
           this.legendUrlTemplate, this.imageryMetadataUrl);
     };

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -774,7 +774,6 @@ itemscope itemtype="http://schema.org/WebApplication"
 
         var defaultApiUrl = prtl + '${api_url}';
         var apiUrl = setBackend(defaultApiUrl, prtl + '${api_tech_url}', 'api_url');
-        var mapproxyUrl = setBackend(prtl + '${mapproxy_url}', prtl + '${mapproxy_tech_url}', 'mapproxy_url');
         var vectorTilesUrl = setBackend(prtl + '${vectortiles_url}', prtl + '${vectortiles_tech_url}', 'vectortiles_url');
         var wmsUrl = setBackend(prtl + '${wms_url}',  prtl + '${wms_tech_url}', 'wms_url');
         var shopUrl = setBackend(prtl + '${shop_url}', prtl + '${shop_tech_url}', 'shop_url');
@@ -793,7 +792,6 @@ itemscope itemtype="http://schema.org/WebApplication"
           apiUrl: apiUrl,
           printUrl: printUrl,
           proxyUrl: proxyUrl,
-          mapproxyUrl: mapproxyUrl,
           vectorTilesUrl: vectorTilesUrl,
           shopUrl: shopUrl,
           publicUrl: publicUrl,
@@ -841,11 +839,9 @@ itemscope itemtype="http://schema.org/WebApplication"
         module.config(function(gaLayersProvider, gaGlobalOptions) {
           gaLayersProvider.dfltWmsSubdomains = ['', '0', '1', '2', '3', '4'];
           gaLayersProvider.dfltWmtsNativeSubdomains = ['100', '101', '102', '103', '104'];
-          gaLayersProvider.dfltWmtsMapProxySubdomains = ['100', '101', '102', '103', '104'];
           gaLayersProvider.dfltVectorTilesSubdomains = staging === 'prod' ? ['100', '101', '102', '103', '104'] : ['', '0', '1', '2', '3', '4'];
           gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
-          gaLayersProvider.wmtsGetTileUrlTemplate = '//tod{s}.bgdi.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
-          gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =  gaGlobalOptions.mapproxyUrl + '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+          gaLayersProvider.wmtsGetTileUrlTemplate = '//tod{s}.bgdi.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
           gaLayersProvider.terrainTileUrlTemplate = '//terrain100.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
           gaLayersProvider.vectorTilesUrlTemplate = gaGlobalOptions.vectorTilesUrl + '/{Layer}/{Time}/';
           gaLayersProvider.imageryMetadataUrl = '//3d.geo.admin.ch/imagery/';

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -10,7 +10,6 @@ beforeEach(function() {
     var publicUrl = '//public.geo.admin.ch';
     var printUrl = '//print.geo.admin.ch';
     var proxyUrl = '//proxy.geo.admin.ch';
-    var mapproxyUrl = '//wmts{s}.geo.admin.ch';
     var shopUrl = '//shop.bgdi.ch';
     var wmsUrl = '//wms.geo.admin.ch';
     var apacheBasePath = '/';
@@ -26,7 +25,6 @@ beforeEach(function() {
       mapUrl: location.origin + apacheBasePath,
       apiUrl: location.protocol + apiUrl,
       printUrl: location.protocol + printUrl,
-      mapproxyUrl: location.protocol + mapproxyUrl,
       shopUrl: location.protocol + shopUrl,
       publicUrl: location.protocol + publicUrl,
       publicUrlRegexp: /^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*/,
@@ -71,14 +69,11 @@ beforeEach(function() {
 
   module(function(gaLayersProvider, gaGlobalOptions) {
     gaLayersProvider.dfltWmsSubdomains = ['', '0', '1', '2', '3', '4'];
-    gaLayersProvider.dfltWmtsNativeSubdomains = ['5', '6', '7', '8', '9'];
-    gaLayersProvider.dfltWmtsMapProxySubdomains = ['20', '21', '22', '23', '24'];
+    gaLayersProvider.dfltWmtsSubdomains = ['5', '6', '7', '8', '9'];
     gaLayersProvider.dfltVectorTilesSubdomains = ['100', '101', '102', '103', '104'];
     gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
-    gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
+    gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
 
-    gaLayersProvider.wmtsMapProxyGetTileUrlTemplate = gaGlobalOptions.mapproxyUrl +
-        '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
     gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
     gaLayersProvider.vectorTilesUrlTemplate = '//vectortiles{s}.geo.admin.ch/{Layer}/{Time}/';
     gaLayersProvider.layersConfigUrlTemplate = 'https://example.com/all?lang={Lang}';

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -516,15 +516,11 @@ describe('ga_map_service', function() {
       'ch.vbs.patrouilledesglaciers-z_rennen': {}
     };
     var terrainTpl = '//3d.geo.admin.ch/1.0.0/{layer}/default/{time}/4326';
-    var wmtsTpl = '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{y}/{x}.{format}';
-    var wmtsMpTpl = window.location.protocol + '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
+    var wmtsTpl = '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
     var vectorTilesTpl = '//vectortiles100.geo.admin.ch/{layer}/{time}/';
     var wmsTpl = '//wms{s}.geo.admin.ch/?layers={layer}&format=image%2F{format}&service=WMS&version=1.3.0&request=GetMap&crs=CRS:84&bbox={westProjected},{southProjected},{eastProjected},{northProjected}&width=512&height=512&styles=';
     var expectWmtsUrl = function(l, t, f) {
       return expectUrl(wmtsTpl, l, t, f);
-    };
-    var expectWmtsMpUrl = function(l, t, f) {
-      return expectUrl(wmtsMpTpl, l, t, f);
     };
     var expectTerrainUrl = function(l, t, f) {
       return expectUrl(terrainTpl, l, t, f);
@@ -916,20 +912,6 @@ describe('ga_map_service', function() {
         expect(params.maximumLevel).to.eql(undefined);
         expect(params.hasAlphaChannel).to.eql(false);
         expect(prov.bodId).to.be('wmts3dcustom');
-        spy.restore();
-      });
-
-      it('returns a CesiumImageryProvider from a wmts using mapproxy tiles', function() {
-        var spy = sinon.spy(Cesium, 'UrlTemplateImageryProvider');
-        var prov = gaLayers.getCesiumImageryProviderById('wmtsmapproxy');
-        expect(prov).to.be.an(Cesium.UrlTemplateImageryProvider);
-        // Properties of Cesium object are set in a promise and I don 't
-        // succeed to test it so we test the params we send to the constructor
-        // instead.
-        var params = spy.args[0][0];
-        expect(params.url).to.eql(expectWmtsMpUrl('wmtsmapproxy', '20160201'));
-        expect(params.subdomains).to.eql(['20', '21', '22', '23', '24']);
-        expect(prov.bodId).to.be('wmtsmapproxy');
         spy.restore();
       });
 


### PR DESCRIPTION
This removes the mapproxy specific URLS. As we pass everything via CloudFront now, we don't have any difference between mapproxy generated tiles, tod tiles and pre-generated tiles.

Also, this PR assures that for all projections systems, we use col/row in our matrixset, with the only exception being lv03 tiles, which uses row/col.

This also means the this won't work anymore with the 4326 pre-generated tiles, because factually, they are wrong (as they are row/col).

@ltclm Before we go live with lv95, we need to take this into account. We'll need to decide on what to do with the pre-generated tiles.