### PR TITLE
Makes settings responsive

### DIFF
--- a/src/components/controls3d/style/controls3d.less
+++ b/src/components/controls3d/style/controls3d.less
@@ -167,12 +167,6 @@
       width: 20px;
      }
    }
-
-   &:hover {
-     [ga-help] {
-       opacity: 1;
-     }
-   }
 }
 
 .ga-pegman-dragging {

--- a/src/components/help/style/help.less
+++ b/src/components/help/style/help.less
@@ -5,12 +5,16 @@
   opacity: 0.3;
 
   &:hover {
-    opacity: 1;
+    opacity: 1!important;
   }
 
   button.ga-icon {
     height: 100%;
     font-size: 14px;
+  }
+
+  @media (max-width: @screen-tablet) {
+    display: none;
   }
 }
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -125,13 +125,7 @@ itemscope itemtype="http://schema.org/WebApplication"
       </script>
     <![endif]-->
 
-    <div ng-cloak class="corner-ribbon
-% if device == 'mobile':
-    top-left
-% else:
-    bottom-left
-% endif
-    sticky red shadow" ng-show="globals.is3dActive">
+    <div ng-cloak class="corner-ribbon" ng-show="globals.is3dActive">
       3D - BETA
     </div>
     <div ng-controller="GaSeoController">

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -224,25 +224,24 @@ itemscope itemtype="http://schema.org/WebApplication"
            ga-attribution-ol3d="::ol3d">
       </div>
     </div> <!-- #map -->
-% if device != 'mobile':
-    <div ng-cloak ng-show="globals.is3dActive"
-         ga-cesium-inspector
-         ga-cesium-inspector-ol3d="::ol3d"></div>
-    <div ng-cloak ng-show="globals.is3dActive"
-         ga-cesium-3d-tiles-inspector
-         ga-cesium-3d-tiles-inspector-ol3d="::ol3d"></div>
-% endif
-% if device == 'mobile':
-    <div ga-offline-selector
-         ga-offline-selector-map="::map">
-    </div>
-% endif
 
-    <div ga-controls3d ga-controls3d-ol3d="::ol3d" ng-if="ol3d" ng-show="globals.is3dActive" ga-controls3d-pegman="globals.pegman"></div>
-    <div ga-attribution-warning
-         ga-attribution-warning-ol3d="::ol3d">
-      <span translate>3d_overlay_warning</span>
+    <!-- 3d buutons and inspectors -->
+    <div ng-cloak ng-if="globals.is3dActive">
+      <div ga-cesium-inspector
+           ga-cesium-inspector-ol3d="::ol3d"></div>
+      <div ga-cesium-3d-tiles-inspector
+           ga-cesium-3d-tiles-inspector-ol3d="::ol3d"></div>
+      <div ga-controls3d
+           ga-controls3d-ol3d="::ol3d"
+           ga-controls3d-pegman="globals.pegman"></div>
+      <div ga-attribution-warning
+           ga-attribution-warning-ol3d="::ol3d">
+        <span translate>3d_overlay_warning</span>
+      </div>
     </div>
+  % if device == 'mobile':
+    <div ng-cloak ga-offline-selector ga-offline-selector-map="::map"></div>
+  % endif
 % if device != 'embed':
     <div ng-cloak translate-cloak id="footer" class="navbar navbar-fixed-bottom">
       <div  class="pull-left" ga-scale-line ga-scale-line-map="::map" ng-show="!globals.is3dActive"></div>
@@ -496,12 +495,10 @@ itemscope itemtype="http://schema.org/WebApplication"
         </button>
       </div> <!-- #pulldown-content -->
     </div> <!-- #pulldown -->
-
   % if device == 'mobile':
     <!-- Modal: offline menu -->
     <div ng-cloak translate-cloak ga-offline-menu ga-offline-menu-map="map"></div>
   % endif
