### PR TITLE
Removing useless attributes for printing

### DIFF
--- a/src/components/print/PrintLayerService.js
+++ b/src/components/print/PrintLayerService.js
@@ -47,6 +47,7 @@ goog.require('ga_urlutils_service');
   var UNITS_RATIO = 39.37; // inches per meter
   var styleId = 0;
   var format = new ol.format.GeoJSON();
+  var vectorPropertiesToKeep = ['geometry', 'styleUrl', 'type'];
 
   function encodeGraticule(dpi) {
     return {
@@ -331,6 +332,13 @@ goog.require('ga_urlutils_service');
       // if the map is not rotated
 
       if (geometry.intersectsExtent(printRectangleCoords)) {
+        // Most properties are useless for printing
+        var properties = feature.getKeys();
+        angular.forEach(properties, function(property) {
+          if (vectorPropertiesToKeep.indexOf(property) < 0) {
+            feature.unset(property, true);
+          }
+        })
         var encFeature = format.writeFeatureObject(feature);
         if (!encFeature.properties) {
           encFeature.properties = {};
@@ -339,6 +347,7 @@ goog.require('ga_urlutils_service');
           // see: https://github.com/geoadmin/mf-geoadmin3/issues/1213
           delete encFeature.properties.Style;
           delete encFeature.properties.overlays;
+          encFeature.properties = {};
         }
         encFeature.properties._gx_style = encStyle.id;
         encFeatures.push(encFeature);

--- a/test/specs/print/PrintLayerService.spec.js
+++ b/test/specs/print/PrintLayerService.spec.js
@@ -49,6 +49,41 @@ describe('ga_printlayer_service', function() {
       });
     });
 
+    describe('#encodeVector()', function() {
+
+      var lyr, source, feature;
+
+      beforeEach(function() {
+        var geometry = new ol.geom.Point(center);
+        feature = new ol.Feature({
+          name: 'dummy',
+          geometry: geometry
+        });
+        feature.set('toto', 'abcd')
+        source = new ol.source.Vector({});
+        source.addFeature(feature);
+        lyr = new ol.layer.Vector({
+          source: source
+        });
+
+      });
+
+      afterEach(function() {
+        source = null;
+        feature = null;
+        lyr = null;
+      });
+
+      it('returns an encoded vector layer', function() {
+
+        var encVector = gaPrintLayer.encodeVector(lyr, lyr.getSource().getFeatures(), false, 2000000,
+            extent, 150);
+
+        expect(encVector.type).to.eql('Vector');
+      });
+
+    });
+
     describe('#encodeStyles()', function() {
 
       var source, feature;
@@ -59,6 +94,7 @@ describe('ga_printlayer_service', function() {
           name: 'dummy',
           geometry: geometry
         });
+        feature.set('toto', 'abcd')
         source = new ol.source.Vector({});
         source.addFeature(feature);
       });
@@ -105,8 +141,8 @@ describe('ga_printlayer_service', function() {
         var encFeatures = gaPrintLayer.encodeFeatures(vectorWithoutStyle, feature, false, 20000,
             extent, 150);
         // Default style
-        expect(encFeatures.encStyles[0]).to.eql({
-          id: 0,
+        expect(encFeatures.encStyles[1]).to.eql({
+          id: 1,
           zIndex: undefined,
           rotation: 0,
           pointRadius: 5,
@@ -132,7 +168,7 @@ describe('ga_printlayer_service', function() {
         });
         var encFeatures = gaPrintLayer.encodeFeatures(vectorWithStyle, feature, false, 20000,
             extent, 150);
-        var encStyle = encFeatures.encStyles['1'];
+        var encStyle = encFeatures.encStyles['2'];
 
         expect(encFeatures.encFeatures[0].geometry.coordinates).to.eql(center);
         expect(encStyle.fillColor).to.eql('#ffa500');
@@ -149,14 +185,27 @@ describe('ga_printlayer_service', function() {
 
         var encFeatures = gaPrintLayer.encodeFeatures(vectorWithStyleFunction, feature, false, 20000,
             extent, 150);
-        var encStyle = encFeatures.encStyles['2'];
+        var encStyle = encFeatures.encStyles['3'];
         expect(encFeatures.encFeatures[0].geometry.coordinates).to.eql(center);
 
         expect(encStyle.fillColor).to.eql('#008000');
         expect(encStyle.strokeColor).to.eql('#ffffff');
         expect(encStyle.pointRadius).to.eql(6);
-
       });
+
+      it('returns only needed attributes', function() {
+
+        var vectorWithoutStyle = new ol.layer.Vector({
+          source: source
+        });
+
+        var encFeatures = gaPrintLayer.encodeFeatures(vectorWithoutStyle, feature, false, 20000,
+            extent, 150);
+        // Remove properties
+        expect(feature.getKeys()).to.eql([ 'geometry' ]);
+        expect(encFeatures.encFeatures[0].properties).to.eql({ _gx_style: 4 });
+      });
+
     });
 
     describe('#encodeWMTS()', function() {


### PR DESCRIPTION
Some vector files are too large for printing, because of large number of attributes (very very big description in KML for instance). The PR https://github.com/geoadmin/mf-geoadmin3/pull/4233 adds a warning.

This PR remove them.

[Vector layer too large (warning or not), won't print](https://map.geo.admin.ch/?lang=rm&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttps:%2F%2Fwww.procrastinatio.org%2Fkml%2FHdataDocuments201701_TemperaturKantoneAuswahl_StationenGIS-Datendoc_TempAuswahl.kml&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&E=2632700.44&N=1216512.47&zoom=2)

[This PR, large Vector layer will print](https://mf-geoadmin3.int.bgdi.ch/mom_print_remove_attributes/index.html?lang=rm&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttps:%2F%2Fwww.procrastinatio.org%2Fkml%2FHdataDocuments201701_TemperaturKantoneAuswahl_StationenGIS-Datendoc_TempAuswahl.kml&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&E=2632700.44&N=1216512.47&zoom=2)

<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>
