### PR TITLE
fix flight mode UP and DOWN arrows

### DIFF
--- a/src/components/controls3d/fps.js
+++ b/src/components/controls3d/fps.js
@@ -372,12 +372,13 @@ FPS.prototype.flyModeTick_ = function(delta) {
     roll += 0.02;
   }
   if (this.buttons_.forward) {
-    pitch -= 0.02;
+    pitch -= 0.02 * Math.cos(roll);
+    heading -= 0.02 * Math.sin(roll)
   }
   if (this.buttons_.backward) {
-    pitch += 0.02;
+    pitch += 0.02 * Math.cos(roll);
+    heading += 0.02 * Math.sin(roll)
   }
-
   // rotate the plane on roll
   if (roll < Cesium.Math.PI) {
     // turn right

--- a/src/components/controls3d/fps.js
+++ b/src/components/controls3d/fps.js
@@ -373,11 +373,11 @@ FPS.prototype.flyModeTick_ = function(delta) {
   }
   if (this.buttons_.forward) {
     pitch -= 0.02 * Math.cos(roll);
-    heading -= 0.02 * Math.sin(roll)
+    heading -= 0.02 * Math.sin(roll);
   }
   if (this.buttons_.backward) {
     pitch += 0.02 * Math.cos(roll);
-    heading += 0.02 * Math.sin(roll)
+    heading += 0.02 * Math.sin(roll);
   }
   // rotate the plane on roll
   if (roll < Cesium.Math.PI) {


### PR DESCRIPTION
Using UP and DOWN now is applied to the both heading and pitch, which seems a bit more realistic.

It is still a bit awkward because the center of the focus is slightly moving, but this is another issue which occurs also with the "normal" 3D view.

this fixes [this issue](https://github.com/geoadmin/mf-geoadmin3/issues/4470)


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbon_fix_flight_mode/index.html)</jenkins>