-
     <!-- Modal: topics selection -->
     <div id="topicSelector" ng-cloak translate-cloak ga-topic></div>
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -142,26 +142,21 @@ itemscope itemtype="http://schema.org/WebApplication"
       </a>
       <div id="search-container" ng-controller="GaSearchController">
         <div ga-search ga-search-map="map" ga-search-options="options" ga-search-focused="globals.searchFocused" ga-search-ol3d="::ol3d"></div>
-  % if device == 'desktop':
         <span ga-help="24,31,25" ga-help-options="{showOnHover:true}"></span>
-  % endif
         <div class="warning-not-prod" ng-if="!globals.hostIsProd">
           <span translate>test_host_warning</span>
         </div>
       </div>
-  % if device == 'desktop':
       <div id="toptools">
         <div ga-fullscreen ga-fullscreen-map="map"></div>&nbsp;&nbsp;
         <a href="" ng-click="globals.feedbackPopupShown = !globals.feedbackPopupShown">
           <span translate>problem_announcement</span>
         </a>&nbsp;&nbsp;
         <a target="_blank" href="//help.geo.admin.ch/?lang={{langId}}" translate>help_label</a>&nbsp;&nbsp;
-        <a href="{{deviceSwitcherHref}}" translate>mobile_redirect</a>&nbsp;&nbsp;
         <div ng-controller="GaTranslationController">
           <div ga-translation-selector ga-translation-selector-options="options"></div>
         </div>
       </div>
-  % endif
       <button class="btn ga-menu-bt" ng-click="globals.pulldownShown=true" translate>menu</button>
       ## css animation doesnt work on pseudo element, let use this instead
       <div class="ga-offline-msg alert-danger" translate>offline_sorry</div>

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -257,7 +257,7 @@ itemscope itemtype="http://schema.org/WebApplication"
              ga-mouse-position-options="options"></div>
       </div>
   % endif
-     <div class="pull-right">
+      <div class="pull-right">
         <a target="_blank" href="https://www.geo.admin.ch/{{langId}}/about-swiss-geoportal/impressum.html#copyright" translate>copyright_label</a>
       </div>
   % if device == 'desktop':
@@ -415,11 +415,7 @@ itemscope itemtype="http://schema.org/WebApplication"
              ga-collapsible-show="globals.catalogShown">
             <i class="fa fa-caret-down"></i>
             <span>{{topicId | translate}}</span>
-
-  % if device == 'desktop':
             <span ga-help="32,37,39" ga-help-options="{showOnHover:true}"></span>
-  % endif
-
           </a>
           <div id="catalog" class="collapse" ng-controller="GaCatalogtreeController">
             <div class="panel-body panel-body-wide accordion-inner-catalog"
@@ -436,10 +432,7 @@ itemscope itemtype="http://schema.org/WebApplication"
              ga-collapsible-show="globals.selectionShown">
             <i class="fa fa-caret-down"></i>
             <span translate>layers_displayed</span>
-
-% if device == 'desktop':
             <span ga-help="34,35,36" ga-help-options="{showOnHover:true}"></span>
-% endif
           </a>
           <div id="selection" class="collapse">
             <div class="panel-body panel-body-wide" ga-layermanager ga-layermanager-map="map">

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -147,7 +147,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           <span translate>test_host_warning</span>
         </div>
       </div>
-      <div id="toptools">
+      <div id="toptools" ng-if="!globals.settingsShown">
         <div ga-fullscreen ga-fullscreen-map="map"></div>&nbsp;&nbsp;
         <a href="" ng-click="globals.feedbackPopupShown = !globals.feedbackPopupShown">
           <span translate>problem_announcement</span>
@@ -226,7 +226,7 @@ itemscope itemtype="http://schema.org/WebApplication"
     </div> <!-- #map -->
 
     <!-- 3d buutons and inspectors -->
