### PR TITLE
Space between copyright sign

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -439,7 +439,7 @@ goog.require('ga_urlutils_service');
                   display: [$scope.layout.map.width, $scope.layout.map.height],
                   // scale has to be one of the advertise by the print server
                   scale: $scope.scale.value,
-                  dataOwner: allDataOwner ? '©' + allDataOwner : '',
+                  dataOwner: allDataOwner ? '© ' + allDataOwner : '',
                   shortLink: shortLink || '',
                   rotation: -((view.getRotation() * 180.0) / Math.PI)
                 }, defaultPage)

--- a/test/specs/print/PrintDirective.spec.js
+++ b/test/specs/print/PrintDirective.spec.js
@@ -490,7 +490,7 @@ describe('ga_print_directive', function() {
             expect(config.layers).to.eql([encLayer, encLayer]);
             expect(config.layers[0].legend).to.be();
             expect(config.layers[1].legend).to.be();
-            expect(config.pages[0].dataOwner).to.eql('©attribution,attribution');
+            expect(config.pages[0].dataOwner).to.eql('© attribution,attribution');
             expect(config.pages[0].timestamp).to.eql('1987');
           });
 


### PR DESCRIPTION
...hard to tell what this PR is doing. Maybe adding a single space...

See https://github.com/geoadmin/mf-geoadmin3/issues/4103

and test [with](https://mf-geoadmin3.int.bgdi.ch/mom_copyright_print/index.html)