### PR TITLE
Updated WMTS with ESRI basemap

### DIFF
--- a/src/js/ImportController.js
+++ b/src/js/ImportController.js
@@ -174,6 +174,7 @@ goog.require('ngeo.fileService');
         'http://rips-gdi.lubw.baden-wuerttemberg.de/arcgis/services/wms/UIS_0100000001500003/MapServer/WMSServer',
         'http://rips-gdi.lubw.baden-wuerttemberg.de/arcgis/services/wms/UIS_0100000004200001/MapServer/WMSServer',
         // WMTS servers
+        'https://tiles.arcgis.com/tiles/oPre3pOfRfefL8y0/arcgis/rest/services/Topographic_Map_Switzerland/MapServer/WMTS/1.0.0/WMTSCapabilities.xml',
         'https://www.gis.stadt-zuerich.ch/wmts/wmts-zh-stzh-ogd.xml',
         'http://www.basemap.at/wmts/1.0.0/WMTSCapabilities.xml',
         'https://wxs.ign.fr/bvl2gp6za3srtz6yblo9fx8o/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities',


### PR DESCRIPTION
added WMTS Topographic Map Switzerland (LV95) based on TLM provided and paid by ESRI https://www.arcgis.com/home/item.html?id=a4f54fc8c93e440aa91d763ffe59512b