### PR TITLE
Add simple print wmts protocol LV95

### DIFF
--- a/src/components/print/PrintLayerService.js
+++ b/src/components/print/PrintLayerService.js
@@ -404,6 +404,7 @@ goog.require('ga_urlutils_service');
       var requestEncoding = source.getRequestEncoding() || 'REST';
       // Not all layers have projection assigned
       var dfltTileMatrixSet = gaGlobalOptions.defaultEpsg.split(':')[1];
+      var isExternalWmts = angular.equals(config, {});
 
       // resourceURL for RESTful, service endpoint for KVP
       var url = source.getUrls()[0];
@@ -425,8 +426,6 @@ goog.require('ga_urlutils_service');
       angular.extend(enc, {
         type: 'WMTS',
         layer: source.getLayer(),
-        baseURL: baseUrl,
-        matrixIds: matrices,
         version: source.getVersion() || '1.0.0',
         requestEncoding: requestEncoding,
         formatSuffix: source.getFormat().replace('image/', ''),
@@ -435,6 +434,23 @@ goog.require('ga_urlutils_service');
         params: wmtsDimensions,
         matrixSet: source.getMatrixSet() || dfltTileMatrixSet
       });
+      if (!isExternalWmts) {
+        angular.extend(enc, {
+          baseURL: baseUrl.slice(0, baseUrl.indexOf('/1.0.0')),
+          zoomOffset: tileGrid.getMinZoom(),
+          tileOrigin: tileGrid.getOrigin(),
+          tileSize: [tileGrid.getTileSize(), tileGrid.getTileSize()],
+          resolutions: tileGrid.getResolutions(),
+          maxExtent: extent
+        });
+      } else {
+        // use the full monty WMTS definition fo external source   
+        angular.extend(enc, {
+          layer: source.getLayer(),
+          baseURL: baseUrl,
+          matrixIds: matrices
+        });
+      }
 
       var multiPagesPrint = false;
       if (config.timestamps) {


### PR DESCRIPTION
Using again the simplified WMTS protocol updated for correct col/row order (changes in mapfish-print)

See [Demo](https://mf-geoadmin3.int.bgdi.ch/mom_print_dpi/index.html?print_url=//service-print.dev.bgdi.ch)

Fixes https://github.com/geoadmin/mf-geoadmin3/issues/4029

:bomb: Use only with this this release (or a subsequent one) https://github.com/geoadmin/service-print/releases/tag/r_171108 from branch https://github.com/geoadmin/mapfish-print/tree/2.1.x_geoadmin3 branch
