### PR TITLE
Update vector tiles sources to new setup

### DIFF
--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -289,22 +289,22 @@ goog.require('ga_urlutils_service');
               }, {
                 serverLayerName: 'swissbasemap',
                 sourceId: 'swissbasemap', // id of the source to use
-                styleUrl: 'https://tileserver.dev.bgdi.ch/styles/swissbasemap-osm-integrated/style.json'
+                styleUrl: 'https://tileserver.dev.bgdi.ch/styles/swissbasemap-osm-europe-20170925/style.json'
               }, {
                 serverLayerName: 'osm',
                 sourceId: 'osm',
-                styleUrl: 'https://tileserver.dev.bgdi.ch/styles/swissbasemap-osm-integrated/style.json'
+                styleUrl: 'https://tileserver.dev.bgdi.ch/styles/swissbasemap-osm-europe-20170925/style.json'
               }, {
                 serverLayerName: 'relief-osm',
                 sourceId: 'relief-osm',
                 sourceType: 'raster',
-                styleUrl: 'https://tileserver.dev.bgdi.ch/styles/swissbasemap-osm-integrated/style.json',
+                styleUrl: 'https://tileserver.dev.bgdi.ch/styles/swissbasemap-osm-europe-20170925/style.json',
                 opacity: 0.3
               }, {
                 serverLayerName: 'relief',
                 sourceId: 'relief',
                 sourceType: 'raster',
-                styleUrl: 'https://tileserver.dev.bgdi.ch/styles/swissbasemap-osm-integrated/style.json',
+                styleUrl: 'https://tileserver.dev.bgdi.ch/styles/swissbasemap-osm-europe-20170925/style.json',
                 opacity: 1
               }, {
                 serverLayerName: 'openmaptiles',


### PR DESCRIPTION
This updates the PR of @oterral to point to the correct tileserver resources for vector tiles.

Note that this does not work yet because of faulty CORS headers. But @ltkum is workin on that one.

Self-merge because it's applied to a branch.

<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>
