### PR TITLE
Don't remove element from the resolutions array otherwise it removes …

### DIFF
--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -488,7 +488,7 @@ goog.require('ga_urlutils_service');
           // value at which the layer stop being displayed.
           var tileGridMinRes = config.tileGridMinRes;
           if (config.resolutions) {
-            tileGridMinRes = config.resolutions.pop();
+            tileGridMinRes = config.resolutions.slice(-1)[0];
           }
 
           // For some obscure reasons, on iOS, displaying a base 64 image

--- a/test/specs/map/Layers.spec.js
+++ b/test/specs/map/Layers.spec.js
@@ -709,6 +709,7 @@ describe('ga_layers_service', function() {
       describe('when online', function() {
 
         it('returns a WMTS layer', function() {
+
           var layer = gaLayers.getOlLayerById('wmts');
           expect(layer instanceof ol.layer.Tile).to.be.ok();
           expect(layer.getMinResolution()).to.be(0.5);
@@ -743,9 +744,11 @@ describe('ga_layers_service', function() {
           var tileGrid = gaLayers.getOlLayerById('wmtsWithResolutions').getSource().getTileGrid();
           expect(tileGrid instanceof ol.tilegrid.WMTS).to.be.ok();
           expect(tileGrid.getResolutions().length).to.eql(21);
+          // Test if the resolutions array is unchanged
+          expect(gaLayers.getLayer('wmtsWithResolutions').resolutions.length).to.be(3);
         });
 
-        it('returns a WMTS getting the tileGridMinRes from an array of resolutions', function() {
+        it('returns a WMTS getting the tileGridMinRes from tileGridMinRes property', function() {
           var tileGrid = gaLayers.getOlLayerById('wmtsWithTileGridMinRes').getSource().getTileGrid();
           expect(tileGrid instanceof ol.tilegrid.WMTS).to.be.ok();
           expect(tileGrid.getResolutions().length).to.eql(20);


### PR DESCRIPTION
…the display of an lod in 3d



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/fix_reg/index.html)</jenkins>