### PR TITLE
Fix #3952: Don't sanitize features twice

### DIFF
--- a/test/specs/map/KmlService.spec.js
+++ b/test/specs/map/KmlService.spec.js
@@ -440,6 +440,13 @@ describe('ga_kml_service', function() {
           isNotValid.verify();
           var feats = olLayer.getSource().getFeatures();
           expect(feats.length).to.be(4);
+
+          // Verify coordinates are not reprojected twice
+          var projectedCoord = [1013007.3662187896, 5909489.863677091, 0];
+          expect(feats[0].getGeometry().getCoordinates()).to.eql(projectedCoord);
+          expect(feats[1].getGeometry().getCoordinates()).to.eql(projectedCoord);
+          expect(feats[2].getGeometry().getCoordinates()).to.eql(projectedCoord);
+          expect(feats[3].getGeometry().getCoordinates()).to.eql(projectedCoord);
           done();
         });
         $httpBackend.flush();


### PR DESCRIPTION
[Updload a KML with network link to test](https://mf-geoadmin3.int.bgdi.ch/fix_3952/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,)