### PR TITLE
Avoid break of e2e tests when search data has changed

### DIFF
--- a/src/style/print.less
+++ b/src/style/print.less
@@ -1,9 +1,6 @@
 @media print {
+
   // ****** PRINT GENERAL SETTINGS
-
-  body {
-  }
-
   .popover {
     box-shadow: none;
   }

--- a/test/saucelabs/helpers.py
+++ b/test/saucelabs/helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import time
+import re
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -28,7 +29,7 @@ def waitForUrlChange(driver, pattern, find=True, timeout=10):
     newUrl = driver.current_url
     if find:
         # We wait until we find pattern
-        while pattern not in newUrl:
+        while not re.search(pattern, newUrl):
             newUrl = driver.current_url
             t1 = time.time()
             if t1 - t0 > timeout:
@@ -37,7 +38,7 @@ def waitForUrlChange(driver, pattern, find=True, timeout=10):
         return False
     else:
         # We wait until we don't find a pattern
-        while pattern in newUrl:
+        while re.search(pattern, newUrl):
             newUrl = driver.current_url
             t1 = time.time()
             if t1 - t0 > timeout:

--- a/test/saucelabs/search_test.py
+++ b/test/saucelabs/search_test.py
@@ -144,37 +144,37 @@ searchLocationTests = [
     {
         'searchText': u'Kanalstrasse bus rar',
         'resultTitle': u'Bus Raron, Kanalstrasse',
-        'resultLocation': u'E=2627443.00&N=1128141.00&zoom=13'
+        'resultLocation': u'E=26274[0-9]{2}.[0-9]{2}&N=11281[0-9]{2}.[0-9]{2}&zoom=13'
     },
     {
         'searchText': u'p Mesolcina Bellinzona',
         'resultTitle': u'Bus Bellinzona, Piazza Mesolcina',
-        'resultLocation': u'E=2722500.00&N=1117499.00&zoom=13'
+        'resultLocation': u'E=27225[0-9]{2}.[0-9]{2}&N=11174[0-9]{2}.[0-9]{2}&zoom=13'
     },
     {
         'searchText': u'bruckenmoostrasse 11 raron',
         'resultTitle': u'Brückenmoosstrasse 11 3942 Raron',
-        'resultLocation': u'E=2627659.50&N=1128632.88&zoom=10'
+        'resultLocation': u'E=26276[0-9]{2}.[0-9]{2}&N=11286[0-9]{2}.[0-9]{2}&zoom=10'
     },
     {
         'searchText': u'rte berne 91 1010',
         'resultTitle': u'Route de Berne 91 1010 Lausanne',
-        'resultLocation': u'E=2539257.00&N=1154208.00&zoom=10'
+        'resultLocation': u'E=25392[0-9]{2}.[0-9]{2}&N=11542[0-9]{2}.[0-9]{2}&zoom=10'
     },
     {
         'searchText': u'pl chateau 3 laus',
         'resultTitle': u'Place du Château 3 1005 Lausanne',
-        'resultLocation': u'E=2538433.00&N=1152885.00&zoom=10'
+        'resultLocation': u'E=25384[0-9]{2}.[0-9]{2}&N=11528[0-9]{2}.[0-9]{2}&zoom=10'
     },
     {
         'searchText': u'basel',
         'resultTitle': u'Basel (BS)',
-        'resultLocation': 'E=2611723.45&N=1267109.36&zoom=6'
+        'resultLocation': 'E=26117[0-9]{2}.[0-9]{2}&N=12671[0-9]{2}.[0-9]{2}&zoom=6'
     },
     {
         'searchText': u'bern',
         'resultTitle': u'Bern (BE)',
-        'resultLocation': u'E=2596671.19&N=1200393.39&zoom=5'
+        'resultLocation': u'E=25966[0-9]{2}.[0-9]{2}&N=12003[0-9]{2}.[0-9]{2}&zoom=5'
     }
 ]
 
@@ -198,13 +198,13 @@ swissSearchParamTests = [
         'searchText': u'chemin des caves 11',
         'oneResOnly': True,
         'resultTitle': u'Chemin des Caves 11 1040 Echallens',
-        'resultLocation': u'E=2538398.00&N=1166096.00&zoom=10'
+        'resultLocation': u'E=25383[0-9]{2}.[0-9]{2}&N=11660[0-9]{2}.[0-9]{2}&zoom=10'
     },
     {
         'searchText': u'oliviers vinzel 1',
         'oneResOnly': False,
         'resultTitle': u'Chemin des Oliviers 8 1184 Vinzel',
-        'resultLocation': u'E=2511163.00&N=1144687.00&zoom=10'
+        'resultLocation': u'E=25111[0-9]{2}.[0-9]{2}&N=11446[0-9]{2}.[0-9]{2}&zoom=10'
     }
 ]
 


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/teo_fix/index.html)</jenkins>