### PR TITLE
 Add templating support for json style

### DIFF
--- a/JSONSTYLES.md
+++ b/JSONSTYLES.md
@@ -71,6 +71,11 @@ For `point` geomType the radius (given in pixels) determines the size of the sym
 * fill: same options as defined in [ol.style.Fill](http://openlayers.org/en/latest/apidoc/ol.style.Fill.html).
 * label->text: same options as defined in [ol.style.Text](http://openlayers.org/en/latest/apidoc/ol.style.Text.html)
 
+For `label` 2 options are available.
+
+* `property` displays a property value found in a GeoJSON feature properties.
+* `template` displays a combination of multiple properties and/or static text. Properties are referenced with `${}`. (for instance `${firstname} ${lastname}`)
+
 Type unique
 -----------
 

--- a/src/components/StylesFromLiteralsService.js
+++ b/src/components/StylesFromLiteralsService.js
@@ -229,7 +229,7 @@ goog.provide('ga_stylesfromliterals_service');
       };
 
       OlStyleForPropertyValue.prototype.setOlText_ = function(olStyle,
-        labelProperty, labelTemplate, properties) {
+          labelProperty, labelTemplate, properties) {
         var text;
         properties = properties || [];
         if (labelProperty) {

--- a/src/components/StylesFromLiteralsService.js
+++ b/src/components/StylesFromLiteralsService.js
@@ -230,7 +230,7 @@ goog.provide('ga_stylesfromliterals_service');
 
       OlStyleForPropertyValue.prototype.setOlText_ = function(olStyle,
         labelProperty, labelTemplate, properties) {
-        var text, prop;
+        var text;
         properties = properties || [];
         if (labelProperty) {
           text = properties[labelProperty];
@@ -239,12 +239,11 @@ goog.provide('ga_stylesfromliterals_service');
           }
         } else if (labelTemplate) {
           text = labelTemplate;
-          for (var k in properties) {
-            prop = properties[k];
+          angular.forEach(properties, function(prop, k) {
             if (prop !== undefined && prop !== null) {
               text = text.replace('${' + k + '}', prop.toString());
             }
-          }
+          });
         }
         if (text) {
           olStyle.getText().setText(text);

--- a/src/components/StylesFromLiteralsService.js
+++ b/src/components/StylesFromLiteralsService.js
@@ -231,12 +231,13 @@ goog.provide('ga_stylesfromliterals_service');
       OlStyleForPropertyValue.prototype.setOlText_ = function(olStyle,
         labelProperty, labelTemplate, properties) {
         var text, prop;
-        if (properties && labelProperty) {
+        properties = properties || [];
+        if (labelProperty) {
           text = properties[labelProperty];
           if (text !== undefined && text !== null) {
             text = text.toString();
           }
-        } else if (properties && labelTemplate) {
+        } else if (labelTemplate) {
           text = labelTemplate;
           for (var k in properties) {
             prop = properties[k];
@@ -245,7 +246,7 @@ goog.provide('ga_stylesfromliterals_service');
             }
           }
         }
-        if (text && text != labelTemplate) {
+        if (text) {
           olStyle.getText().setText(text);
         }
         return olStyle;
@@ -259,9 +260,9 @@ goog.provide('ga_stylesfromliterals_service');
         value = value !== undefined ? value : this.defaultVal;
         geomType = getGeomTypeFromGeometry(feature.getGeometry());
 
-        if (this.type == 'unique') {
+        if (this.type === 'unique') {
           olStyles = this.styles[geomType][value];
-        } else if (this.type == 'range') {
+        } else if (this.type === 'range') {
           olStyles = this.findOlStyleInRange_(value, geomType);
         }
 

--- a/src/components/StylesFromLiteralsService.js
+++ b/src/components/StylesFromLiteralsService.js
@@ -241,7 +241,7 @@ goog.provide('ga_stylesfromliterals_service');
           text = labelTemplate;
           angular.forEach(properties, function(prop, k) {
             if (prop !== undefined && prop !== null) {
-              text = text.replace('${' + k + '}', prop.toString());
+              text = text.replace('${' + k + '}', prop);
             }
           });
         }

--- a/src/components/print/PrintLayerService.js
+++ b/src/components/print/PrintLayerService.js
@@ -490,7 +490,7 @@ goog.require('ga_urlutils_service');
     var regexMapservWMS = new RegExp(mapservWMS, 'gi');
     var match = regexMapservWMS.test(url);
     if (match) {
-        customParams['MAP_RESOLUTION'] = dpi;
+      customParams['MAP_RESOLUTION'] = dpi;
     }
 
     params.VERSION = params.VERSION || '1.3.0';

--- a/test/saucelabs/search_test.py
+++ b/test/saucelabs/search_test.py
@@ -144,12 +144,12 @@ searchLocationTests = [
     {
         'searchText': u'Kanalstrasse bus rar',
         'resultTitle': u'Bus Raron, Kanalstrasse',
-        'resultLocation': u'E=2627442.63&N=1128140.86&zoom=13'
+        'resultLocation': u'E=2627443.00&N=1128141.00&zoom=13'
     },
     {
         'searchText': u'p Mesolcina Bellinzona',
         'resultTitle': u'Bus Bellinzona, Piazza Mesolcina',
-        'resultLocation': u'E=2722500.45&N=1117499.12&zoom=13'
+        'resultLocation': u'E=2722500.00&N=1117499.00&zoom=13'
     },
     {
         'searchText': u'bruckenmoostrasse 11 raron',

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -349,7 +349,7 @@ describe('ga_stylesfromliterals_service', function() {
           '}}'
       );
       var gaStyle = gaStylesFromLiterals(uniqueTypeStyle);
-      var olStyle = gaStyle.getFeatureStyle(olFeature);
+      var olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       var olImage = olStyle.getImage();
       var olText = olStyle.getText();
       expect(olStyle).to.be.an(ol.style.Style);
@@ -377,7 +377,7 @@ describe('ga_stylesfromliterals_service', function() {
             '"oraison": "mylady"' +
           '}}'
       );
-      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       olImage = olStyle.getImage();
       olText = olStyle.getText();
       expect(olStyle).to.be.an(ol.style.Style);
@@ -446,7 +446,7 @@ describe('ga_stylesfromliterals_service', function() {
             '"foo": "bar"' +
           '}}'
       );
-      var olStyle = gaStyle.getFeatureStyle(olFeature);
+      var olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       var olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.be.an(ol.style.Image);
       expect(olImage.getFill()).to.be.an(ol.style.Fill);
@@ -468,7 +468,7 @@ describe('ga_stylesfromliterals_service', function() {
             '"foo": "toto"' +
           '}}'
       );
-      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.be.an(ol.style.Image);
       expect(olImage.getFill()).to.be.an(ol.style.Fill);
@@ -696,7 +696,7 @@ describe('ga_stylesfromliterals_service', function() {
             '"foo": 3' +
           '}}'
       );
-      var olStyle = gaStyle.getFeatureStyle(olFeature);
+      var olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       var olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.be.an(ol.style.Image);
       expect(olImage.getFill()).to.be.an(ol.style.Fill);
@@ -718,7 +718,7 @@ describe('ga_stylesfromliterals_service', function() {
             '"foo": 11' +
           '}}'
       );
-      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.be.an(ol.style.Image);
       expect(olImage.getFill()).to.be.an(ol.style.Fill);
@@ -740,7 +740,7 @@ describe('ga_stylesfromliterals_service', function() {
             '"foo": 10' +
           '}}'
       );
-      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.be.an(ol.style.Image);
       expect(olImage.getFill()).to.be.an(ol.style.Fill);
@@ -763,7 +763,7 @@ describe('ga_stylesfromliterals_service', function() {
           '}}'
       );
       var stub = sinon.stub($window, 'alert');
-      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.equal(null);
       expect(stub.calledWithExactly('Feature ID: undefined. No matching style found for key foo and value 1000.')).to.be(true);
@@ -892,7 +892,7 @@ describe('ga_stylesfromliterals_service', function() {
           '}}'
       );
       var stub = sinon.stub($window, 'alert');
-      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olStyle = gaStyle.getFeatureStyle(olFeature, 100);
       olImage = olStyle.getImage();
       expect(olStyle.getImage()).to.equal(null);
       expect(stub.calledWithExactly('Feature ID: undefined. No matching style found for key foo and value 1000.')).to.be(true);

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -925,6 +925,40 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olText.getFont()).to.equal('bold 1.35em FrutigerNeueW02-Regular, Times, sans-serif');
       expect(olText.getTextAlign()).to.equal('center');
       expect(olText.getTextBaseline()).to.equal('middle');
+      // Test with a 0
+      var olFeature = geoJsonFormat.readFeature(
+          '{"type": "Feature",' +
+          '"geometry": {' +
+            '"coordinates": [' +
+              '10000,' +
+              '20000' +
+            '],' +
+            '"type": "Point"' +
+          '},' +
+          '"properties": {' +
+            '"foo": 0,' +
+            '"name": "Joe",' +
+            '"country": "Baltimore"' +
+          '}}'
+      );
+      olStyle = gaStyle.getFeatureStyle(olFeature, 100);
+      olImage = olStyle.getImage();
+      olText = olStyle.getText();
+      expect(olStyle.getImage()).to.be.an(ol.style.Image);
+      expect(olImage.getFill()).to.be.an(ol.style.Fill);
+      expect(olImage.getFill().getColor()).to.equal('#FF1FF1');
+      expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
+      expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
+      expect(olImage.getStroke().getWidth()).to.equal(3);
+      expect(olText.getText()).to.equal('Joe is for 0 days in Baltimore');
+      expect(olText.getStroke()).to.an(ol.style.Stroke);
+      expect(olText.getStroke().getColor()).to.equal('#FFFFFF');
+      expect(olText.getStroke().getWidth()).to.equal(3);
+      expect(olText.getFill()).to.an(ol.style.Fill);
+      expect(olText.getFill().getColor()).to.equal('#FF1FF1');
+      expect(olText.getFont()).to.equal('bold 1.35em FrutigerNeueW02-Regular, Times, sans-serif');
+      expect(olText.getTextAlign()).to.equal('center');
+      expect(olText.getTextBaseline()).to.equal('middle');
     });
 
     it('supports range type style assignment resolution dependent', function() {

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -447,6 +447,39 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olText.getOffsetY()).to.equal(2);
       expect(olText.getTextAlign()).to.equal('center');
       expect(olText.getTextBaseline()).to.equal('middle');
+
+      olFeature = geoJsonFormat.readFeature(
+          '{"type": "Feature",' +
+          '"geometry": {' +
+            '"coordinates": [' +
+              '[10000,' +
+               '20000],' +
+              '[12000,' +
+               '21000]' +
+            '],' +
+            '"type": "LineString"' +
+          '},' +
+          '"properties": {' +
+            '"foo": "bar",' +
+            '"oraison": 0' +
+          '}}'
+      );
+      olStyle = gaStyle.getFeatureStyle(olFeature, 100);
+      olImage = olStyle.getImage();
+      olText = olStyle.getText();
+      expect(olStyle).to.be.an(ol.style.Style);
+      expect(olImage).not.to.be.an(ol.style.Image);
+      expect(olText).to.be.an(ol.style.Text);
+      expect(olStyle.getStroke()).to.be.an(ol.style.Stroke);
+      expect(olStyle.getStroke().getColor()).to.equal('#FFFFFF');
+      expect(olStyle.getStroke().getWidth()).to.equal(3);
+      expect(olText.getText()).to.equal('0');
+      expect(olText.getStroke()).to.an(ol.style.Stroke);
+      expect(olText.getScale()).to.equal(1.1);
+      expect(olText.getOffsetX()).to.equal(1);
+      expect(olText.getOffsetY()).to.equal(2);
+      expect(olText.getTextAlign()).to.equal('center');
+      expect(olText.getTextBaseline()).to.equal('middle');
     });
 
     it('supports simple unique type style assignment', function() {
@@ -925,8 +958,9 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olText.getFont()).to.equal('bold 1.35em FrutigerNeueW02-Regular, Times, sans-serif');
       expect(olText.getTextAlign()).to.equal('center');
       expect(olText.getTextBaseline()).to.equal('middle');
+
       // Test with a 0
-      var olFeature = geoJsonFormat.readFeature(
+      olFeature = geoJsonFormat.readFeature(
           '{"type": "Feature",' +
           '"geometry": {' +
             '"coordinates": [' +

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -188,6 +188,60 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olStyle.getStroke().getLineJoin()).to.equal('square');
     });
 
+    it('supports single type style assignment for a point and a static label', function() {
+      var singleTypeStyle = {
+        type: 'single',
+        geomType: 'point',
+        vectorOptions: {
+          type: 'circle',
+          radius: 8,
+          fill: {
+            color: '#FFFFFF'
+          },
+          stroke: {
+            color: '#FFFFFF',
+            width: 2
+          },
+          label: {
+            template: 'oh yes I am static',
+            text: {
+              textAlign: 'center',
+              textBaseline: 'middle',
+              font: 'bold 10px Helvetica',
+              stroke: {
+                color: 'rgba(22, 22, 22, 0.4)',
+                width: 4
+              },
+              fill: {
+                color: 'rgba(52, 52, 52, 0.3)'
+              }
+            }
+          }
+        }
+      };
+      var gaStyle = gaStylesFromLiterals(singleTypeStyle);
+      var olStyle = gaStyle.getFeatureStyle();
+      var olImage = olStyle.getImage();
+      var olText = olStyle.getText();
+      expect(olStyle).to.be.an(ol.style.Style);
+      expect(olImage).to.be.an(ol.style.Circle);
+      expect(olText).to.be.an(ol.style.Text);
+      expect(olImage.getFill()).to.be.an(ol.style.Fill);
+      expect(olImage.getFill().getColor()).to.equal('#FFFFFF');
+      expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
+      expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
+      expect(olImage.getStroke().getWidth()).to.equal(2);
+      expect(olImage.getRadius()).to.equal(8);
+      expect(olText.getText()).to.equal('oh yes I am static');
+      expect(olText.getTextAlign()).to.equal('center');
+      expect(olText.getTextBaseline()).to.equal('middle');
+      expect(olText.getStroke()).to.be.an(ol.style.Stroke);
+      expect(olText.getStroke().getColor()).to.equal('rgba(22, 22, 22, 0.4)');
+      expect(olText.getStroke().getWidth()).to.equal(4);
+      expect(olText.getFill()).to.be.an(ol.style.Fill);
+      expect(olText.getFill().getColor()).to.equal('rgba(52, 52, 52, 0.3)');
+    });
+
     it('supports single type style assignment for a polygon', function() {
       var singleTypeStyle = {
         type: 'single',

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -770,6 +770,109 @@ describe('ga_stylesfromliterals_service', function() {
       stub.restore();
     });
 
+    it('supports label templates', function() {
+      var rangeTypeStyle = {
+        type: 'range',
+        property: 'foo',
+        ranges: [
+          {
+            geomType: 'point',
+            range: [0, 10],
+            vectorOptions: {
+              type: 'circle',
+              radius: 8,
+              fill: {
+                color: '#FF1FF1'
+              },
+              stroke: {
+                color: '#FFFFFF',
+                width: 3
+              },
+              label: {
+                template: '${name} is for ${foo} days in ${country}',
+                text: {
+                  textAlign: 'center',
+                  textBaseline: 'middle',
+                  font: 'bold 1.35em FrutigerNeueW02-Regular, Times, sans-serif',
+                  stroke: {
+                    color: '#FFFFFF',
+                    width: 3
+                  },
+                  fill: {
+                    color: '#FF1FF1'
+                  }
+                }
+              }
+            }
+          }, {
+            geomType: 'point',
+            range: [10, 2000000],
+            vectorOptions: {
+              type: 'circle',
+              radius: 8,
+              fill: {
+                color: '#FF2222'
+              },
+              stroke: {
+                color: '#F55555',
+                width: 2
+              },
+              label: {
+                template: '${name} is for ${foo} days in ${country}',
+                text: {
+                  textAlign: 'center',
+                  textBaseline: 'middle',
+                  font: 'bold 1.35em FrutigerNeueW02-Regular, Times, sans-serif',
+                  stroke: {
+                    color: '#FF2222',
+                    width: 3
+                  },
+                  fill: {
+                    color: '#F55555'
+                  }
+                }
+              }
+            }
+          }
+        ]
+      };
+      var gaStyle = gaStylesFromLiterals(rangeTypeStyle);
+      var geoJsonFormat = new ol.format.GeoJSON();
+      var olFeature = geoJsonFormat.readFeature(
+          '{"type": "Feature",' +
+          '"geometry": {' +
+            '"coordinates": [' +
+              '10000,' +
+              '20000' +
+            '],' +
+            '"type": "Point"' +
+          '},' +
+          '"properties": {' +
+            '"foo": 15,' +
+            '"name": "Joe",' +
+            '"country": "Baltimore"' +
+          '}}'
+      );
+      var olStyle = gaStyle.getFeatureStyle(olFeature, 100);
+      var olImage = olStyle.getImage();
+      var olText = olStyle.getText();
+      expect(olStyle.getImage()).to.be.an(ol.style.Image);
+      expect(olImage.getFill()).to.be.an(ol.style.Fill);
+      expect(olImage.getFill().getColor()).to.equal('#FF2222');
+      expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
+      expect(olImage.getStroke().getColor()).to.equal('#F55555');
+      expect(olImage.getStroke().getWidth()).to.equal(2);
+      expect(olText.getText()).to.equal('Joe is for 15 days in Baltimore');
+      expect(olText.getStroke()).to.an(ol.style.Stroke);
+      expect(olText.getStroke().getColor()).to.equal('#FF2222');
+      expect(olText.getStroke().getWidth()).to.equal(3);
+      expect(olText.getFill()).to.an(ol.style.Fill);
+      expect(olText.getFill().getColor()).to.equal('#F55555');
+      expect(olText.getFont()).to.equal('bold 1.35em FrutigerNeueW02-Regular, Times, sans-serif');
+      expect(olText.getTextAlign()).to.equal('center');
+      expect(olText.getTextBaseline()).to.equal('middle');
+    });
+
     it('supports range type style assignment resolution dependent', function() {
       var rangeTypeStyle = {
         type: 'range',

--- a/test/specs/print/PrintLayerService.spec.js
+++ b/test/specs/print/PrintLayerService.spec.js
@@ -211,13 +211,13 @@ describe('ga_printlayer_service', function() {
           layers: [ 'ch.swisstopo.fixpunkte-agnes' ],
           styles: [ '' ],
           format: 'image/png',
-          customParams: 
+          customParams:
            { EXCEPTIONS: 'XML',
              TRANSPARENT: 'true',
              MAP_RESOLUTION: 150,
              VERSION: '1.3.0',
              CRS: 'EPSG:2056' },
-           singleTile: false 
+          singleTile: false
         });
       });
     });
@@ -263,7 +263,7 @@ describe('ga_printlayer_service', function() {
           layers: [ 'not-so-important' ],
           styles: [ '' ],
           format: 'image/png',
-          customParams: 
+          customParams:
            { EXCEPTIONS: 'XML',
              TRANSPARENT: 'true',
              VERSION: '1.1.1',


### PR DESCRIPTION
The templating support is needed for meteo data.

[Test Link](https://mf-chsdi3.dev.bgdi.ch/meteo_temp/shorten/7761f8d696)

I've heard there may be a problem with EDGE, I cannot test right now but keep that in mind before merging.

In the label section of the JSON style, you can now use:

```json
"label": {
  "template": "${firstprop} is better than ${secondprop}"
}
...
```
