### PR TITLE
Remove exception of swissimage-product

### DIFF
--- a/src/components/map/MapService.js
+++ b/src/components/map/MapService.js
@@ -400,26 +400,17 @@ goog.require('ga_urlutils_service');
           return urls;
         };
 
-        var useLV03Template = function(layer, tileMatrixSet) {
-          if (tileMatrixSet === '21781') {
-            return true;
-          }
-          // 3D swissimage-product and background layers were pre-generated with
-          // LV03 scheme (row/col), which is wrong. With ToD, we will use the
-          // correct scheme (col/row)
-          if (layer === 'ch.swisstopo.swissimage-product' &&
-              tileMatrixSet === '4326') {
-            return true;
-          }
-          return false;
-        };
-
         var getWmtsGetTileTpl = function(layer, time, tileMatrixSet, format) {
           var tpl;
-          if (useLV03Template(layer, tileMatrixSet)) {
+          if (tileMatrixSet === '21781') {
             tpl = wmtsUrl + wmtsLV03PathTemplate;
           } else {
-            tpl = wmtsUrl + wmtsPathTemplate;
+            if (tileMatrixSet === '4326' &&
+                  layer === 'ch.swisstopo.swissimage-product') {
+              tpl = '//tod{s}.prod.bgdi.ch' + wmtsPathTemplate;
+            } else {
+              tpl = wmtsUrl + wmtsPathTemplate;
+            }
           }
           var url = tpl.replace('{Layer}', layer).replace('{Format}', format);
           if (time) {

--- a/test/saucelabs/search_test.py
+++ b/test/saucelabs/search_test.py
@@ -149,7 +149,7 @@ searchLocationTests = [
     {
         'searchText': u'p Mesolcina Bellinzona',
         'resultTitle': u'Bus Bellinzona, Piazza Mesolcina',
-        'resultLocation': u'E=2722500.46&N=1117499.12&zoom=13'
+        'resultLocation': u'E=2722500.45&N=1117499.12&zoom=13'
     },
     {
         'searchText': u'bruckenmoostrasse 11 raron',


### PR DESCRIPTION
Show the good image in 3d for swissimage-product layer:

[Before](https://map.geo.admin.ch/index.html?lang=fr&topic=ech&bgLayer=voidLayer&layers=ch.swisstopo.swissimage-product,ch.swisstopo.swissnames3d&lon=7.45102&lat=46.94809&elevation=1169&heading=2.874&pitch=-89.991&layers_visibility=true,false)
[After](https://mf-geoadmin3.int.bgdi.ch/teo_fix_3/index.html?lang=fr&topic=ech&bgLayer=voidLayer&layers=ch.swisstopo.swissimage-product,ch.swisstopo.swissnames3d&lon=7.45027&lat=46.94777&elevation=1061&heading=357.966&pitch=-84.968)
