### PR TITLE
WMTS per env and parameter in url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ PRINT_TECH_URL ?= //service-print.
 LAST_PRINT_URL := $(call lastvalue,print-url)
 PROXY_URL ?= //service-proxy.prod.bgdi.ch
 LAST_PROXY_URL := $(call lastvalue,proxy-url)
+WMTS_URL ?= tod.dev.bgdi.ch
+WMTS_TECH_URL ?= //tod.
+LAST_WMTS_URL ?= $(call lastvalue,wmts-url)
 
 PUBLIC_URL_REGEXP ?= ^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*
 ADMIN_URL_REGEXP ?= ^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)
@@ -510,6 +513,8 @@ define buildpage
 		--var "shop_tech_url=$(SHOP_TECH_URL)" \
 		--var "wms_url=$(WMS_URL)" \
 		--var "wms_tech_url=$(WMS_TECH_URL)" \
+		--var "wmts_url=$(WMTS_URL)" \
+		--var "wmts_tech_url=$(WMTS_TECH_URL)" \
 		--var "default_topic_id=$(DEFAULT_TOPIC_ID)" \
 		--var "translation_fallback_code=$(TRANSLATION_FALLBACK_CODE)" \
 		--var "languages=$(LANGUAGES)" \
@@ -557,6 +562,7 @@ prd/index.html: src/index.mako.html \
 	    .build-artefacts/last-print-url \
 	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path \
+	    .build-artefacts/last-wmts-url \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	$(call buildpage,desktop,prod,$(VERSION),$(VERSION)/,$(S3_BASE_PATH))
@@ -573,6 +579,7 @@ prd/mobile.html: src/index.mako.html \
 	    .build-artefacts/last-print-url \
 	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path \
+	    .build-artefacts/last-wmts-url \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	$(call buildpage,mobile,prod,$(VERSION),$(VERSION)/,$(S3_BASE_PATH))
@@ -588,6 +595,7 @@ prd/embed.html: src/index.mako.html \
 	    .build-artefacts/last-print-url \
 	    .build-artefacts/last-proxy-url \
 	    .build-artefacts/last-apache-base-path \
+	    .build-artefacts/last-wmts-url \
 	    .build-artefacts/last-version
 	mkdir -p $(dir $@)
 	$(call buildpage,embed,prod,$(VERSION),$(VERSION)/,$(S3_BASE_PATH))
@@ -648,6 +656,7 @@ src/mobile.html: src/index.mako.html \
 	    .build-artefacts/last-public-url \
 	    .build-artefacts/last-print-url \
 	    .build-artefacts/last-proxy-url \
+	    .build-artefacts/last-wmts-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,mobile,,,,$(S3_SRC_BASE_PATH))
 
@@ -661,6 +670,7 @@ src/embed.html: src/index.mako.html \
 	    .build-artefacts/last-public-url \
 	    .build-artefacts/last-print-url \
 	    .build-artefacts/last-proxy-url \
+	    .build-artefacts/last-wmts-url \
 	    .build-artefacts/last-apache-base-path
 	$(call buildpage,embed,,,,$(S3_SRC_BASE_PATH))
 
@@ -815,6 +825,9 @@ ${PYTHON_VENV}:
 
 .build-artefacts/last-apache-base-directory::
 	$(call cachelastvariable,$@,$(APACHE_BASE_DIRECTORY),$(LAST_APACHE_BASE_DIRECTORY),apache-base-directory)
+
+.build-artefacts/last-wmts-url::
+	$(call cachelastvariable,$@,$(WMTS_URL),$(LAST_WMTS_URL),wmts-url)
 
 .build-artefacts/ol-cesium:
 	git clone --recursive https://github.com/openlayers/ol-cesium.git $@

--- a/README.md
+++ b/README.md
@@ -255,17 +255,19 @@ Add `mapproxy_url=//theNameOfAMapProxyServer`
 
 Add `public_url=//theNameOfAPublicServer`
 
-# Examples of usage
-National : 
-- Norwegian Institute of Bioecomic Research : <b> Geoportal forest of Norway</b>: http://kartbeta.skogoglandskap.no/kilden  
+Add `wmts_url=//theNameOfAWmtsService`
 
-- Geoportal <b> Luxembourg</b>  is a clone of our first version: http://map.geoportail.lu/ 
+# Examples of usage
+National :
+- Norwegian Institute of Bioecomic Research : <b> Geoportal forest of Norway</b>: http://kartbeta.skogoglandskap.no/kilden
+
+- Geoportal <b> Luxembourg</b>  is a clone of our first version: http://map.geoportail.lu/
 
 Regional :
 
