### PR TITLE
chore(package): update autoprefixer to version 8.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "caniuse-db": "1.0.30000846",
     "angular-mocks": "1.7.0",
-    "autoprefixer": "8.5.0",
+    "autoprefixer": "8.5.1",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "bootstrap": "3.3.7",


### PR DESCRIPTION
Closes #4298



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/greenkeeper/autoprefixer-8.5.1/index.html)</jenkins>