### PR TITLE
Param `alti_url`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ TECH_SUFFIX = .bgdi.ch
 API_URL ?= //api3.geo.admin.ch
 API_TECH_URL ?= //mf-chsdi3.
 LAST_API_URL := $(call lastvalue,api-url)
+ALTI_URL ?= //api3.geo.admin.ch
+LAST_ALTI_URL := $(call lastvalue,alti-url) 
+ALTI_TECH_URL ?= //mf-chsdi3.
 MAPPROXY_URL ?= //wmts{s}.geo.admin.ch
 MAPPROXY_TECH_URL ?= //wmts{s}.
 LAST_MAPPROXY_URL := $(call lastvalue,mapproxy-url)
@@ -165,6 +168,7 @@ help:
 	@echo "Variables:"
 	@echo
 	@echo "- API_URL Service URL         (build with: $(LAST_API_URL), current value: $(API_URL))"
+	@echo "- ALTI_URL Alti service URL   (build with: $(LAST_ALTI_URL), current value: $(ALTI_URL))"
 	@echo "- PRINT_URL Print service URL (build with: $(LAST_PRINT_URL), current value: $(PRINT_URL))"
 	@echo "- MAPPROXY_URL Service URL    (build with: $(LAST_MAPPROXY_URL), current value: $(MAPPROXY_URL))"
 	@echo "- VECTORTILES_URL Service URL (build with: $(LAST_VECTORTILES_URL), current value: $(VECTORTILES_URL))"
@@ -514,6 +518,8 @@ define buildpage
 		--var "tech_suffix=$(TECH_SUFFIX)" \
 		--var "api_url=$(API_URL)" \
 		--var "api_tech_url=$(API_TECH_URL)" \
+		--var "alti_url=$(ALTI_URL)" \
+		--var "alti_tech_url=$(ALTI_TECH_URL)" \
 		--var "print_url=$(PRINT_URL)" \
 		--var "print_tech_url=$(PRINT_TECH_URL)" \
 		--var "proxy_url=$(PROXY_URL)" \
@@ -568,6 +574,7 @@ endef
 prd/index.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-alti-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-vectortiles-url \
 	    .build-artefacts/last-shop-url \
@@ -585,6 +592,7 @@ prd/index.html: src/index.mako.html \
 prd/mobile.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-alti-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-vectortiles-url \
 	    .build-artefacts/last-shop-url \
@@ -602,6 +610,7 @@ prd/mobile.html: src/index.mako.html \
 prd/embed.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-alti-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-shop-url \
 	    .build-artefacts/last-wms-url \
@@ -650,6 +659,7 @@ src/style/app.css: $(SRC_LESS_FILES)
 src/index.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-alti-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-vectortiles-url \
 	    .build-artefacts/last-shop-url \
@@ -663,6 +673,7 @@ src/index.html: src/index.mako.html \
 src/mobile.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-alti-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-vectortiles-url \
 	    .build-artefacts/last-shop-url \
@@ -677,6 +688,7 @@ src/mobile.html: src/index.mako.html \
 src/embed.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    .build-artefacts/last-api-url \
+	    .build-artefacts/last-alti-url \
 	    .build-artefacts/last-mapproxy-url \
 	    .build-artefacts/last-vectortiles-url \
 	    .build-artefacts/last-shop-url \
@@ -809,6 +821,9 @@ ${PYTHON_VENV}:
 
 .build-artefacts/last-api-url::
 	$(call cachelastvariable,$@,$(API_URL),$(LAST_API_URL),api-url)
+
+.build-artefacts/last-alti-url::
+	$(call cachelastvariable,$@,$(ALTI_URL),$(LAST_ALTI_URL),alti-url)
 
 .build-artefacts/last-mapproxy-url::
 	$(call cachelastvariable,$@,$(MAPPROXY_URL),$(LAST_MAPPROXY_URL),mapproxy-url)

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Add `env=(dev|int|prod)`
 
 Add `api_url=//theNameOfAnAPIServer`
 
