### PR TITLE
Make mouse movement less nervous in 3D 

### DIFF
--- a/src/components/controls3d/fps.js
+++ b/src/components/controls3d/fps.js
@@ -46,6 +46,13 @@ function FPS(scene, scope) {
   };
 
   /**
+   * Slow down the mouse movement
+   * @const {number}
+   * @private
+   */
+  this.mouseMovementLag_ = 0.1;
+
+  /**
    * @type {number}
    * @private
    */
@@ -248,11 +255,11 @@ FPS.prototype.setActive = function(active, optPosition) {
 FPS.prototype.onMouseMove_ = function(event) {
   if (this.getPointerLock()) {
     if (event.movementX && event.movementY) {
-      this.movementX_ += event.movementX;
-      this.movementY_ += event.movementY;
+      this.movementX_ += event.movementX * this.mouseMovementLag_;
+      this.movementY_ += event.movementY * this.mouseMovementLag_;
     } else if (event.mozMovementX && event.mozMovementY) {
-      this.movementX_ += event.mozMovementX;
-      this.movementY_ += event.mozMovementY;
+      this.movementX_ += event.mozMovementX * this.mouseMovementLag_;
+      this.movementY_ += event.mozMovementY * this.mouseMovementLag_;
     }
   }
 };


### PR DESCRIPTION
Now movement is one tenth of the mouse movement (can be changed)

[Test link](https://mf-geoadmin3.int.bgdi.ch/fix_4479/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swissnames3d&lon=7.04843&lat=47.12940&elevation=1653&heading=168.848&pitch=-45.000)

<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>


See  #4479