-    <div ng-cloak ng-if="globals.is3dActive">
+    <div ng-cloak ng-if="globals.is3dActive && ol3d">
       <div ga-cesium-inspector
            ga-cesium-inspector-ol3d="::ol3d"></div>
       <div ga-cesium-3d-tiles-inspector
@@ -445,8 +445,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           </div>
         </div> <!-- .panel -->
 
-  % if device == 'mobile':
-        <div class="panel">
+        <div class="panel" ng-if="globals.settingsShown">
           <a class="panel-heading accordion-toggle collapsed" data-toggle="collapse" data-parent="#pulldown-content" href="#settings">
             <i class="fa fa-caret-down"></i>
             <span translate>settings</span>
@@ -457,9 +456,6 @@ itemscope itemtype="http://schema.org/WebApplication"
                 <a href="" ng-click="globals.feedbackPopupShown = !globals.feedbackPopupShown">
                   <span ng-class="{'selected': globals.feedbackPopupShown}" translate>problem_announcement</span>
                 </a>
-              </p>
-              <p>
-                <a href="{{deviceSwitcherHref}}" translate>desktop_redirect</a>
               </p>
               <div class="options">
                 <label ng-controller="GaTranslationController">
@@ -476,7 +472,7 @@ itemscope itemtype="http://schema.org/WebApplication"
             </div>
           </div>
         </div> <!-- .panel -->
-  % endif
+        
         <button id="menu-button" class="btn btn-default"
                 ng-click="globals.pulldownShown=!globals.pulldownShown">
           <span class="ga-hidden-mobile">

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -153,6 +153,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           <span translate>problem_announcement</span>
         </a>&nbsp;&nbsp;
         <a target="_blank" href="//help.geo.admin.ch/?lang={{langId}}" translate>help_label</a>&nbsp;&nbsp;
+        <a href="{{deviceSwitcherHref}}" translate>mobile_redirect</a>&nbsp;&nbsp;
         <div ng-controller="GaTranslationController">
           <div ga-translation-selector ga-translation-selector-options="options"></div>
         </div>
@@ -225,7 +226,7 @@ itemscope itemtype="http://schema.org/WebApplication"
       </div>
     </div> <!-- #map -->
 
-    <!-- 3d buutons and inspectors -->
+    <!-- 3d buttons and inspectors -->
     <div ng-cloak ng-if="globals.is3dActive && ol3d">
       <div ga-cesium-inspector
            ga-cesium-inspector-ol3d="::ol3d"></div>
@@ -239,9 +240,9 @@ itemscope itemtype="http://schema.org/WebApplication"
         <span translate>3d_overlay_warning</span>
       </div>
     </div>
-  % if device == 'mobile':
+% if device == 'mobile':
     <div ng-cloak ga-offline-selector ga-offline-selector-map="::map"></div>
-  % endif
+% endif
 % if device != 'embed':
     <div ng-cloak translate-cloak id="footer" class="navbar navbar-fixed-bottom">
       <div  class="pull-left" ga-scale-line ga-scale-line-map="::map" ng-show="!globals.is3dActive"></div>
@@ -374,26 +375,23 @@ itemscope itemtype="http://schema.org/WebApplication"
             <div class="panel-body panel-body-wide panel-cursor">
               <ul>
                 <li><!-- Import -->
-                  <a href="" ng-click="globals.importPopupShown = !globals.importPopupShown"
-                     data-original-title="{{'import_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="bottom"
-                     accesskey="w">
+                  <a href="" accesskey="w"
+                     ng-click="globals.importPopupShown = !globals.importPopupShown"
+                     translate-attr="{title: 'import_tooltip'}">
                     <span ng-class="{'selected': globals.importPopupShown}" translate>import</span>
                   </a>
                 </li>
                 <li ng-show="!globals.is3dActive"><!-- Compare -->
