### PR TITLE
Set wmts time dimension to empty when time property is undefined

### DIFF
--- a/src/components/map/DefinePropertiesForLayerService.js
+++ b/src/components/map/DefinePropertiesForLayerService.js
@@ -142,7 +142,7 @@ goog.provide('ga_definepropertiesforlayer_service');
               if (this instanceof ol.layer.Layer) {
                 var src = this.getSource();
                 if (src instanceof ol.source.WMTS) {
-                  src.updateDimensions({'Time': val});
+                  src.updateDimensions({'Time': val || ''});
                 } else if (src instanceof ol.source.ImageWMS ||
                     src instanceof ol.source.TileWMS) {
                   if (angular.isDefined(val)) {

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -503,7 +503,7 @@ goog.require('ga_urlutils_service');
                   replace('{y}', '{TileRow}');
               olSource = config.olSource = new ol.source.WMTS({
                 dimensions: {
-                  'Time': timestamp
+                  'Time': timestamp || ''
                 },
                 // Workaround: Set a cache size of zero when layer is
                 // timeEnabled see:

--- a/test/specs/BrowserSnifferService.spec.js
+++ b/test/specs/BrowserSnifferService.spec.js
@@ -99,7 +99,7 @@ describe('ga_browsersniffer_service', function() {
     var pages = ['index', 'mobile', 'embed'];
     pages.forEach(function(type, idx) {
       it('detects it\'s not the ' + props[idx] + ' page', function() {
-        [ 
+        [
           'http://geoadmin.ch/' + type,
           'http://geoadmin.ch/' + type + '/src/'
         ].forEach(function(page) {
@@ -111,8 +111,8 @@ describe('ga_browsersniffer_service', function() {
         });
       });
 
-      it('detects it\'s the ' + props[idx]  + ' page', function() {
-        [ 
+      it('detects it\'s the ' + props[idx] + ' page', function() {
+        [
           'http://geoadmin.ch/' + type + '/src/' + type + '.html',
           'http://geoadmin.ch/' + type + '/' + type + '.html',
           'http://geoadmin.ch/' + type + '.html'

--- a/test/specs/map/DefinePropertiesForLayerService.spec.js
+++ b/test/specs/map/DefinePropertiesForLayerService.spec.js
@@ -233,6 +233,27 @@ describe('ga_definepropertiesforlayer_service', function() {
       expect(layer.get(prop)).to.be(undefined);
     });
 
+    it('set WMTS.dimesion.Time to empty when time is undefined', function() {
+      var prop = 'time';
+
+      // WMTS
+      var layer = new ol.layer.Tile({
+        source: new ol.source.WMTS({})
+      });
+      gaDefine(layer);
+      expect(layer.get(prop)).to.be(undefined);
+      expect(layer[prop]).to.be(undefined);
+      layer[prop] = 'test';
+      expect(layer.get(prop)).to.be('test');
+      expect(layer.getSource().getDimensions().Time).to.be('test');
+
+      var spy = sinon.spy(layer.getSource(), 'updateDimensions');
+      layer[prop] = undefined;
+      expect(spy.callCount).to.be(1);
+      expect(spy.args[0][0].Time).to.be('');
+      expect(layer.get(prop)).to.be();
+    });
+
     it('verifies getCesiumXXX property', function() {
       var props = [
         'getCesiumDataSource',

--- a/test/specs/map/Layers.spec.js
+++ b/test/specs/map/Layers.spec.js
@@ -681,6 +681,14 @@ describe('ga_layers_service', function() {
           expectCommonProperties(layer, 'wmts');
         });
 
+        it('returns a WMTS layer when time is undefined', function() {
+          sinon.stub(gaTime, 'get').returns('1934');
+          var layer = gaLayers.getOlLayerById('wmts');
+          var source = layer.getSource();
+          expect(source instanceof ol.source.WMTS).to.be.ok();
+          expect(source.getDimensions().Time).to.be('');
+        });
+
         it('returns a WMS layer', function() {
           var layer = gaLayers.getOlLayerById('wms');
           expect(layer instanceof ol.layer.Image).to.be.ok();


### PR DESCRIPTION
Fix a regression.

[On prod](https://map.geo.admin.ch/index.html?lang=fr&topic=luftbilder&bgLayer=voidLayer&layers_timestamp=19851231,&layers=ch.swisstopo.lubis-luftbilder_farbe,ch.swisstopo.lubis-luftbilder-dritte-firmen&catalogNodes=1179,1180,1186&E=2577355.44&N=1240003.62&zoom=0&time=1985)
[With this PR](https://mf-geoadmin3.int.bgdi.ch/teo_time/index.html?lang=fr&topic=luftbilder&bgLayer=voidLayer&layers_timestamp=19851231,&layers=ch.swisstopo.lubis-luftbilder_farbe,ch.swisstopo.lubis-luftbilder-dritte-firmen&catalogNodes=1179,1180,1186&E=2577355.44&N=1240003.62&zoom=0&time=1985)