### PR TITLE
Fix and add new regular shapes + PYPI

### DIFF
--- a/JSONSTYLES.md
+++ b/JSONSTYLES.md
@@ -42,7 +42,7 @@ The `vectorOptions` property defines the style to apply and is structured as fol
   "geomType": "point",
   "rotation": "optionalPropertyName",
   "vectorOptions": {
-    "type": "circle|icon|square|triangle|star|cross",
+    "type": "circle|icon|square|triangle|star|cross|pentagon|hexagon",
     "radius": 10,
     "stroke": {
       // The stroke style

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ PRINT_TECH_URL ?= //service-print.
 LAST_PRINT_URL := $(call lastvalue,print-url)
 PROXY_URL ?= //service-proxy.prod.bgdi.ch
 LAST_PROXY_URL := $(call lastvalue,proxy-url)
+PYPI_URL ?= https://pypi.fcio.net/simple/
+LAST_PYPI_URL := $(call lastvalue,pypi-url)
 
 # Map services variables
 WMS_URL ?= //wms.geo.admin.ch
@@ -151,7 +153,7 @@ MAKO_LAST_VARIABLES = .build-artefacts/last-api-url \
 	    .build-artefacts/last-terrain-url \
 	    .build-artefacts/last-vectortiles-url \
 	    .build-artefacts/last-apache-base-path
-	
+
 MAKO_LAST_VARIABLES_PROD = ${MAKO_LAST_VARIABLES} \
 	    .build-artefacts/last-version
 
@@ -827,18 +829,18 @@ $(addprefix .build-artefacts/annotated/, $(SRC_JS_FILES) src/TemplateCacheModule
 	    --namespace="__ga_template_cache__" \
 	    --output_mode=list > $@
 
-.build-artefacts/requirements.timestamp: ${PYTHON_VENV} requirements.txt
-	${PIP_CMD} install -r requirements.txt
+.build-artefacts/requirements.timestamp: .build-artefacts/last-pypi-url ${PYTHON_VENV} requirements.txt
+	${PIP_CMD} install --index-url ${PYPI_URL} -r requirements.txt
 	@if [ ! -e ${PYTHON_VENV}/local ]; then \
 	  ln -s . ${PYTHON_VENV}/local; \
 	fi
 	cp scripts/cmd.py ${PYTHON_VENV}/local/lib/python2.7/site-packages/mako/cmd.py
 	touch $@
 
-${PYTHON_VENV}:
+${PYTHON_VENV}: .build-artefacts/last-pypi-url
 	mkdir -p .build-artefacts
 	virtualenv --no-site-packages $@
-	${PIP_CMD} install -U pip setuptools
+	${PIP_CMD} install --index-url ${PYPI_URL} -U pip setuptools
 
 .build-artefacts/last-version::
 	$(call cachelastvariable,$@,$(VERSION),$(LAST_VERSION),version)
@@ -886,6 +888,9 @@ ${PYTHON_VENV}:
 
 .build-artefacts/last-vectortiles-url::
 	$(call cachelastvariable,$@,$(VECTORTILES_URL),$(LAST_VECTORTILES_URL),vectortiles-url)
+
+.build-artefacts/last-pypi-url::
+	$(call cachelastvariable,$@,$(PYPI_URL),$(LAST_PYPI_URL),pypi-url)
 
 
 .build-artefacts/cesium:

--- a/src/components/StylesFromLiteralsService.js
+++ b/src/components/StylesFromLiteralsService.js
@@ -23,12 +23,22 @@ goog.provide('ga_stylesfromliterals_service');
               points: 3,
               angle: 0
             },
-            star: {
+            pentagon: {
               points: 5,
               angle: 0
             },
+            star: {
+              points: 5,
+              angle: 0,
+              radius2: options.radius ? options.radius / 2 : undefined
+            },
             cross: {
               points: 4,
+              angle: 0,
+              radius2: 0
+            },
+            hexagon: {
+              points: 6,
               angle: 0
             }
           };

--- a/src/components/print/PrintLayerService.js
+++ b/src/components/print/PrintLayerService.js
@@ -334,7 +334,7 @@ goog.require('ga_urlutils_service');
         var encFeature = format.writeFeatureObject(feature);
 
         // We remove all attributes to reduce the size of the request
-        // and to avoid bugs like #1213. The style attribute is always 
+        // and to avoid bugs like #1213. The style attribute is always
         // '_gx_style', which is hardcoded.
         encFeature.properties = {};
         encFeature.properties._gx_style = encStyle.id;

--- a/src/components/shop/ShopService.js
+++ b/src/components/shop/ShopService.js
@@ -129,9 +129,9 @@ goog.require('ga_translation_service');
             geometry = transformExtent(geometry, proj);
           }
           sessionId = sessionId || new Date();
+          var params = getParams(orderType, layerBodId, featureId, geometry);
           var url = gaGlobalOptions.shopUrl + '/' + gaLang.get() +
-              '/dispatcher?' + getParams(orderType, layerBodId, featureId,
-                geometry);
+              '/dispatcher?' + params;
           winShop = $window.open(url, WIN_SHOP_PREFIX + sessionId);
         };
 

