### PR TITLE
by default use pypi.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ PRINT_TECH_URL ?= //service-print.
 LAST_PRINT_URL := $(call lastvalue,print-url)
 PROXY_URL ?= //service-proxy.prod.bgdi.ch
 LAST_PROXY_URL := $(call lastvalue,proxy-url)
-PYPI_URL ?= https://pypi.fcio.net/simple/
+PYPI_URL ?= https://pypi.org/simple/
 LAST_PYPI_URL := $(call lastvalue,pypi-url)
 
 # Map services variables


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>

@oterral could you please try to deploy with this fix?

Apparently now pypi.org is working again. We should use it as default. With the use lf PYPI_URL environment variable we are still able to overrwrite it if needed in our build environment. By default we should keep pypi.org in the Makefile...


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbon_fix_pypi_mess/index.html)</jenkins>