### PR TITLE
Go Live of ToD. All Layers but not swissimage

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -388,30 +388,13 @@ goog.require('ga_urlutils_service');
           return urls;
         };
 
-        var todLayers = [
-          'ch.swisstopo.swisstlm3d-karte-farbe.3d',
-          'ch.swisstopo.swisstlm3d-karte-grau.3d',
+        var todExcludeLayers = [
           'ch.swisstopo.swissimage-product',
-          'ch.swisstopo.swisstlm3d-wanderwege',
-          'ch.bav.haltestellen-oev'
-        ];
-
-        var tod03Layers = [
-          'ch.swisstopo.pixelkarte-grau',
-          'ch.swisstopo.swisstlm3d-wanderwege',
-          'ch.bav.haltestellen-oev',
-          'ch.swisstopo.geologie-geotechnik-gk200',
-          'ch.swisstopo.geologie-generalkarte-ggk200',
-          'ch.swisstopo.geologie-gravimetrischer_atlas'
+          'ch.swisstopo.swissimage'
         ];
 
         var useToD = function(layer, tileMatrixSet) {
-          if (tileMatrixSet === '4326') {
-            return (todLayers.indexOf(layer) !== -1);
-          } else if (tileMatrixSet === '21781') {
-            return (tod03Layers.indexOf(layer) !== -1);
-          }
-          return false;
+          return todExcludeLayers.indexOf(layer) === -1;
         }
 
         var getWmtsGetTileTpl = function(layer, time, tileMatrixSet,

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -516,8 +516,8 @@ describe('ga_map_service', function() {
       'ch.vbs.patrouilledesglaciers-z_rennen': {}
     };
     var terrainTpl = '//3d.geo.admin.ch/1.0.0/{layer}/default/{time}/4326';
-    var wmtsTpl = '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{y}/{x}.{format}';
-    var wmtsMpTpl = window.location.protocol + '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
+    var wmtsTpl = '//tod{s}.bgdi.ch//1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
+    var wmtsMpTpl = '//tod{s}.bgdi.ch//1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
     var vectorTilesTpl = '//vectortiles100.geo.admin.ch/{layer}/{time}/';
     var wmsTpl = '//wms{s}.geo.admin.ch/?layers={layer}&format=image%2F{format}&service=WMS&version=1.3.0&request=GetMap&crs=CRS:84&bbox={westProjected},{southProjected},{eastProjected},{northProjected}&width=512&height=512&styles=';
     var expectWmtsUrl = function(l, t, f) {
@@ -888,7 +888,7 @@ describe('ga_map_service', function() {
         // instead.
         var params = spy.args[0][0];
         expect(params.url).to.eql(expectWmtsUrl('serverlayername3d', '20160201'));
-        expect(params.subdomains).to.eql(['5', '6', '7', '8', '9']);
+        expect(params.subdomains).to.eql(['100', '101']);
         expect(params.minimumLevel).to.eql(window.minimumLevel);
         expect(params.maximumRetrievingLevel).to.eql(window.maximumRetrievingLevel);
         expect(params.maximumLevel).to.eql(18);
@@ -928,7 +928,7 @@ describe('ga_map_service', function() {
         // instead.
         var params = spy.args[0][0];
         expect(params.url).to.eql(expectWmtsMpUrl('wmtsmapproxy', '20160201'));
-        expect(params.subdomains).to.eql(['20', '21', '22', '23', '24']);
+        expect(params.subdomains).to.eql(['100', '101']);
         expect(prov.bodId).to.be('wmtsmapproxy');
         spy.restore();
       });
@@ -1100,8 +1100,8 @@ describe('ga_map_service', function() {
           expect(source.getDimensions().Time).to.be('20180101');
           expect(source.getProjection().getCode()).to.be('EPSG:21781');
           expect(source.getRequestEncoding()).to.be('REST');
-          expect(source.getUrls().length).to.be(5);
-          expect(source.getUrls()[0]).to.be('//wmts5.geo.admin.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
+          expect(source.getUrls().length).to.be(2);
+          expect(source.getUrls()[0]).to.be('//tod100.prod.bgdi.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
           expect(source.getTileLoadFunction()).to.be.a(Function);
           var tileGrid = source.getTileGrid();
           expect(tileGrid instanceof ol.tilegrid.WMTS).to.be.ok();


### PR DESCRIPTION
This is the PR for the go-live of ToD.

The revert path is already on prod and corresponds to current master:
master/4035d4d/1710041101

[TestLink](https://mf-geoadmin3.int.bgdi.ch/gjn_tod_go_live/index.html)