+Add `alti_url=//theNameOfAnAltiServer`
+
 Add `wms_url=//theNameOfAWMSServer`
 
 Add `print_url=//theNameOfAPrintServer`

--- a/rc_ci
+++ b/rc_ci
@@ -2,6 +2,7 @@ source rc_dev
 export KEEP_VERSION=false
 export DEPLOY_TARGET=ci
 export API_URL=//mf-chsdi3.ci.bgdi.ch
+export ALTI_URL=//mf-chsdi3.ci.bgdi.ch
 export APACHE_BASE_PATH=
 export VARNISH_HOSTS=(ip-10-220-4-250.eu-west-1.compute.internal)
 export E2E_TARGETURL=https://mf-geoadmin3.ci.bgdi.ch

--- a/rc_dev
+++ b/rc_dev
@@ -3,6 +3,7 @@ export DEPLOY_TARGET=dev
 export APACHE_BASE_PATH=
 export E2E_TARGETURL=https://mf-geoadmin3.dev.bgdi.ch
 export API_URL=//mf-chsdi3.dev.bgdi.ch
+export ALTI_URL=//mf-chsdi3.dev.bgdi.ch
 export MAPPROXY_URL=//wmts{s}.dev.bgdi.ch
 export VECTORTILES_URL=//vectortiles{s}.dev.bgdi.ch
 export WMS_URL=//wms-bgdi.dev.bgdi.ch

--- a/rc_int
+++ b/rc_int
@@ -4,6 +4,7 @@ export E2E_TARGETURL=https://mf-geoadmin3.int.bgdi.ch
 export APACHE_BASE_PATH=
 export VARNISH_HOSTS=(ip-10-220-6-81.eu-west-1.compute.internal ip-10-220-4-223.eu-west-1.compute.internal)
 export API_URL=//mf-chsdi3.int.bgdi.ch
+export ALTI_URL=//mf-chsdi3.int.bgdi.ch
 export MAPPROXY_URL=//wmts{s}.int.bgdi.ch
 export VECTORTILES_URL=//vectortiles{s}.int.bgdi.ch
 export WMS_URL=//wms-bgdi.int.bgdi.ch

--- a/rc_prod
+++ b/rc_prod
@@ -4,6 +4,7 @@ export APACHE_BASE_PATH=
 export E2E_TARGETURL=https://map.geo.admin.ch
 export VARNISH_HOSTS=(ip-10-220-5-71.eu-west-1.compute.internal ip-10-220-6-245.eu-west-1.compute.internal)
 export API_URL=//api3.geo.admin.ch
+export ALTI_URL=//api3.geo.admin.ch
 export MAPPROXY_URL=//wmts{s}.geo.admin.ch
 export VECTORTILES_URL=//vectortiles{s}.geo.admin.ch
 export WMS_URL=//wms.geo.admin.ch

--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -1239,7 +1239,7 @@ goog.require('ga_urlutils_service');
             center = ol.extent.getCenter(extent);
           }
 