-                  <a href=""  ng-click="globals.isSwipeActive = !globals.isSwipeActive"
-                     data-original-title="{{'swipe_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="bottom"
-                     accesskey="c">
+                  <a href=""  accesskey="c"
+                     ng-click="globals.isSwipeActive = !globals.isSwipeActive"
+                     translate-attr="{title: 'swipe_tooltip'}">
                     <span ng-class="{'selected': globals.isSwipeActive}" translate>swipe</span>
                   </a>
                 </li>
                 <li ng-show="!globals.is3dActive"><!-- Feature Tree -->
-                  <a href=""  ng-click="globals.isFeatureTreeActive = !globals.isFeatureTreeActive"
-                     data-original-title="{{'featuretree_tooltip' | translate}}"
-                     class="ga-custom-tooltip" data-placement="top"
-                     accesskey="s">
+                  <a href="" accesskey="s"
+                     ng-click="globals.isFeatureTreeActive = !globals.isFeatureTreeActive"
+                     translate-attr="{title: 'featuretree_tooltip'}">
                     <span  ng-class="{'selected': globals.isFeatureTreeActive}" translate>object_information</span>
                   </a>
                 </li>
@@ -457,6 +455,9 @@ itemscope itemtype="http://schema.org/WebApplication"
                   <span ng-class="{'selected': globals.feedbackPopupShown}" translate>problem_announcement</span>
                 </a>
               </p>
+              <p>
+                <a href="{{deviceSwitcherHref}}" translate>desktop_redirect</a>
+              </p>
               <div class="options">
                 <label ng-controller="GaTranslationController">
                   <span translate>lang_chooser_label</span>
@@ -472,7 +473,7 @@ itemscope itemtype="http://schema.org/WebApplication"
             </div>
           </div>
         </div> <!-- .panel -->
-        
+
         <button id="menu-button" class="btn btn-default"
                 ng-click="globals.pulldownShown=!globals.pulldownShown">
           <span class="ga-hidden-mobile">
@@ -512,7 +513,6 @@ itemscope itemtype="http://schema.org/WebApplication"
       </div>
     </div> <!-- end Feedback -->
 
-  % if device == 'desktop':
     <!-- Popup: Import -->
     <div ng-if="globals.importPopupShown"
          ga-popup="globals.importPopupShown"
@@ -527,7 +527,6 @@ itemscope itemtype="http://schema.org/WebApplication"
         </div>
       </div>
     </div> <!-- end Import -->
-  % endif
 
     <!-- Popup: Profile -->
     <div ng-controller="GaProfilePopupController">
@@ -805,16 +804,14 @@ itemscope itemtype="http://schema.org/WebApplication"
           staging: staging,
           apiOverwrite: apiOverwrite
         });
-
-        $('.ga-custom-tooltip').tooltip();
-
       })();
 
-% if device == 'mobile':
-## Workaround for iOS 6.x bug: content shifted after orientation change
-## As we can't use css fix ( see http://stackoverflow.com/a/12518946/29655 )
-## we force a redraw on orientation change
-## ( see http://stackoverflow.com/a/13235711/29655 )
+      /**
+       *  Workaround for iOS 6.x bug: content shifted after orientation change
+       *  As we can't use css fix ( see http://stackoverflow.com/a/12518946/29655 )
+       *  we force a redraw on orientation change
+       *  ( see http://stackoverflow.com/a/13235711/29655 )
+       */
       (function(){
         $(window).bind("orientationchange", function(){
           $('#header').hide();
@@ -825,7 +822,6 @@ itemscope itemtype="http://schema.org/WebApplication"
           }, 0);
         });
       })();
-% endif
     </script>
   </body>
 </html>

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -256,6 +256,7 @@ goog.require('ga_window_service');
       catalogShown: false,
       selectionShown: false,
       feedbackPopupShown: false,
+      settingsShown: false,
       isShareActive: false,
       isDrawActive: false,
       isFeatureTreeActive: false,
