### PR TITLE
Avoid js error when selecting a point cloud label

### DIFF
--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -401,6 +401,7 @@ goog.require('ga_window_service');
               }
               // Use by the ga-shop directive
               scope.clickCoordinate = coordinate;
+              var feat;
               var pointerShown = $(map.getTarget()).css('cursor') === 'pointer';
               var mapRes = map.getView().getResolution();
               var mapProj = map.getView().getProjection();
@@ -418,9 +419,13 @@ goog.require('ga_window_service');
                 for (var i = 0, ii = pickedObjects.length; i < ii; i++) {
                   var prim = pickedObjects[i].primitive;
                   var entity = pickedObjects[i].id;
-                  var feat = prim.olFeature || entity.olFeature;
-                  var lay = prim.olLayer || entity.olLayer;
+                  if (prim && prim.olFeature) {
+                    feat = prim.olFeature;
+                  } else if (entity && entity.olFeature) {
+                    feat = entity.olFeature;
+                  }
                   if (isFeatureQueryable(feat)) {
+                    var lay = prim.olLayer || entity.olLayer;
                     showVectorFeature(feat, lay);
                     all.push($q.when(1));
                     break;

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -401,7 +401,6 @@ goog.require('ga_window_service');
               }
               // Use by the ga-shop directive
               scope.clickCoordinate = coordinate;
-              var feat;
               var pointerShown = $(map.getTarget()).css('cursor') === 'pointer';
               var mapRes = map.getView().getResolution();
               var mapProj = map.getView().getProjection();
@@ -417,6 +416,7 @@ goog.require('ga_window_service');
                 var pickedObjects = scope.ol3d.getCesiumScene().
                     drillPick(position3d, 10);
                 for (var i = 0, ii = pickedObjects.length; i < ii; i++) {
+                  var feat;
                   var prim = pickedObjects[i].primitive;
                   var entity = pickedObjects[i].id;
                   if (prim && prim.olFeature) {


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>


This fixes an unreported bug.

Step to reproduce:

1. Open https://s.geo.admin.ch/79c6ad5dd6
2. Open your debugger
3. Click on a name

Result:
An ugly JS error appears

Expected Result:
No JS error


Basically when `drill picking` a point cloud in 3D, we don't have a `olFeature` on primitive and the id of the entity is undefined.

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/select_feat_3d/index.html)</jenkins>