-- Geoportal <b> Bayern</b>  : https://geoportal.bayern.de/bayernatlas/  
+- Geoportal <b> Bayern</b>  : https://geoportal.bayern.de/bayernatlas/
 
-- Geoportal <b> Jura-Bernois</b> https://map.geojb.ch  
+- Geoportal <b> Jura-Bernois</b> https://map.geojb.ch
 
 - Geoportal <b> Trento</b> https://webgis.provincia.tn.it/wgt/
 

--- a/rc_dev
+++ b/rc_dev
@@ -10,3 +10,4 @@ export SHOP_URL=//shop-bgdi.dev.bgdi.ch
 export PUBLIC_URL=//public.dev.bgdi.ch
 export PRINT_URL=//service-print.dev.bgdi.ch
 export PROXY_URL=//service-proxy.dev.bgdi.ch
+export WMTS_URL=//tod.dev.bgdi.ch

--- a/rc_int
+++ b/rc_int
@@ -11,3 +11,4 @@ export SHOP_URL=//shop-bgdi.int.bgdi.ch
 export PUBLIC_URL=//public.int.bgdi.ch
 export PRINT_URL=//service-print.int.bgdi.ch
 export PROXY_URL=//service-proxy.int.bgdi.ch
+export WMTS_URL=//tod{s}.int.bgdi.ch

--- a/rc_prod
+++ b/rc_prod
@@ -11,3 +11,4 @@ export SHOP_URL=//shop.swisstopo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export PRINT_URL=//print.geo.admin.ch
 export PROXY_URL=//service-proxy.prod.bgdi.ch
+export WMTS_URL=//tod{s}.prod.bgdi.ch

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -782,6 +782,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         var printUrl = setBackend(prtl + '${print_url}', prtl + '${print_tech_url}', 'print_url');
         var proxyUrl = prtl + '${proxy_url}' + '/';
         var apiOverwrite = !!(getParam('api_url') || env);