@@ -270,6 +271,7 @@ goog.require('ga_window_service');
         $scope.globals.searchFocused = gaWindow.isWidth('>xs');
         $scope.globals.pulldownShown = gaWindow.isWidth('>s') &&
              gaWindow.isHeight('>s');
+        $scope.globals.settingsShown = gaWindow.isWidth('<=m');
       });
     });
 
@@ -373,11 +375,20 @@ goog.require('ga_window_service');
           });
         }
       }
+      
       // Open share panel by default on phone
       if ($scope.globals.pulldownShown && !$scope.globals.isShareActive &&
           !$scope.globals.isDrawActive && gaWindow.isWidth('xs')) {
         $scope.$applyAsync(function() {
           $scope.globals.isShareActive = true;
+        });
+      }
+
+      // Display settings panel
+      if ((gaWindow.isWidth('<=m') && !$scope.globals.settingsShown) || 
+         (gaWindow.isWidth('>m') && $scope.globals.settingsShown)) {
+        $scope.$applyAsync(function() {
+          $scope.globals.settingsShown = !$scope.globals.settingsShown;
         });
       }
     });

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -375,7 +375,7 @@ goog.require('ga_window_service');
           });
         }
       }
-      
+
       // Open share panel by default on phone
       if ($scope.globals.pulldownShown && !$scope.globals.isShareActive &&
           !$scope.globals.isDrawActive && gaWindow.isWidth('xs')) {
@@ -385,7 +385,7 @@ goog.require('ga_window_service');
       }
 
       // Display settings panel
-      if ((gaWindow.isWidth('<=m') && !$scope.globals.settingsShown) || 
+      if ((gaWindow.isWidth('<=m') && !$scope.globals.settingsShown) ||
          (gaWindow.isWidth('>m') && $scope.globals.settingsShown)) {
         $scope.$applyAsync(function() {
           $scope.globals.settingsShown = !$scope.globals.settingsShown;

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -218,13 +218,13 @@ button.ga-btn, button.ngeo-btn, .ol-control button {
 }
 
 .cadastre {
- &.it, &.de, &.fr {
-   #catalogHeading {
-     [ga-help] {
-       display: none;
-     }
-   }
- }
+  &.it, &.de, &.fr {
+    #catalogHeading {
+      [ga-help] {
+        display: none;
+      }
+    }
+  }
 }
 
 

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -217,21 +217,14 @@ button.ga-btn, button.ngeo-btn, .ol-control button {
   }
 }
 
-.cadastre.de, .cadastre.fr {
+.cadastre {
+ &.it, &.de, &.fr {
    #catalogHeading {
-       &[aria-expanded="true"] span {
-           letter-spacing: -0.4px;
-       }
-       [ga-help] {
-         display: none;
-       }
+     [ga-help] {
+       display: none;
+     }
    }
-}
-
-.cadastre.it #catalogHeading[aria-expanded="true"] {
-  [ga-help] {
-    display: none;
-  }
+ }
 }
 
 
@@ -464,13 +457,6 @@ input[type=text][readonly] {
     height: unit(@small-header-height, px);
     background: #fff;
   }
-
-  @media (max-width: @screen-phone) {
-    [ga-help] {
-      display: none;
-    }
-  }
-
 }
 
 #search-container {
@@ -493,10 +479,6 @@ input[type=text][readonly] {
 
     @media (min-width: @screen-desktop) and (min-height: @screen-s-height) {
       top: 21px;
-    }
-
-    @media (max-width: @screen-tablet) {
-      display: none;
     }
   }
 

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -494,6 +494,10 @@ input[type=text][readonly] {
     @media (min-width: @screen-desktop) and (min-height: @screen-s-height) {
       top: 21px;
     }
+
+    @media (max-width: @screen-tablet) {
+      display: none;
+    }
   }
 
   @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
@@ -638,15 +642,10 @@ input[type=text][readonly] {
   }
 
   a {
-    font-size: 80%;
+    font-size: 0.8em;
   }
 
