### PR TITLE
DataOwner and 3rdPartyDataowner are in separate blocks

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -355,16 +355,8 @@ goog.require('ga_urlutils_service');
             }
 
             // Build the correct copyright text to display
-            var dataOwner = attributions.join();
-            var thirdPartyDataOwner = thirdPartyAttributions.join();
-            if (dataOwner && thirdPartyDataOwner) {
-              dataOwner = '© ' + dataOwner + ',';
-            } else if (!dataOwner && thirdPartyDataOwner) {
-              thirdPartyDataOwner = '© ' + thirdPartyDataOwner;
-            } else if (dataOwner && !thirdPartyDataOwner) {
-              dataOwner = '© ' + dataOwner;
-              thirdPartyDataOwner = false;
-            }
+            var allDataOwner = attributions.concat(thirdPartyAttributions);
+            allDataOwner = '©' + allDataOwner.join();
             var movieprint = $scope.options.movie && $scope.options.multiprint;
             var spec = {
               layout: $scope.layout.name,
@@ -387,8 +379,8 @@ goog.require('ga_urlutils_service');
                   display: [$scope.layout.map.width, $scope.layout.map.height],
                   // scale has to be one of the advertise by the print server
                   scale: $scope.scale.value,
-                  dataOwner: dataOwner,
-                  thirdPartyDataOwner: thirdPartyDataOwner,
+                  dataOwner: allDataOwner,
+                  thirdPartyDataOwner: false,
                   shortLink: shortLink || '',
                   rotation: -((view.getRotation() * 180.0) / Math.PI)
                 }, defaultPage)

--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -380,7 +380,6 @@ goog.require('ga_urlutils_service');
                   // scale has to be one of the advertise by the print server
                   scale: $scope.scale.value,
                   dataOwner: allDataOwner,
-                  thirdPartyDataOwner: false,
                   shortLink: shortLink || '',
                   rotation: -((view.getRotation() * 180.0) / Math.PI)
                 }, defaultPage)

--- a/test/specs/map/WmsService.spec.js
+++ b/test/specs/map/WmsService.spec.js
@@ -2,7 +2,7 @@
 describe('ga_wms_service', function() {
 
   describe('gaWms', function() {
-    var gaWms, map, gaGlobalOptions, $rootScope;
+    var gaWms, map, gaGlobalOptions, $rootScope, gaLang;
 
     var getExternalWmsLayer = function(params) {
       var layer = new ol.layer.Image({
@@ -98,6 +98,7 @@ describe('ga_wms_service', function() {
       inject(function($injector) {
         gaWms = $injector.get('gaWms');
         gaGlobalOptions = $injector.get('gaGlobalOptions');
+        gaLang = $injector.get('gaLang');
         $rootScope = $injector.get('$rootScope');
       });
       map = new ol.Map({});
@@ -238,12 +239,13 @@ describe('ga_wms_service', function() {
 
     describe('#getLegend()', function() {
       it('tests with default values', function(done) {
+
         var wmsLayer = getExternalWmsLayer({
           LAYERS: 'somelayer'
         });
         var expectedHtml = '<img alt="No legend available" src="http://foo.ch/wms?' +
             'request=GetLegendGraphic&layer=somelayer&style=default&service=WMS&' +
-            'version=1.3.0&format=image%2Fpng&sld_version=1.1.0&lang=en"></img>';
+            'version=1.3.0&format=image%2Fpng&sld_version=1.1.0&lang=' + gaLang.get() + '"></img>';
         gaWms.getLegend(wmsLayer).then(function(resp) {
           var html = resp.data;
           expect(html).to.be(expectedHtml);
@@ -260,7 +262,7 @@ describe('ga_wms_service', function() {
         });
         var expectedHtml = '<img alt="No legend available" src="http://foo.ch/wms?' +
             'request=GetLegendGraphic&layer=somelayer&style=default&service=WMS&' +
-            'version=1.1.1&format=image%2Fpng&sld_version=1.1.0&lang=en"></img>';
+            'version=1.1.1&format=image%2Fpng&sld_version=1.1.0&lang=' + gaLang.get() + '"></img>';
         gaWms.getLegend(wmsLayer).then(function(resp) {
           var html = resp.data;
           expect(html).to.be(expectedHtml);


### PR DESCRIPTION
[Demo](https://mf-chsdi3.int.bgdi.ch/shorten/772fb6aa4b)

Refs: https://github.com/geoadmin/mf-geoadmin3/issues/4032

Should be deployed alongs with: https://github.com/geoadmin/service-print/pull/61 (no break, but ugly comma at end of strings)