### PR TITLE
Tiles on Demand Beta Go Live

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -388,7 +388,7 @@ goog.require('ga_urlutils_service');
 
         var todLayers = [
           'ch.swisstopo.swisstlm3d-karte-farbe.3d',
-          'ch.swisstopo.swisstlm3d-wanderwege'
+          'ch.swisstopo.swisstlm3d-karte-grau.3d'
         ];
 
         var useToD = function(layer, tileMatrixSet) {

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -353,6 +353,7 @@ goog.require('ga_urlutils_service');
           dfltWmtsMapProxySubdomains, dfltVectorTilesSubdomains,
           wmsUrlTemplate, wmtsGetTileUrlTemplate,
           wmtsMapProxyGetTileUrlTemplate, terrainTileUrlTemplate,
+          wmtsToDUrlTemplate, dfltToDSubdomains,
           vectorTilesUrlTemplate, layersConfigUrlTemplate,
           legendUrlTemplate, imageryMetadataUrl) {
         var layers;
@@ -385,10 +386,24 @@ goog.require('ga_urlutils_service');
           return urls;
         };
 
+        var todLayers = [
+          'ch.swisstopo.swisstlm3d-karte-farbe.3d',
+          'ch.swisstopo.swisstlm3d-wanderwege'
+        ];
+
+        var useToD = function(layer, tileMatrixSet) {
+          if (tileMatrixSet !== '4326') {
+            return false;
+          }
+          return (todLayers.indexOf(layer) !== -1);
+        }
+
         var getWmtsGetTileTpl = function(layer, time, tileMatrixSet,
             format, useNativeTpl) {
           var tpl;
-          if (useNativeTpl) {
+          if (useToD(layer, tileMatrixSet)) {
+            tpl = wmtsToDUrlTemplate;
+          } else if (useNativeTpl) {
             tpl = wmtsGetTileUrlTemplate;
           } else {
             tpl = wmtsMapProxyGetTileUrlTemplate;
@@ -659,8 +674,10 @@ goog.require('ga_urlutils_service');
               url: getWmtsGetTileTpl(requestedLayer, timestamp,
                   '4326', format, hasNativeTiles),
               tileSize: 256,
-              subdomains: hasNativeTiles ? h2(dfltWmtsNativeSubdomains) :
-                h2(dfltWmtsMapProxySubdomains)
+              subdomains: useToD(requestedLayer, '4326') ?
+                h2(dfltToDSubdomains) :
+                hasNativeTiles ? h2(dfltWmtsNativeSubdomains) :
+                  h2(dfltWmtsMapProxySubdomains)
             };
           } else if (config3d.type === 'wms') {
             var tileSize = 512;
@@ -1041,6 +1058,7 @@ goog.require('ga_urlutils_service');
           this.dfltWmtsMapProxySubdomains, this.dfltVectorTilesSubdomains,
           this.wmsUrlTemplate, this.wmtsGetTileUrlTemplate,
           this.wmtsMapProxyGetTileUrlTemplate, this.terrainTileUrlTemplate,
+          this.wmtsToDUrlTemplate, this.dfltToDSubdomains,
           this.vectorTilesUrlTemplate, this.layersConfigUrlTemplate,
           this.legendUrlTemplate, this.imageryMetadataUrl);
     };

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -158,6 +158,9 @@ goog.require('ga_waitcursor_service');
     gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =
         gaGlobalOptions.mapproxyUrl +
         '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+    gaLayersProvider.wmtsToDUrlTemplate = '//tod{s}.prod.bgdi.ch/' +
+        '1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+    gaLayersProvider.dfltToDSubdomains = ['100', '101', '102', '103', '104'];
     gaLayersProvider.terrainTileUrlTemplate =
         '//terrain100.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
     gaLayersProvider.vectorTilesUrlTemplate = gaGlobalOptions.vectorTilesUrl +

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -71,13 +71,16 @@ beforeEach(function() {
   module(function(gaLayersProvider, gaGlobalOptions) {
     gaLayersProvider.dfltWmsSubdomains = ['', '0', '1', '2', '3', '4'];
     gaLayersProvider.dfltWmtsNativeSubdomains = ['5', '6', '7', '8', '9'];
+    gaLayersProvider.dfltToDSubdomains = ['100', '101'];
     gaLayersProvider.dfltWmtsMapProxySubdomains = ['20', '21', '22', '23', '24'];
     gaLayersProvider.dfltVectorTilesSubdomains = ['100', '101', '102', '103', '104'];
     gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
     gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
-
+    gaLayersProvider.wmtsToDUrlTemplate = '//tod{s}.bgdi.ch//1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
     gaLayersProvider.wmtsMapProxyGetTileUrlTemplate = gaGlobalOptions.mapproxyUrl +
         '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+
+      // https://regex101.com/r/U5ccHi/3
     gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
     gaLayersProvider.vectorTilesUrlTemplate = '//vectortiles{s}.geo.admin.ch/{Layer}/{Time}/';
     gaLayersProvider.layersConfigUrlTemplate = 'https://example.com/all?lang={Lang}';


### PR DESCRIPTION
Currently not working because back-ends are not ready yet.

The idea is to have quite a big flexibility to add/remove layers during the beta. As it's currently set-up, only 4326 will work with Tiles on demand and only the layers specified in code in the array.

[TestLink](https://mf-geoadmin3.int.bgdi.ch/gjn_tod/index.html)