-          return $http.get(gaGlobalOptions.apiUrl + '/rest/services/height', {
+          return $http.get(gaGlobalOptions.altiUrl + '/rest/services/height', {
             params: {
               easting: center[0],
               northing: center[1]

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -747,6 +747,7 @@ itemscope itemtype="http://schema.org/WebApplication"
 
         var defaultApiUrl = prtl + '${api_url}';
         var apiUrl = setBackend(defaultApiUrl, prtl + '${api_tech_url}', 'api_url');
+        var altiUrl = setBackend(prtl + '${alti_url}', prtl + '${alti_tech_url}', 'alti_url');
         var mapproxyUrl = setBackend(prtl + '${mapproxy_url}', prtl + '${mapproxy_tech_url}', 'mapproxy_url');
         var vectorTilesUrl = setBackend(prtl + '${vectortiles_url}', prtl + '${vectortiles_tech_url}', 'vectortiles_url');
         var wmsUrl = setBackend(prtl + '${wms_url}',  prtl + '${wms_tech_url}', 'wms_url');
@@ -765,6 +766,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           pegman: !!window.location.search.match(/(pegman=true)/),
           mapUrl: location.origin + pathname,
           apiUrl: apiUrl,
+          altiUrl: altiUrl,
           printUrl: printUrl,
           proxyUrl: proxyUrl,
           mapproxyUrl: mapproxyUrl,
@@ -774,6 +776,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           publicUrlRegexp: new RegExp('${public_url_regexp}'),
           adminUrlRegexp: adminUrlRegexp,
           cachedApiUrl: apiUrl + cacheAdd,
+          cachedAltiUrl: altiUrl + cacheAdd,
           wmtsUrl: wmtsUrl,
           cachedPrintUrl: printUrl + cacheAdd,
           resourceUrl: location.origin + s3pathname + '${versionslashed}',

--- a/src/js/ContextPopupController.js
+++ b/src/js/ContextPopupController.js
@@ -7,7 +7,7 @@ goog.provide('ga_contextpopup_controller');
   module.controller('GaContextPopupController', function($scope,
       gaGlobalOptions) {
     $scope.options = {
-      heightUrl: gaGlobalOptions.apiUrl + '/rest/services/height',
+      heightUrl: gaGlobalOptions.altiUrl + '/rest/services/height',
       qrcodeUrl: gaGlobalOptions.apiUrl + '/qrcodegenerator'
     };
   });

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -198,7 +198,7 @@ goog.require('ga_waitcursor_service');
   module.config(function(gaProfileProvider, gaGlobalOptions) {
     gaProfileProvider.d3libUrl = gaGlobalOptions.resourceUrl +
         'lib/d3.min.js';
-    gaProfileProvider.profileUrl = gaGlobalOptions.apiUrl +
+    gaProfileProvider.profileUrl = gaGlobalOptions.altiUrl +
         '/rest/services/profile.json';
   });
 

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -8,6 +8,7 @@ beforeEach(function() {
     var version = '123456';
     var versionSlashed = version + '/';
     var apiUrl = '//api3.geo.admin.ch';
+    var altiUrl = '//api3.geo.admin.ch';
     var publicUrl = '//public.geo.admin.ch';
     var printUrl = '//print.geo.admin.ch';
     var proxyUrl = '//proxy.geo.admin.ch';
@@ -26,6 +27,7 @@ beforeEach(function() {
       pegman: false,
       mapUrl: location.origin + apacheBasePath,
       apiUrl: location.protocol + apiUrl,
+      altiUrl: location.protocol + altiUrl,
       printUrl: location.protocol + printUrl,
       mapproxyUrl: location.protocol + mapproxyUrl,
       shopUrl: location.protocol + shopUrl,
@@ -110,7 +112,7 @@ beforeEach(function() {
     gaProfileProvider.d3libUrl =
         gaGlobalOptions.resourceUrl + 'lib/d3.min.js';
     gaProfileProvider.profileUrl =
-        gaGlobalOptions.apiUrl + '/rest/services/profile.json';
+        gaGlobalOptions.altiUrl + '/rest/services/profile.json';
   });
 
   module(function(gaUrlUtilsProvider, gaGlobalOptions) {


### PR DESCRIPTION
[Test link service-alti ready for LV95](https://mf-geoadmin3.int.bgdi.ch/mom_alti_url/index.html?alti_url=//service-alti.int.bgdi.ch/ltrea_lv95) (using //service-alti.int.bgdi.ch/ltrea_lv95). This service is smart enough to detect the SRS automagically.

[Test link current](https://mf-geoadmin3.int.bgdi.ch/mom_alti_url/index.html?alti_url=//service-alti.int.bgdi.ch) (using //service-alti.int.bgdi.ch)

* param `alti_url` for LV95 testing
* ready for using `alti.geo.admin.ch`and `service-alti.`addresses