--- a/test/specs/StylesFromLiterals.spec.js
+++ b/test/specs/StylesFromLiterals.spec.js
@@ -139,6 +139,8 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olImage.getPoints()).to.be(5);
       expect(olImage.getRotation()).to.be(0);
       expect(olImage.getAngle()).to.be(0);
+      expect(olImage.getRadius()).to.be(8);
+      expect(olImage.getRadius2()).to.be(4);
 
       singleTypeStyle = {
         type: 'single',
@@ -163,6 +165,8 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olImage.getPoints()).to.be(4);
       expect(olImage.getRotation()).to.be(0);
       expect(olImage.getAngle()).to.be(0);
+      expect(olImage.getRadius()).to.be(8);
+      expect(olImage.getRadius2()).to.be(0);
 
       // Test dynamic rotation on single type style
       singleTypeStyle = {
@@ -204,6 +208,33 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olImage.getPoints()).to.be(4);
       expect(olImage.getRotation()).to.be(1.22);
       expect(olImage.getAngle()).to.be(0);
+      expect(olImage.getRadius()).to.be(8);
+      expect(olImage.getRadius2()).to.be(0);
+
+      // Test more shapes
+      singleTypeStyle.vectorOptions.type = 'pentagon'
+      gaStyle = gaStylesFromLiterals(singleTypeStyle);
+      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olImage = olStyle.getImage();
+      expect(olStyle).to.be.an(ol.style.Style);
+      expect(olImage).to.be.an(ol.style.RegularShape);
+      expect(olImage.getPoints()).to.be(5);
+      expect(olImage.getRotation()).to.be(1.22);
+      expect(olImage.getAngle()).to.be(0);
+      expect(olImage.getRadius()).to.be(8);
+      expect(olImage.getRadius2()).to.be(undefined);
+
+      singleTypeStyle.vectorOptions.type = 'hexagon'
+      gaStyle = gaStylesFromLiterals(singleTypeStyle);
+      olStyle = gaStyle.getFeatureStyle(olFeature);
+      olImage = olStyle.getImage();
+      expect(olStyle).to.be.an(ol.style.Style);
+      expect(olImage).to.be.an(ol.style.RegularShape);
+      expect(olImage.getPoints()).to.be(6);
+      expect(olImage.getRotation()).to.be(1.22);
+      expect(olImage.getAngle()).to.be(0);
+      expect(olImage.getRadius()).to.be(8);
+      expect(olImage.getRadius2()).to.be(undefined);
     });
 
     it('supports single type style assignment for a line', function() {
@@ -669,6 +700,8 @@ describe('ga_stylesfromliterals_service', function() {
       expect(olImage.getStroke()).to.be.an(ol.style.Stroke);
       expect(olImage.getStroke().getColor()).to.equal('#FFFFFF');
       expect(olImage.getStroke().getWidth()).to.equal(3);
+      expect(olImage.getRadius()).to.be(8);
+      expect(olImage.getRadius2()).to.be(4);
     });
 
     it('supports simple unique type style assignment resolution dependent', function() {


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>

- Fix pypi build using a new index-url
- Fix `star` and `cross` shapes.
- Added `pentagon` and `hexagon`
- Tests + Doc
- Fix eslint in shop directive (always gets linted)




<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/shapes/index.html)</jenkins>