-  @media (max-width: @screen-tablet) and (min-width: 535px) {
-    width: ~"calc(100% - 320px)";
-    right: 1em;
-  }
-
-  @media (max-width: 534px) {
+  @media (max-width: @screen-tablet) {
     display: none;
   }
 }

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -1779,38 +1779,27 @@ body:not(.embed) {
 
 /* Corner ribbons, from http://codepen.io/eode9/pen/twkKm */
 .corner-ribbon{
-  width: 200px;
-  background: #e43;
   position: absolute;
-  top: 25px;
-  left: -50px;
+  /* bottom-left */
+  top: auto;
+  bottom: 50px; /* Under cesium inspectors */
+  left: -100px;
+  z-index: 40;
+  width: 300px;
+  background: red;
+  color: white;
   text-align: center;
   line-height: 50px;
   letter-spacing: 1px;
-  color: #f0f0f0;
-  .rotate(-45deg);
-  z-index: 400;
-}
+  transform: rotate(45deg);
 
-/* Custom styles */
-
-.corner-ribbon.sticky{
-  position: absolute;
-}
-
-.corner-ribbon.shadow{
-  box-shadow: 0 0 3px rgba(0,0,0,.3);
-}
-
-/* Different positions */
-
-.corner-ribbon.top-left{
-  top: 150px;
-  left: -50px;
-  .rotate(-45deg);
-
-  @media (max-width: @screen-tablet), (max-height: @screen-s-height) {
+  @media (max-width: @screen-tablet) {
+    /* top-left */
     top: 108px;
+    bottom: auto;
+    left: -50px;
+    width: 200px;
+    transform: rotate(-45deg);
   }
 
   @media (max-width: @screen-phone) {
@@ -1818,40 +1807,7 @@ body:not(.embed) {
   }
 }
 
-.corner-ribbon.top-right{
-  top: 25px;
-  right: -50px;
-  left: auto;
-  .rotate(45deg);
-}
-
-.corner-ribbon.bottom-left{
-  top: auto;
-  bottom: 50px;
-  left: -100px;
-  width: 300px;
-  .rotate(45deg);
-}
-
-.corner-ribbon.bottom-right{
-  top: auto;
-  right: -50px;
-  bottom: 25px;
-  left: auto;
-  .rotate(-45deg);
-
-/* Colors */
-
-.corner-ribbon.white{background: #f0f0f0; color: #555;}
-.corner-ribbon.black{background: #333;}
-.corner-ribbon.grey{background: #999;}
-.corner-ribbon.blue{background: #39d;}
-.corner-ribbon.green{background: #2c7;}
-.corner-ribbon.turquoise{background: #1b9;}
-.corner-ribbon.purple{background: #95b;}
-.corner-ribbon.red{background: red; color: white;}
-.corner-ribbon.orange{background: #e82;}
-.corner-ribbon.yellow{background: #ec0;}}
+/* Waring test link */
 
 .warning-not-prod {
   width: 100%;

--- a/test/specs/js/MainController.spec.js
+++ b/test/specs/js/MainController.spec.js
@@ -83,6 +83,7 @@ describe('ga_main_controller', function() {
         expect(g.catalogShown).to.be(false);
         expect(g.selectionShown).to.be(false);
         expect(g.feedbackPopupShown).to.be(false);
+        expect(g.settingsShown).to.be(false);
         expect(g.isShareActive).to.be(false);
         expect(g.isDrawActive).to.be(false);
         expect(g.isFeatureTreeActive).to.be(false);


### PR DESCRIPTION
Part of #3820 

This PR:

 - Display tools (fullscreen ,...)  in the header on desktop and the settings panel on smaller screen
 - Use default html tooltip for advanced tools
 - Hide all ga-help buttons on mobile

[Test]( //mf-geoadmin3.int.bgdi.ch/teo_3820/index.html)