### PR TITLE
chore(package): update caniuse-db to version 1.0.30000864

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "slipjs": "2.1.1"
   },
   "devDependencies": {
-    "caniuse-db": "1.0.30000862",
+    "caniuse-db": "1.0.30000864",
     "angular-mocks": "1.7.2",
     "autoprefixer": "8.6.4",
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Closes #4427



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/greenkeeper/caniuse-db-1.0.30000864/index.html)</jenkins>