### PR TITLE
Fix #3945: Manage opacity for WMTS layers

### DIFF
--- a/src/components/map/PermalinkLayersService.js
+++ b/src/components/map/PermalinkLayersService.js
@@ -312,6 +312,8 @@ goog.require('ga_wmts_service');
                           getCap, infos[1]);
                       // Override the url found in the xml file which is often a
                       // wrong url.
+                      layerOptions.opacity = opacity || 1;
+                      layerOptions.visible = visible;
                       layerOptions.capabilitiesUrl = infos[2];
                       layerOptions.time = timestamp;
                       gaWmts.addWmtsToMap(map, layerOptions, index + 1);

--- a/src/components/map/WmtsService.js
+++ b/src/components/map/WmtsService.js
@@ -48,7 +48,10 @@ goog.require('ga_urlutils_service');
           id: 'WMTS||' + options.layer + '||' + options.capabilitiesUrl,
           source: source,
           extent: gaMapUtils.intersectWithDefaultExtent(options.extent),
-          preload: gaMapUtils.preload
+          preload: gaMapUtils.preload,
+          opacity: options.opacity,
+          visible: options.visible,
+          attribution: options.attribution
         });
         gaDefinePropertiesForLayer(layer);
         layer.useThirdPartyData =

--- a/test/data/wmts-basic.xml
+++ b/test/data/wmts-basic.xml
@@ -79,6 +79,31 @@
     </ows:OperationsMetadata>
     <Contents>
         <Layer>