+        var wmtsUrl = setBackend(prtl + '${wmts_url}', prtl + '${wmts_tech_url}', 'wmts_url');
         ngeo.baseModuleTemplateUrl = 'ngeo/src/modules';
         module.constant('gaGlobalOptions', {
           //dev3d to be removed once 3d goes live
@@ -800,6 +801,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           publicUrlRegexp: new RegExp('${public_url_regexp}'),
           adminUrlRegexp: adminUrlRegexp,
           cachedApiUrl: apiUrl + cacheAdd,
+          wmtsUrl: wmtsUrl,
           cachedPrintUrl: printUrl + cacheAdd,
           resourceUrl: location.origin + s3pathname + '${versionslashed}',
           wmsUrl: wmsUrl,

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -158,10 +158,10 @@ goog.require('ga_waitcursor_service');
     gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =
         gaGlobalOptions.mapproxyUrl +
         '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
-    gaLayersProvider.wmtsToDUrlTemplate = '//tod{s}.prod.bgdi.ch/' +
-        '1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
-    gaLayersProvider.wmtsToD03UrlTemplate = '//tod{s}.prod.bgdi.ch/' +
-        '1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
+    gaLayersProvider.wmtsToDUrlTemplate = gaGlobalOptions.wmtsUrl +
+        '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+    gaLayersProvider.wmtsToD03UrlTemplate = gaGlobalOptions.wmtsUrl +
+        '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
     gaLayersProvider.dfltToDSubdomains = ['100', '101', '102', '103', '104'];
     gaLayersProvider.terrainTileUrlTemplate =
         '//terrain100.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -13,6 +13,7 @@ beforeEach(function() {
     var mapproxyUrl = '//wmts{s}.geo.admin.ch';
     var shopUrl = '//shop.bgdi.ch';
     var wmsUrl = '//wms.geo.admin.ch';
+    var wmtsUrl = '//tod{s}.bgdi.ch';
     var apacheBasePath = '/';
     var cacheAdd = '/' + version;
     var pathname = location.pathname.replace(/(context|index|mobile|embed)\.html$/g, '');
@@ -35,6 +36,7 @@ beforeEach(function() {
       resourceUrl: location.origin + pathname + versionSlashed,
       proxyUrl: location.protocol + proxyUrl + '/',
       wmsUrl: location.protocol + wmsUrl,
+      wmtsUrl: location.protocol + wmtsUrl,
       w3wUrl: 'dummy.test.url.com',
       lv03tolv95Url: '//api.example.com/reframe/lv03tolv95',
       lv95tolv03Url: '//api.example.com/reframe/lv95tolv03',
@@ -71,12 +73,13 @@ beforeEach(function() {
   module(function(gaLayersProvider, gaGlobalOptions) {
     gaLayersProvider.dfltWmsSubdomains = ['', '0', '1', '2', '3', '4'];
     gaLayersProvider.dfltWmtsNativeSubdomains = ['5', '6', '7', '8', '9'];
-    gaLayersProvider.dfltToDSubdomains = ['5', '6', '7', '8', '9'];
     gaLayersProvider.dfltWmtsMapProxySubdomains = ['5', '6', '7', '8', '9'];
     gaLayersProvider.dfltVectorTilesSubdomains = ['100', '101', '102', '103', '104'];
+    gaLayersProvider.dfltToDSubdomains = ['100', '101', '102', '103', '104'];
     gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
     gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
-    gaLayersProvider.wmtsToDUrlTemplate = '//tod{s}.bgdi.ch//1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+    gaLayersProvider.wmtsToDUrlTemplate = gaGlobalOptions.wmtsUrl + '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+    gaLayersProvider.wmtsToD03UrlTemplate = gaGlobalOptions.wmtsUrl + '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
     gaLayersProvider.wmtsMapProxyGetTileUrlTemplate = gaGlobalOptions.mapproxyUrl +
         '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
 

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -516,9 +516,9 @@ describe('ga_map_service', function() {
       'ch.vbs.patrouilledesglaciers-z_rennen': {}
     };
     var terrainTpl = '//3d.geo.admin.ch/1.0.0/{layer}/default/{time}/4326';
-    var todTpl = '//tod{s}.bgdi.ch//1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
-    var wmtsTpl = '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{y}/{x}.{format}';
-    var wmtsMpTpl = window.location.protocol + '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
+    var todTpl = location.protocol + '//tod{s}.bgdi.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
+    var wmtsTpl = location.protocol + '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{y}/{x}.{format}';
+    var wmtsMpTpl = location.protocol + '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
     var vectorTilesTpl = '//vectortiles100.geo.admin.ch/{layer}/{time}/';
     var wmsTpl = '//wms{s}.geo.admin.ch/?layers={layer}&format=image%2F{format}&service=WMS&version=1.3.0&request=GetMap&crs=CRS:84&bbox={westProjected},{southProjected},{eastProjected},{northProjected}&width=512&height=512&styles=';
     var expectWmtsUrl = function(l, t, f) {
@@ -897,7 +897,7 @@ describe('ga_map_service', function() {
         // instead.
         var params = spy.args[0][0];
         expect(params.url).to.eql(expectWmtsUrl('serverlayername3d', '20160201'));
-        expect(params.subdomains).to.eql(['5', '6', '7', '8', '9']);
+        expect(params.subdomains).to.eql(['100', '101', '102', '103', '104']);
         expect(params.minimumLevel).to.eql(window.minimumLevel);
         expect(params.maximumRetrievingLevel).to.eql(window.maximumRetrievingLevel);
         expect(params.maximumLevel).to.eql(18);
@@ -937,7 +937,7 @@ describe('ga_map_service', function() {
         // instead.
         var params = spy.args[0][0];
         expect(params.url).to.eql(expectWmtsMpUrl('wmtsmapproxy', '20160201'));
-        expect(params.subdomains).to.eql(['5', '6', '7', '8', '9']);
+        expect(params.subdomains).to.eql(['100', '101', '102', '103', '104']);
         expect(prov.bodId).to.be('wmtsmapproxy');
         spy.restore();
       });
@@ -1111,9 +1111,9 @@ describe('ga_map_service', function() {
           expect(source.getRequestEncoding()).to.be('REST');
           expect(source.getUrls().length).to.be(5);
           if (gaLayers.useToD('serverLayerName', '21781')) {
-            expect(source.getUrls()[0]).to.be('//tod5.prod.bgdi.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
+            expect(source.getUrls()[0]).to.be('http://tod100.bgdi.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
           } else {
-            expect(source.getUrls()[0]).to.be('//wmts5.geo.admin.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
+            expect(source.getUrls()[0]).to.be('http://wmts5.geo.admin.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
           }
           expect(source.getTileLoadFunction()).to.be.a(Function);
           var tileGrid = source.getTileGrid();


### PR DESCRIPTION
As for the other sevices we have now one service per env, so it make sense to point to the respective env.

Without it we may write unwanted tiles to the prod bucket.

Also you can now use `wmts_url` parameter.