### PR TITLE
chore(package): update caniuse-db to version 1.0.30000833

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "slipjs": "2.1.1"
   },
   "devDependencies": {
-    "caniuse-db": "1.0.30000832",
+    "caniuse-db": "1.0.30000833",
     "angular-mocks": "1.6.10",
     "autoprefixer": "8.4.1",
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Closes #4297



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/greenkeeper/caniuse-db-1.0.30000833/index.html)</jenkins>