### PR TITLE
downgrade eslint to 4.91.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "babel-preset-env": "^1.4.0",
     "bootstrap": "3.3.7",
     "commander": "2.16.0",
-    "eslint": "5.0.1",
+    "eslint": "4.19.1",
     "eslint-config-standard": "12.0.0-alpha.0",
     "eslint-plugin-import": "2.13.0",
     "eslint-plugin-node": "6.0.1",


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>
fixes https://github.com/geoadmin/mf-geoadmin3/issues/4458

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/dev_ltclm_downgrade_eslint/index.html)</jenkins>