### PR TITLE
Revert ToD, assure tests work under both conditions

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -387,14 +387,15 @@ goog.require('ga_urlutils_service');
           });
           return urls;
         };
-
+        /*
         var todExcludeLayers = [
           'ch.swisstopo.swissimage-product',
           'ch.swisstopo.swissimage'
         ];
-
+*/
         var useToD = function(layer, tileMatrixSet) {
-          return todExcludeLayers.indexOf(layer) === -1;
+          return false;
+          // return todExcludeLayers.indexOf(layer) === -1;
         }
 
         var getWmtsGetTileTpl = function(layer, time, tileMatrixSet,
@@ -584,6 +585,10 @@ goog.require('ga_urlutils_service');
         // Load layers configuration with value from permalink
         // gaLang.get() never returns an undefined value on page load.
         var configP = loadLayersConfig(gaLang.get());
+
+        this.useToD = function(layer, tilematrix) {
+          return useToD(layer, tilematrix);
+        }
 
         /**
          * Get the promise of the layers config requets

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -71,8 +71,8 @@ beforeEach(function() {
   module(function(gaLayersProvider, gaGlobalOptions) {
     gaLayersProvider.dfltWmsSubdomains = ['', '0', '1', '2', '3', '4'];
     gaLayersProvider.dfltWmtsNativeSubdomains = ['5', '6', '7', '8', '9'];
-    gaLayersProvider.dfltToDSubdomains = ['100', '101'];
-    gaLayersProvider.dfltWmtsMapProxySubdomains = ['20', '21', '22', '23', '24'];
+    gaLayersProvider.dfltToDSubdomains = ['5', '6', '7', '8', '9'];
+    gaLayersProvider.dfltWmtsMapProxySubdomains = ['5', '6', '7', '8', '9'];
     gaLayersProvider.dfltVectorTilesSubdomains = ['100', '101', '102', '103', '104'];
     gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
     gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';


### PR DESCRIPTION
This reverts ToD. I forgot to have a revert version ready yesterday that includes the Offline fix by @oterral . So I'll merge this and create a revert version. Then re-apply ToD in master.

Also, I've adapted the tests so they work both with ToD enabled and disabled.

Now, to switch between ToD enabled/disabled, onyl the useToD function needs to be adapted.

FYI @oterral @loicgasser