### PR TITLE
Support any whitespace separator between coordinates

### DIFF
--- a/src/components/search/SearchService.js
+++ b/src/components/search/SearchService.js
@@ -13,7 +13,7 @@ goog.require('ga_reframe_service');
    * DMSXXX: Match Degrees Minutes Seconds coordinates
    *         (ex: 6° 58' 12.11'' E 46° 58' 12.12'' N)
    */
-  var D = '([\\d.,]{2,})[°\\sNSWEO]*[ ,/]+([\\d.,]{3,})[\\s°NSWEO]*';
+  var D = '([\\d.,]{2,})[°\\sNSWEO]*[\\s,/]+([\\d.,]{3,})[\\s°NSWEO]*';
   var DM = '([\\d]{1,2})[°\\s]*([\\d.,]+)[\\s\',NSEWO/]*';
   var DMSDegree = '\\b0{0,2}[0-9]{1,2}\\s*[°|º]\\s*';
   var DMSMinute = '[0-9]{1,2}\\s*[\'|′]';
@@ -51,7 +51,7 @@ goog.require('ga_reframe_service');
   };
 
   var sanitizeCoordinate = function(str) {
-    return parseFloat(str.replace(/[ \t' ]/g, ''));
+    return parseFloat(str.replace(/[ \s' ]/g, ''));
   }
 
   // Reorder coordinates.

--- a/test/specs/search/SearchService.spec.js
+++ b/test/specs/search/SearchService.spec.js
@@ -42,6 +42,15 @@ describe('ga_search_service', function() {
         $rootScope.$digest();
       });
 
+      it('with tab as separator', function(done) {
+        getCoordinate(extent, '2600123.12\t1200345').then(function(position) {
+          expect(position).to.eql(coord2056);
+          expect(spy.callCount).to.eql(0);
+          done();
+        });
+        $rootScope.$digest();
+      });
+
       it('separated by comma', function(done) {
         getCoordinate(extent, '2600123.12,1200345').then(function(position) {
           expect(position).to.eql(coord2056);
@@ -205,7 +214,10 @@ describe('ga_search_service', function() {
         // Separators
         '6.96948,46.9712',
         '6.96948                46.9712',
-        '6.96948/46.9712'
+        '6.96948/46.9712',
+        '6.96948\n46.9712',
+        '6.96948\t46.9712',
+        '6.96948\r46.9712'
       ]
 
       strings.forEach(function(str) {


### PR DESCRIPTION
See https://github.com/geoadmin/mf-geoadmin3/compare/master...mom_tab?expand=1#diff-e911512acd1a63a0f60d9cdc823942db

<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>

Hopefully fixes https://github.com/geoadmin/mf-geoadmin3/issues/4409

Now you may copy/paste 2 cells (horizontal/vertical)  from Excel

![excel-to-map](https://user-images.githubusercontent.com/1236739/42206192-b27b9384-7ea6-11e8-8cf0-aeb059cca1b7.png)

