### PR TITLE
chore(package): update caniuse-db to version 1.0.30000855

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "slipjs": "2.1.1"
   },
   "devDependencies": {
-    "caniuse-db": "1.0.30000851",
+    "caniuse-db": "1.0.30000855",
     "angular-mocks": "1.7.2",
     "autoprefixer": "8.6.2",
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Closes #4380



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/greenkeeper/caniuse-db-1.0.30000855/index.html)</jenkins>