### PR TITLE
[MVT] Third party style icon on bg selector

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -20,6 +20,8 @@ goog.provide('ga_urlutils_service');
 
         var SUBDOMAINS_REGEXP = /\{s(:(([\w,]?)+))?\}/;
 
+        var AGNOSTIC_REGEXP = /^\/\//;
+
         // Test validity of a URL
         this.isValid = function(url) {
           return (!!url && url.length > 0 && URL_REGEXP.test(url));
@@ -54,6 +56,19 @@ goog.provide('ga_urlutils_service');
         // Test using a head request if the remote resource enables CORS
         this.isCorsEnabled = function(url) {
           return $http.head(url, { timeout: 1500 });
+        };
+
+        this.resolveStyleUrl = function(styleUrl, externalStyleUrl) {
+          var url = styleUrl;
+          if (AGNOSTIC_REGEXP.test(externalStyleUrl)) {
+            externalStyleUrl = $window.location.protocol + externalStyleUrl;
+          }
+          if (externalStyleUrl && this.isValid(externalStyleUrl)) {
+            url = externalStyleUrl;
+          } else if (AGNOSTIC_REGEXP.test(styleUrl)) {
+            url = $window.location.protocol + styleUrl;
+          }
+          return url;
         };
 
         this.buildProxyUrl = function(url) {

--- a/src/components/backgroundselector/BackgroundSelectorDirective.js
+++ b/src/components/backgroundselector/BackgroundSelectorDirective.js
@@ -5,11 +5,12 @@ goog.require('ga_background_service');
 (function() {
 
   var module = angular.module('ga_backgroundselector_directive', [
-    'ga_background_service'
+    'ga_background_service',
+    'pascalprecht.translate'
   ]);
 
   module.directive('gaBackgroundSelector',
-      function(gaBackground) {
+      function($window, $translate, gaBackground) {
         return {
           restrict: 'A',
           templateUrl:
@@ -21,6 +22,7 @@ goog.require('ga_background_service');
           link: function(scope, elt, attrs) {
             scope.isBackgroundSelectorClosed = true;
             scope.backgroundLayers = [];
+            scope.styleUrl = false;
 
             scope.$watch('currentLayer', function(newVal, oldVal) {
               if (oldVal !== newVal) {
@@ -33,6 +35,7 @@ goog.require('ga_background_service');
                 var ol3dEnabled = scope.ol3d && scope.ol3d.getEnabled();
                 if (!(bgLayer.disable3d && ol3dEnabled)) {
                   scope.currentLayer = bgLayer;
+                  scope.styleUrl = !!scope.currentLayer.styleUrl;
                 }
               }
               scope.toggleMenu();
@@ -58,12 +61,17 @@ goog.require('ga_background_service');
             gaBackground.loadConfig().then(function() {
               scope.backgroundLayers = gaBackground.getBackgrounds();
               scope.currentLayer = gaBackground.get();
+              scope.styleUrl = !!scope.currentLayer.styleUrl;
             });
             scope.$on('gaBgChange', function(evt, newBg) {
               if (!scope.currentLayer || newBg.id !== scope.currentLayer.id) {
                 scope.currentLayer = newBg;
               }
             });
+
+            scope.showWarning = function() {
+              $window.alert($translate.instant('custom_style'));
+            };
 
             elt.find('.ga-bg-layer-bt').on('click', scope.toggleMenu);
           }

--- a/src/components/backgroundselector/BackgroundSelectorDirective.js
+++ b/src/components/backgroundselector/BackgroundSelectorDirective.js
@@ -1,81 +1,121 @@
 goog.provide('ga_backgroundselector_directive');
 
 goog.require('ga_background_service');
+goog.require('ga_event_service');
 
 (function() {
-
   var module = angular.module('ga_backgroundselector_directive', [
     'ga_background_service',
+    'ga_event_service',
     'pascalprecht.translate'
   ]);
 
-  module.directive('gaBackgroundSelector',
-      function($window, $translate, gaBackground) {
-        return {
-          restrict: 'A',
-          templateUrl:
-            'components/backgroundselector/partials/backgroundselector.html',
-          scope: {
-            map: '=gaBackgroundSelectorMap',
-            ol3d: '=gaBackgroundSelectorOl3d'
-          },
-          link: function(scope, elt, attrs) {
-            scope.isBackgroundSelectorClosed = true;
-            scope.backgroundLayers = [];
-            scope.styleUrl = false;
+  module.directive('gaBackgroundSelector', function(
+      $window,
+      $translate,
+      gaBackground,
+      gaEvent
+  ) {
+    return {
+      restrict: 'A',
+      templateUrl:
+        'components/backgroundselector/partials/backgroundselector.html',
+      scope: {
+        map: '=gaBackgroundSelectorMap',
+        ol3d: '=gaBackgroundSelectorOl3d'
+      },
+      link: function(scope, elt, attrs) {
+        scope.isBackgroundSelectorClosed = true;
+        scope.backgroundLayers = [];
+        scope.styleUrl = false;
 
-            scope.$watch('currentLayer', function(newVal, oldVal) {
-              if (oldVal !== newVal) {
-                gaBackground.set(scope.map, newVal);
-              }
-            });
+        scope.$watch('currentLayer', function(newVal, oldVal) {
+          if (oldVal !== newVal) {
+            gaBackground.set(scope.map, newVal);
+          }
+        });
 
-            scope.activateBackgroundLayer = function(bgLayer) {
-              if (scope.currentLayer !== bgLayer) {
-                var ol3dEnabled = scope.ol3d && scope.ol3d.getEnabled();
-                if (!(bgLayer.disable3d && ol3dEnabled)) {
-                  scope.currentLayer = bgLayer;
-                  scope.styleUrl = !!scope.currentLayer.styleUrl;
-                }
-              }
-              scope.toggleMenu();
-            };
-
-            scope.toggleMenu = function() {
-              elt.toggleClass('ga-open');
-            };
-
-            scope.getClass = function(layer) {
-              if (layer) {
-                var selected = (scope.currentLayer &&
-                  layer.id === scope.currentLayer.id);
-                var splitLayer = layer.id.split('.');
-                return (selected ? 'ga-bg-highlight ' : '') +
-                'ga-' + splitLayer[splitLayer.length - 2] +
-                ' ' + (layer.disable3d ? 'ga-disable3d' : '');
-              }
-            };
-
-            // Get the first background with the loadConfig promise: this
-            // directive may not be listening to the first broadcast.
-            gaBackground.loadConfig().then(function() {
-              scope.backgroundLayers = gaBackground.getBackgrounds();
-              scope.currentLayer = gaBackground.get();
+        scope.activateBackgroundLayer = function(bgLayer) {
+          if (scope.currentLayer !== bgLayer) {
+            var ol3dEnabled = scope.ol3d && scope.ol3d.getEnabled();
+            if (!(bgLayer.disable3d && ol3dEnabled)) {
+              scope.currentLayer = bgLayer;
               scope.styleUrl = !!scope.currentLayer.styleUrl;
-            });
-            scope.$on('gaBgChange', function(evt, newBg) {
-              if (!scope.currentLayer || newBg.id !== scope.currentLayer.id) {
-                scope.currentLayer = newBg;
-              }
-            });
+            }
+          }
+          scope.toggleMenu();
+        };
 
-            scope.showWarning = function() {
-              $window.alert($translate.instant('custom_style'));
-            };
+        scope.toggleMenu = function() {
+          elt.toggleClass('ga-open');
+        };
 
-            elt.find('.ga-bg-layer-bt').on('click', scope.toggleMenu);
+        scope.getClass = function(layer) {
+          if (layer) {
+            var selected =
+              scope.currentLayer && layer.id === scope.currentLayer.id;
+            var splitLayer = layer.id.split('.');
+            return (
+              (selected ? 'ga-bg-highlight ' : '') +
+              'ga-' +
+              splitLayer[splitLayer.length - 2] +
+              ' ' +
+              (layer.disable3d ? 'ga-disable3d' : '')
+            );
           }
         };
+
+        // Get the first background with the loadConfig promise: this
+        // directive may not be listening to the first broadcast.
+        gaBackground.loadConfig().then(function() {
+          scope.backgroundLayers = gaBackground.getBackgrounds();
+          scope.currentLayer = gaBackground.get();
+          scope.styleUrl = !!scope.currentLayer.styleUrl;
+        });
+        scope.$on('gaBgChange', function(evt, newBg) {
+          if (!scope.currentLayer || newBg.id !== scope.currentLayer.id) {
+            scope.currentLayer = newBg;
+          }
+        });
+
+        scope.showWarning = function(layer) {
+          var url =
+            layer && layer.styleUrl ?
+              layer.styleUrl :
+              scope.currentLayer.styleUrl;
+          $window.alert(
+              $translate.instant(
+                  'external_data_warning').replace('--URL--', url)
+          );
+        };
+        // Display the third party data tooltip, only on mouse events
+        var tooltipOptions = {
+          trigger: 'manual',
+          selector: '.fa-user',
+          container: 'body',
+          placement: 'top',
+          title: function() {
+            return $translate.instant('external_data_tooltip');
+          },
+          template:
+            '<div class="tooltip ga-red-tooltip">' +
+            '<div class="tooltip-arrow"></div>' +
+            '<div class="tooltip-inner"></div>' +
+            '</div>'
+        };
+
+        gaEvent.onMouseOverOut(elt, function(evt) {
+          var link = $(evt.target);
+          if (!link.data('bs.tooltip')) {
+            link.tooltip(tooltipOptions);
+          }
+          link.tooltip('show');
+        }, function(evt) {
+          $(evt.target).tooltip('hide');
+        }, tooltipOptions.selector);
+
+        elt.find('.ga-bg-layer-bt').on('click', scope.toggleMenu);
       }
-  );
+    };
+  });
 })();

--- a/src/components/backgroundselector/partials/backgroundselector.html
+++ b/src/components/backgroundselector/partials/backgroundselector.html
@@ -9,4 +9,4 @@
   <div class="ga-bg-layer-bt-text" translate>bg_chooser_label</div>
   <button class="ga-icon ga-btn fa fa-user" ng-click="showWarning()" ng-show="!!styleUrl"></button>
   <i class="fa fa-chevron-sign-right"></i>
-</div> 
+</div>

--- a/src/components/backgroundselector/partials/backgroundselector.html
+++ b/src/components/backgroundselector/partials/backgroundselector.html
@@ -3,8 +3,10 @@
      class="ga-bg-layer ga-bg-layer-{{$index}} {{getClass(layer)}}"
      translate-attr="{title: layer.label}">
   <div class="ga-bg-layer-text" translate>{{layer.label}}</div>
+  <button class="ga-icon ga-btn fa fa-user" ng-click="showWarning(layer)" ng-show="!!layer.styleUrl"></button>
 </div>
 <div class="ga-bg-layer-bt" translate-attr="{title: 'bg_toggle'}">
   <div class="ga-bg-layer-bt-text" translate>bg_chooser_label</div>
+  <button class="ga-icon ga-btn fa fa-user" ng-click="showWarning()" ng-show="!!styleUrl"></button>
   <i class="fa fa-chevron-sign-right"></i>
 </div> 

--- a/src/components/backgroundselector/style/backgroundselector.less
+++ b/src/components/backgroundselector/style/backgroundselector.less
@@ -169,6 +169,7 @@
     font-size: 1.8em;
     @media (max-width: @screen-tablet) {
       font-size: 1.1rem;
+      right:  3px;
     }
   }
 }

--- a/src/components/backgroundselector/style/backgroundselector.less
+++ b/src/components/backgroundselector/style/backgroundselector.less
@@ -153,6 +153,21 @@
       .transformHorizontal(0);
     }
   }
+
+  &.ga-open .ga-bg-layer-bt {
+    button.fa-user {
+      display: none;
+    }
+  }
+  .fa-user {
+    float: right;
+    color: red;
+    top: 3px;
+    font-size: 1.8em;
+    @media (max-width: @screen-tablet) {
+      font-size: 1.1rem;
+    }
+  }
 }
 
 .ga-3d-active {

--- a/src/components/backgroundselector/style/backgroundselector.less
+++ b/src/components/backgroundselector/style/backgroundselector.less
@@ -157,6 +157,9 @@
   &.ga-open .ga-bg-layer-bt {
     button.fa-user {
       display: none;
+      @media (max-width: @screen-tablet) {
+        display: block;
+      }
     }
   }
   .fa-user {

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -350,7 +350,6 @@ goog.require('ga_urlutils_service');
                     'ch.swissnames3d.vt'
                   ],
                   styleUrl: 'https://tileserver.dev.bgdi.ch/styles/ch.swisstopo.hybridkarte.vt_1539954688_e92c5b623257c5fafe1594ce4a0a72e0c08b0d80/style.json'
-
                 };
                 response.data['ch.swisstopo.leichte-basiskarte.vt'] = {
                   type: 'aggregate',
@@ -376,7 +375,6 @@ goog.require('ga_urlutils_service');
                   ],
                   styleUrl: 'https://tileserver.dev.bgdi.ch/styles/ch.swisstopo.wandern.vt_1539954688_e92c5b623257c5fafe1594ce4a0a72e0c08b0d80/style.json'
                 };
-
               }
 
             }
@@ -585,11 +583,12 @@ goog.require('ga_urlutils_service');
          * Return an ol.layer.Layer object for a layer id.
          */
         this.getOlLayerById = function(bodId, opts) {
+          var olLayer, styleUrl;
           var config = layers[bodId];
-          var olLayer;
           var timestamp = this.getLayerTimestampFromYear(bodId, gaTime.get());
           var crossOrigin = 'anonymous';
           var extent = config.extent || gaMapUtils.defaultExtent;
+          opts = opts || {};
 
           // The tileGridMinRes is the resolution at which the client
           // zoom is activated. It's different from the config.minResolution
@@ -742,13 +741,9 @@ goog.require('ga_urlutils_service');
                     return olSource.getFeatures();
                   });
                 });
-            var styleUrl;
-            if (opts && opts.externalStyleUrl &&
-                gaUrlUtils.isValid(opts.externalStyleUrl)) {
-              styleUrl = opts.externalStyleUrl;
-            } else {
-              styleUrl = $window.location.protocol + config.styleUrl;
-            }
+
+            styleUrl = gaUrlUtils.resolveStyleUrl(
+                config.styleUrl, opts.externalStyleUrl);
             // IE doesn't understand agnostic URLs
             stylePromises[bodId] = gaUrlUtils.proxifyUrl(styleUrl).
                 then(function(proxyStyleUrl) {
@@ -778,17 +773,11 @@ goog.require('ga_urlutils_service');
               });
             }
 
-            var styleUrl2 = config.styleUrl;
-            if (opts && opts.externalStyleUrl &&
-                gaUrlUtils.isValid(opts.externalStyleUrl)) {
-              styleUrl2 = opts.externalStyleUrl;
-            } else if (/^\/\//.test(styleUrl2)) {
-              styleUrl2 = $window.location.protocol + config.styleUrl;
-            }
-
-            if (config.sourceId && styleUrl2) {
+            styleUrl = gaUrlUtils.resolveStyleUrl(
+                config.styleUrl, opts.externalStyleUrl);
+            if (config.sourceId && styleUrl) {
               var sourceId = config.sourceId;
-              gaGLStyle.get(styleUrl2).then((data) => {
+              gaGLStyle.get(styleUrl).then((data) => {
                 var glStyle = data.style;
                 var spriteData = data.sprite;
                 var spriteUrl = glStyle.sprite + '.png';

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -399,5 +399,42 @@ describe('ga_urlutils_service', function() {
         expect(urls[3]).to.be('wms3.geo.admin.ch');
       });
     });
+
+    describe('#resolveStyleUrl', function() {
+      it('uses the external style url if valid', function() {
+        var styleUrl = 'https://toto.admin.ch/style.json';
+        var externalUrl = 'https://externalstyle.json';
+        var url = gaUrlUtils.resolveStyleUrl(styleUrl, externalUrl);
+        expect(url).to.equal(externalUrl);
+      });
+
+      it('adds protocol to agnostic external style url', function() {
+        var styleUrl = 'https://toto.admin.ch/style.json';
+        var externalUrl = '//externalstyle.json';
+        var url = gaUrlUtils.resolveStyleUrl(styleUrl, externalUrl);
+        expect(url).to.equal('http:' + externalUrl);
+      });
+
+      it('uses the base style url if external style is undefined', function() {
+        var styleUrl = 'https://toto.admin.ch/style.json';
+        var externalUrl = undefined;
+        var url = gaUrlUtils.resolveStyleUrl(styleUrl, externalUrl);
+        expect(url).to.equal(styleUrl);
+      });
+
+      it('uses the base style url if external style is not valid', function() {
+        var styleUrl = 'https://toto.admin.ch/style.json';
+        var externalUrl = 'invalid_url';
+        var url = gaUrlUtils.resolveStyleUrl(styleUrl, externalUrl);
+        expect(url).to.equal(styleUrl);
+      });
+
+      it('adds to protocol to base style url if agnostic', function() {
+        var styleUrl = '//toto.admin.ch/style.json';
+        var externalUrl = undefined;
+        var url = gaUrlUtils.resolveStyleUrl(styleUrl, externalUrl);
+        expect(url).to.equal('http:' + styleUrl);
+      });
+    });
   });
 });

--- a/test/specs/UrlUtilsService.spec.js
+++ b/test/specs/UrlUtilsService.spec.js
@@ -417,7 +417,7 @@ describe('ga_urlutils_service', function() {
 
       it('uses the base style url if external style is undefined', function() {
         var styleUrl = 'https://toto.admin.ch/style.json';
-        var externalUrl = undefined;
+        var externalUrl;
         var url = gaUrlUtils.resolveStyleUrl(styleUrl, externalUrl);
         expect(url).to.equal(styleUrl);
       });
@@ -431,7 +431,7 @@ describe('ga_urlutils_service', function() {
 
       it('adds to protocol to base style url if agnostic', function() {
         var styleUrl = '//toto.admin.ch/style.json';
-        var externalUrl = undefined;
+        var externalUrl;
         var url = gaUrlUtils.resolveStyleUrl(styleUrl, externalUrl);
         expect(url).to.equal('http:' + styleUrl);
       });


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>

@davidoesch Do you want to put an alert window for custom styles like in the layers manager? If yes please define the text. It will probably be a little annoying on small screen to have an alert message. We can deactivate it if needed.

yes: alert window  like in style manager
- [x] Desktop alert window activated when clicking on the  red man in the bg switcher
- [x] Mobile (touch screens)  alert window activated only when touch&hold on the  bg switcher. if possible
- [x] Text use exisiting "msgid external_data_warning" "Warning: Third party data and/or style shown (--URL--). Availability is ensured by third party data provider. The terms and conditions of the third party data owner do apply and have to be respected."
- [x] Mouseover Desktop on icon: use existing msgid "external_data_tooltip" Dataset and/or style provided by third party


@oterral review, small refactoring to resolve style url, it was ugly.

[Test Link with custom BG](https://mf-geoadmin3.int.bgdi.ch/third_party/index.html?lang=fr&topic=are&bgLayer=omt.vt&E=2568726.58&N=1142792.88&zoom=10&catalogNodes=954,959,965&bgLayer_styleUrl=https:%2F%2Frawgit.com%2Fopenmaptiles%2Fosm-bright-gl-style%2Fmaster%2Fstyle.json)

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/third_party/index.html)</jenkins>