### PR TITLE
[WIP] New vegetation and tlm data

### DIFF
--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -231,7 +231,7 @@ goog.require('ga_urlutils_service');
                 'ch.swisstopo.vegetation.3d'
               ];
               var tilesetTs = [
-                '20189999',
+                '20180716',
                 '20170814',
                 '20180716' 
               ];

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -218,7 +218,7 @@ goog.require('ga_urlutils_service');
               response.data['ch.swisstopo.terrain.3d'] = {
                 type: 'terrain',
                 serverLayerName: 'ch.swisstopo.terrain.3d',
-                timestamps: ['20180601'],
+                timestamps: ['20160115'],
                 attribution: 'swisstopo',
                 attributionUrl: 'https://www.swisstopo.admin.ch/' + lang +
                     '/home.html'
@@ -231,9 +231,9 @@ goog.require('ga_urlutils_service');
                 'ch.swisstopo.vegetation.3d'
               ];
               var tilesetTs = [
-                '20180704224839',
+                '20189999',
                 '20170814',
-                '20180712-090616'
+                '20180715-082825' // '20180712-090616'
               ];
               var tilesetStyle = [
                 undefined,

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -231,9 +231,9 @@ goog.require('ga_urlutils_service');
                 'ch.swisstopo.vegetation.3d'
               ];
               var tilesetTs = [
-                '20170425',
+                '20180704224839',
                 '20170814',
-                '20170630'
+                '20180710101607'
               ];
               var tilesetStyle = [
                 undefined,

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -218,7 +218,7 @@ goog.require('ga_urlutils_service');
               response.data['ch.swisstopo.terrain.3d'] = {
                 type: 'terrain',
                 serverLayerName: 'ch.swisstopo.terrain.3d',
-                timestamps: ['20160115'],
+                timestamps: ['20180601'],
                 attribution: 'swisstopo',
                 attributionUrl: 'https://www.swisstopo.admin.ch/' + lang +
                     '/home.html'

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -218,7 +218,7 @@ goog.require('ga_urlutils_service');
               response.data['ch.swisstopo.terrain.3d'] = {
                 type: 'terrain',
                 serverLayerName: 'ch.swisstopo.terrain.3d',
-                timestamps: ['20160115'],
+                timestamps: ['20180601'],
                 attribution: 'swisstopo',
                 attributionUrl: 'https://www.swisstopo.admin.ch/' + lang +
                     '/home.html'
@@ -233,7 +233,7 @@ goog.require('ga_urlutils_service');
               var tilesetTs = [
                 '20180704224839',
                 '20170814',
-                '20180710101607'
+                '20180712-090616'
               ];
               var tilesetStyle = [
                 undefined,

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -233,7 +233,7 @@ goog.require('ga_urlutils_service');
               var tilesetTs = [
                 '20189999',
                 '20170814',
-                '20180715-082825' // '20180712-090616'
+                '20180716' 
               ];
               var tilesetStyle = [
                 undefined,

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -232,7 +232,7 @@ goog.require('ga_urlutils_service');
               ];
               var tilesetTs = [
                 '20180716',
-                '20170814',
+                '20180716',
                 '20180716' 
               ];
               var tilesetStyle = [

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -160,7 +160,7 @@ goog.require('ga_waitcursor_service');
     gaLayersProvider.wmtsLV03Url = gaGlobalOptions.wmtsUrl +
         '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{z}/{y}/{x}.{Format}';
     gaLayersProvider.terrainUrl = gaGlobalOptions.terrainUrl +
-        '/1.0.0/{Layer}/default/{Time}/4326';
+        '/1.0.0/{Layer}/';
     gaLayersProvider.vectorTilesUrl = gaGlobalOptions.vectorTilesUrl +
         '/{Layer}/{Time}/';
 

--- a/test/specs/map/Layers.spec.js
+++ b/test/specs/map/Layers.spec.js
@@ -198,7 +198,7 @@ describe('ga_layers_service', function() {
         expect(terrain).to.eql({
           type: 'terrain',
           serverLayerName: 'ch.swisstopo.terrain.3d',
-          timestamps: ['20160115'],
+          timestamps: ['20180601'],
           attribution: 'swisstopo',
           attributionUrl: 'https://www.swisstopo.admin.ch/somelang/home.html'
         });


### PR DESCRIPTION
THIS PR IS CONSOLIDATED IN https://github.com/geoadmin/mf-geoadmin3/pull/4466

**Updated** 3D data (_adhoc_ sources from June 2018)
* [x] ch.swisstopo.swisstlm3d.3d/20180716 (building, cablecar, bridges)
* [x] ch.swisstopo.vegetation.3d/20180716
* [x] ch.swisstopo.terrain.3d  (20180601/4326). 
* [x] TLM raster map (see with @ltclm )

Half-automatic processed through AWS Batch jobs (image based on https://github.com/geoadmin/analyticalgraphicsinc-swayze)

[Current data (Zürich)(prod)](https://mf-geoadmin3.int.bgdi.ch/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.swissnames3d&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&lon=8.54137&lat=47.36434&elevation=1000&heading=360.000&pitch=-40.044), no buildings, no bridges

[This PR (Zürich)](https://mf-geoadmin3.int.bgdi.ch/mom_new_3d_data/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.swissnames3d&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&lon=8.54137&lat=47.36434&elevation=1000&heading=360.000&pitch=-40.044): buildings, bridges


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/mom_new_3d_data/index.html)</jenkins> (by Jenkins)

Nota: I put my compilations:
 * ch.swisstopo.swisstlm3d.3d-20180716
 * ch.swisstopo.vegetation3d.3d-20180716

back into _ \\v0t0020a.adr.admin.ch\kogis\igeb\BGDI\bgdiscratch\3ddata\import_ 
Those were processed by myself, and not delivered as such.