### PR TITLE
Using opacity from layersConfig not the associated style file 

### DIFF
--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -402,7 +402,7 @@ def init_connection(bucket_name):
     try:
         session = boto3.session.Session()
     except botocore.exceptions.BotoCoreError as e:
-        print('Cannot establish connection. Check you credentials %s.' % profile_name)
+        print('Cannot establish connection to bucket "%s". Check you credentials.' % bucket_name)
         print(e)
         sys.exit(1)
 

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -613,6 +613,7 @@ goog.require('ga_urlutils_service');
             olLayer = new ol.layer.Vector({
               minResolution: config.minResolution,
               maxResolution: config.maxResolution,
+              opacity: config.opacity || 1,
               source: olSource,
               extent: extent
             });

--- a/test/specs/map/Layers.spec.js
+++ b/test/specs/map/Layers.spec.js
@@ -840,7 +840,8 @@ describe('ga_layers_service', function() {
           expect(layer instanceof ol.layer.Vector).to.be.ok();
           expect(layer.getMinResolution()).to.be(0.5);
           expect(layer.getMaxResolution()).to.be(100);
-          expect(layer.getOpacity()).to.be(1);
+          // opacity from layersConfig
+          expect(layer.getOpacity()).to.be(0.35);
           expect(layer.getExtent()).to.eql(gaGlobalOptions.defaultExtent);
           var source = layer.getSource();
           expect(source instanceof ol.source.Vector).to.be.ok();
@@ -921,7 +922,7 @@ describe('ga_layers_service', function() {
           expect(layer instanceof ol.layer.Vector).to.be.ok();
           expect(layer.getMinResolution()).to.be(0.5);
           expect(layer.getMaxResolution()).to.be(100);
-          expect(layer.getOpacity()).to.be(1);
+          expect(layer.getOpacity()).to.be(0.35);
           expect(layer.getExtent()).to.eql(gaGlobalOptions.defaultExtent);
           var source = layer.getSource();
           expect(source instanceof ol.source.Vector).to.be.ok();


### PR DESCRIPTION
Try adding the layer `bikesharing`. It should have an opacity of `0.90`

[Test link with bike sharing](https://mf-geoadmin3.int.bgdi.ch/fix_4485/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.bfe.bikesharing)



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/fix_4485/index.html)</jenkins>

See https://github.com/geoadmin/mf-geoadmin3/issues/4485