+            <ows:Title>Test layer</ows:Title>
+            <ows:Abstract>Périmètre de la Convention alpine en Suisse. La Convention alpine est un traité de droit international conclu par huit Etats alpins (Allemagne, Autriche, France, Italie, Liechtenstein, Monaco, Suisse, Slovénie) et l'Union européenne. L'accord vise à assurer la préservation et la protection des Alpes à travers une politique plurisectorielle, globale et durable.</ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>5.140242 45.398181</ows:LowerCorner>
+                <ows:UpperCorner>11.47757 48.230651</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>ch.wmts.name</ows:Identifier>
+            <ows:Metadata xlink:href="http://www.geocat.ch/geonetwork/srv/deu/metadata.show?uuid=8698bf0b-fceb-4f0f-989b-111e7c4af0a4"/>
+            <Style>
+                <ows:Title>Convention des Alpes</ows:Title>
+                <ows:Identifier>ch.iwmts.name</ows:Identifier>
+                <LegendURL format="image/png" xlink:href="https://api3.geo.admin.ch/static/images/legends/ch.are.alpenkonvention_fr.png"/>
+            </Style>
+            <Format>image/png</Format>
+            <Dimension>
+                <ows:Identifier>Time</ows:Identifier>
+                <Default>20090101</Default>
+                <Value>20090101</Value>
+            </Dimension>
+            <TileMatrixSetLink>
+                    <TileMatrixSet>21781_24</TileMatrixSet>
+            </TileMatrixSetLink>
+                <ResourceURL format="image/png" resourceType="tile" template="https://wmts.geo.admin.ch/1.0.0/ch.are.alpenkonvention/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+        </Layer>
+        <Layer>
             <ows:Title>Convention des Alpes</ows:Title>
             <ows:Abstract>Périmètre de la Convention alpine en Suisse. La Convention alpine est un traité de droit international conclu par huit Etats alpins (Allemagne, Autriche, France, Italie, Liechtenstein, Monaco, Suisse, Slovénie) et l'Union européenne. L'accord vise à assurer la préservation et la protection des Alpes à travers une politique plurisectorielle, globale et durable.</ows:Abstract>
             <ows:WGS84BoundingBox>

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -80,7 +80,7 @@ beforeEach(function() {
     gaLayersProvider.wmtsMapProxyGetTileUrlTemplate = gaGlobalOptions.mapproxyUrl +
         '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
 
-      // https://regex101.com/r/U5ccHi/3
+    // https://regex101.com/r/U5ccHi/3
     gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
     gaLayersProvider.vectorTilesUrlTemplate = '//vectortiles{s}.geo.admin.ch/{Layer}/{Time}/';
     gaLayersProvider.layersConfigUrlTemplate = 'https://example.com/all?lang={Lang}';

--- a/test/specs/import/WmtsGetCapDirective.spec.js
+++ b/test/specs/import/WmtsGetCapDirective.spec.js
@@ -55,14 +55,14 @@ describe('ngeo.wmtsGetCapDirective', function() {
     });
 
     it('creates html elements', function() {
-      expect(elt.find('[ngeo-wmts-get-cap-item]').length).to.be(2);
+      expect(elt.find('[ngeo-wmts-get-cap-item]').length).to.be(3);
       expect(elt.find('.fa-sort-by-alphabet').length).to.be(1);
       expect(elt.find('.ngeo-add').length).to.be(1);
     });
 
     it('has good scope values', function() {
       expect(scope.map).to.be(map);
-      expect(scope.layers.length).to.be(2);
+      expect(scope.layers.length).to.be(3);
       expect(scope.limitations).to.be(undefined);
       expect(scope.userMsg).to.be(undefined);
       expect(scope.options.layerSelected).to.be(null);

--- a/test/specs/map/WmtsService.spec.js
+++ b/test/specs/map/WmtsService.spec.js
@@ -1,18 +1,7 @@
+/* eslint-disable max-len */
 describe('ga_wmts_service', function() {
   describe('gaWmts', function() {
     var gaWmts, map, gaGlobalOptions;
-
-    var getExternalWmtsLayer = function(options) {
-      var source = new ol.source.WMTS(options.sourceConfig);
-      var layer = new ol.layer.Tile({
-        source: source,
-        id: 'WMTS||The WMTS layer||https://foo.ch/wmts'
-      });
-
-      layer.displayInLayerManager = true;
-      layer.url = 'https://foo.ch/wmts';
-      return layer;
-    };
 
     var expectProperties = function(layer, options) {
       // Test Layer's properties
@@ -38,14 +27,6 @@ describe('ga_wmts_service', function() {
       expect(source.urls[0]).to.be(options.url);
 
       // Tests Cesium provider
-      var srsStr = '', crsStr = '&crs=EPSG:4326';
-      options.bbox = '{southProjected},{westProjected},{northProjected},{eastProjected}';
-      if (options.VERSION == '1.1.1') {
-        options.bbox = '{westProjected},{southProjected},{eastProjected},{northProjected}';
-        srsStr = '&srs=EPSG:4326';
-        crsStr = '';
-      }
-
       var prov = layer.getCesiumImageryProvider();
       expect(prov).to.be.an(Cesium.UrlTemplateImageryProvider);
       var url = options.url;
@@ -78,18 +59,19 @@ describe('ga_wmts_service', function() {
     });
 
     describe('#addWmtsToMap()', function() {
+      var url = 'https://foo.ch';
+      var minimalOptions = {
+        label: 'WMTS layer',
+        sourceConfig: {
+          matrixSet: 4326,
+          urls: [url]
+        },
+        layer: 'ch.wmts.layer',
+        capabilitiesUrl: 'https://foo.ch/Capabilities.xml'
+      };
 
       it('adds a layer using minimal parameters', function() {
-        var url = 'https://foo.ch';
-        var options = {
-          label: 'WMTS layer',
-          sourceConfig: {
-            matrixSet: 4326,
-            urls: [url]
-          },
-          layer: 'ch.wmts.layer',
-          capabilitiesUrl: 'https://foo.ch/Capabilities.xml'
-        };
+        var options = minimalOptions;
         gaWmts.addWmtsToMap(map, options);
         expect(map.getLayers().getLength()).to.be(1);
 
@@ -98,6 +80,27 @@ describe('ga_wmts_service', function() {
           url: url,
           label: 'WMTS layer',
           visible: true,
+          opacity: 1,
+          useThirdPartyData: true,
+          layer: options.layer,
+          capabilitiesUrl: options.capabilitiesUrl,
+          projection: undefined
+        });
+      });
+
+      it('adds a layer using custom parameters', function() {
+        var options = minimalOptions;
+        options.opacity = '0.2';
+        options.visible = false;
+        gaWmts.addWmtsToMap(map, options);
+        expect(map.getLayers().getLength()).to.be(1);
+
+        var layer = map.getLayers().item(0);
+        expectProperties(layer, {
+          url: url,
+          label: 'WMTS layer',
+          visible: false,
+          invertedOpacity: 0.8,
           useThirdPartyData: true,
           layer: options.layer,
           capabilitiesUrl: options.capabilitiesUrl,

--- a/test/specs/ngeo/modules/import/WmtsGetCapDirective.spec.js
+++ b/test/specs/ngeo/modules/import/WmtsGetCapDirective.spec.js
@@ -1,5 +1,6 @@
+/* eslint-disable max-len */
 describe('ngeo.wmtsGetCapDirective', function() {
-  var elt, scope, parentScope, map, $rootScope, $compile, $translate, gaWmts, $window, $httpBackend;
+  var elt, scope, parentScope, map, $rootScope, $compile, $window;
 
   var loadDirective = function() {
     parentScope = $rootScope.$new();
@@ -36,9 +37,7 @@ describe('ngeo.wmtsGetCapDirective', function() {
     inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
-      $translate = $injector.get('$translate');
       $window = $injector.get('$window');
-      gaWmts = $injector.get('gaWmts');
     });
 
     map = new ol.Map({});
@@ -55,14 +54,14 @@ describe('ngeo.wmtsGetCapDirective', function() {
     });
 
     it('creates html elements', function() {
-      expect(elt.find('[ngeo-wmts-get-cap-item]').length).to.be(2);
+      expect(elt.find('[ngeo-wmts-get-cap-item]').length).to.be(3);
       expect(elt.find('.fa-sort-by-alphabet').length).to.be(1);
       expect(elt.find('.ngeo-add').length).to.be(1);
     });
 
     it('has good scope values', function() {
       expect(scope.map).to.be(map);
-      expect(scope.layers.length).to.be(2);
+      expect(scope.layers.length).to.be(3);
       expect(scope.limitations).to.be(undefined);
       expect(scope.userMsg).to.be(undefined);
       expect(scope.options.layerSelected).to.be(null);


### PR DESCRIPTION
[Test](//mf-geoadmin3.int.bgdi.ch/fix_3945/index.html?lang=de&zoom=1&X=193700.27&Y=605210.00&layers_indices=5&selectedNode=LT1_1&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=WMTS%7C%7Csnowmask%7C%7Chttps:%2F%2Fwww.skitourenguru.ch%2Fcalc_data%2Fraster%2FWMTSCapabilities.xml&layers_opacity=0.35)