### PR TITLE
Simplify wmts urls, don't overwrite compiletime setting

### DIFF
--- a/rc_prod
+++ b/rc_prod
@@ -11,4 +11,5 @@ export SHOP_URL=//shop.swisstopo.admin.ch
 export PUBLIC_URL=//public.geo.admin.ch
 export PRINT_URL=//print.geo.admin.ch
 export PROXY_URL=//service-proxy.prod.bgdi.ch
-export WMTS_URL=//tod{s}.prod.bgdi.ch
+export WMTS_URL=//wmts{s}.geo.admin.ch
+export WMTS_TECH_URL=//wmts.

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -739,8 +739,6 @@ itemscope itemtype="http://schema.org/WebApplication"
           var url = prodUrl;
           if (env && env != 'prod' && supportedEnv.indexOf(env) !== -1) {
             url = techUrl + env + '${tech_suffix}';
-          } else if (staging != 'prod' && !userEnvRegexp.test(prodUrl)) {
-            url = techUrl + staging + '${tech_suffix}';
           }
           var overwrite = prtl + getParam(overwriteParam);
           url = adminUrlRegexp.test(overwrite) ? overwrite : url;

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -142,31 +142,25 @@ goog.require('ga_waitcursor_service');
 
   module.config(function(gaLayersProvider, gaGlobalOptions) {
     gaLayersProvider.dfltWmsSubdomains = ['', '0', '1', '2', '3', '4'];
-    gaLayersProvider.dfltWmtsNativeSubdomains = ['100', '101', '102', '103',
-      '104', '105', '106', '107', '108', '109'];
-    gaLayersProvider.dfltWmtsMapProxySubdomains =
-      gaGlobalOptions.staging === 'prod' ?
-        ['100', '101', '102', '103', '104', '105', '106', '107', '108', '109'] :
-        ['20', '21', '22', '23', '24'];
-    gaLayersProvider.dfltVectorTilesSubdomains =
-      gaGlobalOptions.staging === 'prod' ?
-        ['100', '101', '102', '103', '104'] :
-        ['', '0', '1', '2', '3', '4'];
     gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
-    gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/' +
-        '{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
-    gaLayersProvider.wmtsMapProxyGetTileUrlTemplate =
-        gaGlobalOptions.mapproxyUrl +
-        '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
-    gaLayersProvider.wmtsToDUrlTemplate = gaGlobalOptions.wmtsUrl +
-        '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
-    gaLayersProvider.wmtsToD03UrlTemplate = gaGlobalOptions.wmtsUrl +
+
+    gaLayersProvider.wmtsSubdomains =
+        ['100', '101', '102', '103', '104'];
+    gaLayersProvider.wmtsUrl = gaGlobalOptions.wmtsUrl;
+    gaLayersProvider.wmtsLV03PathTemplate =
         '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
-    gaLayersProvider.dfltToDSubdomains = ['100', '101', '102', '103', '104'];
+    gaLayersProvider.wmtsPathTemplate =
+        '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+
     gaLayersProvider.terrainTileUrlTemplate =
         '//terrain100.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';
     gaLayersProvider.vectorTilesUrlTemplate = gaGlobalOptions.vectorTilesUrl +
         '/{Layer}/{Time}/';
+    gaLayersProvider.dfltVectorTilesSubdomains =
+      gaGlobalOptions.staging === 'prod' ?
+        ['100', '101', '102', '103', '104'] :
+        ['', '0', '1', '2', '3', '4'];
+
     gaLayersProvider.imageryMetadataUrl = '//3d.geo.admin.ch/imagery/';
     if (gaGlobalOptions.apiOverwrite) {
       gaLayersProvider.layersConfigUrlTemplate = gaGlobalOptions.apiUrl +

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -72,16 +72,12 @@ beforeEach(function() {
 
   module(function(gaLayersProvider, gaGlobalOptions) {
     gaLayersProvider.dfltWmsSubdomains = ['', '0', '1', '2', '3', '4'];
-    gaLayersProvider.dfltWmtsNativeSubdomains = ['5', '6', '7', '8', '9'];
-    gaLayersProvider.dfltWmtsMapProxySubdomains = ['5', '6', '7', '8', '9'];
     gaLayersProvider.dfltVectorTilesSubdomains = ['100', '101', '102', '103', '104'];
-    gaLayersProvider.dfltToDSubdomains = ['100', '101', '102', '103', '104'];
     gaLayersProvider.wmsUrlTemplate = '//wms{s}.geo.admin.ch/';
-    gaLayersProvider.wmtsGetTileUrlTemplate = '//wmts{s}.geo.admin.ch/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
-    gaLayersProvider.wmtsToDUrlTemplate = gaGlobalOptions.wmtsUrl + '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
-    gaLayersProvider.wmtsToD03UrlTemplate = gaGlobalOptions.wmtsUrl + '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
-    gaLayersProvider.wmtsMapProxyGetTileUrlTemplate = gaGlobalOptions.mapproxyUrl +
-        '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
+    gaLayersProvider.wmtsSubdomains = ['5', '6', '7', '8', '9'];
+    gaLayersProvider.wmtsUrl = '//wmts{s}.geo.admin.ch'
+    gaLayersProvider.wmtsLV03PathTemplate = '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
+    gaLayersProvider.wmtsPathTemplate = '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{x}/{y}.{Format}';
 
     // https://regex101.com/r/U5ccHi/3
     gaLayersProvider.terrainTileUrlTemplate = '//3d.geo.admin.ch/1.0.0/{Layer}/default/{Time}/4326';

--- a/test/specs/map/MapDirective.spec.js
+++ b/test/specs/map/MapDirective.spec.js
@@ -55,7 +55,7 @@ describe('ga_map_directive', function() {
       $httpBackend.expectGET(expectedUrl).respond(dfltLayersConfig);
       loadDirective();
       $httpBackend.flush();
-       $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingExpectation();
       $httpBackend.verifyNoOutstandingRequest();
       layer = gaLayers.getOlLayerById('foo');
       map.addLayer(layer);

--- a/test/specs/map/MapService.spec.js
+++ b/test/specs/map/MapService.spec.js
@@ -552,23 +552,15 @@ describe('ga_map_service', function() {
       'ch.vbs.patrouilledesglaciers-z_rennen': {}
     };
     var terrainTpl = '//3d.geo.admin.ch/1.0.0/{layer}/default/{time}/4326';
-    var todTpl = location.protocol + '//tod{s}.bgdi.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
-    var wmtsTpl = '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{y}/{x}.{format}';
-    var wmtsMpTpl = location.protocol + '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
+    var wmtsLV03Tpl = '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{y}/{x}.{format}';
+    var wmtsTpl = '//wmts{s}.geo.admin.ch/1.0.0/{layer}/default/{time}/4326/{z}/{x}/{y}.{format}';
     var vectorTilesTpl = '//vectortiles100.geo.admin.ch/{layer}/{time}/';
     var wmsTpl = '//wms{s}.geo.admin.ch/?layers={layer}&format=image%2F{format}&service=WMS&version=1.3.0&request=GetMap&crs=CRS:84&bbox={westProjected},{southProjected},{eastProjected},{northProjected}&width=512&height=512&styles=';
-    var expectWmtsUrl = function(l, t, f) {
-      if (gaLayers.useToD(l, t)) {
-        return expectUrl(todTpl, l, t, f);
+    var expectWmtsUrl = function(l, t, f, epsg) {
+      if (epsg === '21781') {
+        return expectUrl(wmtsLV03Tpl, l, t, f);
       } else {
         return expectUrl(wmtsTpl, l, t, f);
-      }
-    };
-    var expectWmtsMpUrl = function(l, t, f) {
-      if (gaLayers.useToD(l, t)) {
-        return expectUrl(todTpl, l, t, f);
-      } else {
-        return expectUrl(wmtsMpTpl, l, t, f);
       }
     };
     var expectTerrainUrl = function(l, t, f) {
@@ -936,7 +928,7 @@ describe('ga_map_service', function() {
         // succeed to test it so we test the params we send to the constructor
         // instead.
         var params = spy.args[0][0];
-        expect(params.url).to.eql(expectWmtsUrl('serverlayername3d', '20160201'));
+        expect(params.url).to.eql(expectWmtsUrl('serverlayername3d', '20160201', 'png', '4326'));
         expect(params.subdomains).to.eql(['5', '6', '7', '8', '9']);
         expect(params.minimumLevel).to.eql(window.minimumLevel);
         expect(params.maximumRetrievingLevel).to.eql(window.maximumRetrievingLevel);
@@ -959,26 +951,12 @@ describe('ga_map_service', function() {
         // succeed to test it so we test the params we send to the constructor
         // instead.
         var params = spy.args[0][0];
-        expect(params.url).to.eql(expectWmtsUrl('serverlayername3d', '20160201', 'jpeg'));
+        expect(params.url).to.eql(expectWmtsUrl('serverlayername3d', '20160201', 'jpeg', '4326'));
         expect(params.minimumLevel).to.eql(9);
         expect(params.maximumRetrievingLevel).to.eql(17);
         expect(params.maximumLevel).to.eql(undefined);
         expect(params.hasAlphaChannel).to.eql(false);
         expect(prov.bodId).to.be('wmts3dcustom');
-        spy.restore();
-      });
-
-      it('returns a CesiumImageryProvider from a wmts using mapproxy tiles', function() {
-        var spy = sinon.spy(Cesium, 'UrlTemplateImageryProvider');
-        var prov = gaLayers.getCesiumImageryProviderById('wmtsmapproxy');
-        expect(prov).to.be.an(Cesium.UrlTemplateImageryProvider);
-        // Properties of Cesium object are set in a promise and I don 't
-        // succeed to test it so we test the params we send to the constructor
-        // instead.
-        var params = spy.args[0][0];
-        expect(params.url).to.eql(expectWmtsMpUrl('wmtsmapproxy', '20160201'));
-        expect(params.subdomains).to.eql(['5', '6', '7', '8', '9']);
-        expect(prov.bodId).to.be('wmtsmapproxy');
         spy.restore();
       });
 
@@ -1150,11 +1128,7 @@ describe('ga_map_service', function() {
           expect(source.getProjection().getCode()).to.be('EPSG:21781');
           expect(source.getRequestEncoding()).to.be('REST');
           expect(source.getUrls().length).to.be(5);
-          if (gaLayers.useToD('serverLayerName', '21781')) {
-            expect(source.getUrls()[0]).to.be('http://tod100.bgdi.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
-          } else {
-            expect(source.getUrls()[0]).to.be('//wmts5.geo.admin.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
-          }
+          expect(source.getUrls()[0]).to.be('//wmts5.geo.admin.ch/1.0.0/serverLayerName/default/{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.jpeg');
           expect(source.getTileLoadFunction()).to.be.a(Function);
           var tileGrid = source.getTileGrid();
           expect(tileGrid instanceof ol.tilegrid.WMTS).to.be.ok();


### PR DESCRIPTION
Now that Tiles On Demand is integrated behind VIP addresses, we can simplify the wmts URL managemend on application level. Reverts will happen on Varnish Level.

Also, for 3D go live, we need the tlm3d backgrounds from Tiles On Demand.

So we still have 2 exceptions handled by application code:
a) 3D backgrounds to use Tiles On Demand technical addresses
b) swissimage-product in 4326 to use 'wrong' tiling scheme path.

a) can be removed after the go-live of 3, but first a change on varnish level needs to be done
b) can be removed once Automata is fully working with Tiles On Demand

The smoke will clear once we have both ToD and LV95 live.

[TestLink](https://mf-geoadmin3.int.bgdi.ch/gjn_wmtsurls/index.html?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.swissnames3d&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&lon=7.44068&lat=46.92381&elevation=1626&heading=15.404&pitch=-23.547)