### PR TITLE
Bigger draw menu windows

### DIFF
--- a/src/components/draw/style/drawstyle.less
+++ b/src/components/draw/style/drawstyle.less
@@ -50,7 +50,7 @@
       position: relative;
       overflow-y: auto;
       overflow-x: hidden;
-      max-height: 200px;
+      max-height: 250px;
 
       label {
         margin-right: 5px;


### PR DESCRIPTION
Draw something. The draw window should **not** have an overflow (compare with screenshot in the bug description)

![screenshot from 2018-10-17 14-38-08](https://user-images.githubusercontent.com/1236739/47086629-56ad9800-d21a-11e8-92b7-a22c70ae8fe6.png)


See https://github.com/geoadmin/mf-geoadmin3/issues/4495


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/mom_fix4495/index.html)</jenkins>