### PR TITLE
Disable printprogress caching

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -397,8 +397,13 @@ goog.require('ga_urlutils_service');
                 if (!$scope.options.printing) {
                   return;
                 }
+                var noCacheUrl = url;
+                if (gaBrowserSniffer.msie === 9) {
+                  // #3937: Avoid caching of the request by IE9
+                  noCacheUrl += '&' + (new Date()).getTime();
+                }
                 canceller = $q.defer();
-                $http.get(url, {
+                $http.get(noCacheUrl, {
                   timeout: canceller.promise
                 }).then(function(response) {
                   var data = response.data;


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-geoadmin3/issues/3937

[test to use multiprint on ie9](//mf-geoadmin3.int.bgdi.ch/nocache_printprogress/index.html)