### PR TITLE
Use official wmts also for 3D background

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -395,14 +395,6 @@ goog.require('ga_urlutils_service');
           return urls;
         };
 
-        var getWmtsUrl = function(wmtsUrl, layer) {
-          if (layer === 'ch.swisstopo.swisstlm3d-karte-farbe.3d' ||
-              layer === 'ch.swisstopo.swisstlm3d-karte-grau.3d') {
-            return '//tod{s}.prod.bgdi.ch';
-          }
-          return wmtsUrl;
-        };
-
         var useLV03Template = function(layer, tileMatrixSet) {
           if (tileMatrixSet === '21781') {
             return true;
@@ -420,9 +412,9 @@ goog.require('ga_urlutils_service');
         var getWmtsGetTileTpl = function(layer, time, tileMatrixSet, format) {
           var tpl;
           if (useLV03Template(layer, tileMatrixSet)) {
-            tpl = getWmtsUrl(wmtsUrl, layer) + wmtsLV03PathTemplate;
+            tpl = wmtsUrl + wmtsLV03PathTemplate;
           } else {
-            tpl = getWmtsUrl(wmtsUrl, layer) + wmtsPathTemplate;
+            tpl = wmtsUrl + wmtsPathTemplate;
           }
           var url = tpl.replace('{Layer}', layer).replace('{Format}', format);
           if (time) {


### PR DESCRIPTION
Now that varnish is switched to use the 3D background (current) from ToD, we can remove the exception in the code.

The only remaing exception is swissimage-product in 3D. Varnish still points to traditional wmts bucket, pre-caclulated with AUTOMATA.

Note: when switching swissimage-prodcut, we also need to switch row/col....this will also happen in 3 steps: 1) adapt applicatoin to use tod addresses 2) switch on varnish level 3) switch back 1)