### PR TITLE
Don't update realtime layers when not visible or de-activated

### DIFF
--- a/src/components/map/RealtimeLayersService.js
+++ b/src/components/map/RealtimeLayersService.js
@@ -76,9 +76,10 @@ goog.require('ga_vector_service');
         map = inMap;
         var scope = $rootScope.$new();
         scope.layers = map.getLayers().getArray();
-        scope.layerFilter = gaLayerFilters.realtime;
+        scope.realtime = gaLayerFilters.realtime;
+        scope.selectedAndVisible = gaLayerFilters.selectedAndVisible;
 
-        scope.$watchCollection('layers | filter:layerFilter',
+        scope.$watchCollection('layers | filter:realtime | filter:selectedAndVisible',
             function(newLayers, oldLayers) {
 
               // Layer Removed


### PR DESCRIPTION
This is a PR for the diemo branch.

<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>

As mentioned in the comments https://github.com/geoadmin/mf-geoadmin3/pull/4505, this PR fixes the issue that the layer is reloaded even if de-activated in the layermanager.

