### PR TITLE
Limit identified features to 10

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -442,12 +442,11 @@ goog.require('ga_window_service');
                 var shopLayer = config.shop && !config.shopMulti;
                 var shopMultiLayer = config.shopMulti;
 
-                var limit = shopMultiLayer ? 10 : null;
-                var order = limit ? 'distance' : null;
+                var order = shopMultiLayer ? 'distance' : null;
                 var tol = shopLayer ? 0 : scope.options.tolerance;
 
                 all.push(gaIdentify.get(map, [layerToQuery], geometry, tol,
-                    returnGeometry, canceler.promise, limit, order).then(
+                    returnGeometry, canceler.promise, 10, order).then(
                     function(response) {
                       showFeatures(response.data.results, coordinate);
                       return response.data.results.length;


### PR DESCRIPTION
At the moment we only have a limit of 201 features on the server side.
https://github.com/geoadmin/mf-chsdi3/blob/master/chsdi/views/features.py#L33

Now, we have 2 layers with high density  of points as default layers in the layer tree. (haltestellen, gwr)

When you're zoomed out and click on Zurich you will get more than a hundred results and trigger that many htmlPopup requests on the backend and utimately on OpenTrans backend.
Moreover, I would argue that most of the time these requests are made by mistake and are not wanted.
Now that we're using a third party API to get the transportation data, we may explode our quota very fast. Finally, I think this just makes the app slower stresses both our API and OpenTrans API for no reason.

In this PR, I propose to bring down this number to 20 results per layer.¨
This does not impact the query tool as the htmlPopup requests are only performed when the user interacts with the label previews.

On vector layers we always open one popup per layer and per click and I don't think people ever complained about it. 

ping @davidoesch 