### PR TITLE
[MVT] Use editConfig and remove binding to glStyle

### DIFF
--- a/src/components/GlStyleService.js
+++ b/src/components/GlStyleService.js
@@ -84,7 +84,7 @@ goog.provide('ga_glstyle_service');
                 var editLayerProperty = layer[editPropertyName];
                 if (editLayerProperty &&
                     editLayerProperty === editPropertyValue) {
-                  var editStyle = edit[2].split('|');
+                  var editStyle = edit[2];
                   if (!layer[editStyle[0]]) {
                     layer[editStyle[0]] = {};
                   }

--- a/src/components/backgroundselector/BackgroundService.js
+++ b/src/components/backgroundselector/BackgroundService.js
@@ -35,14 +35,6 @@ goog.require('ga_glstylestorage_service');
           disable3d: true
           // labels: false
         },
-        /*
-        'ch.swisstopo.wandern.vt': {
-          id: 'ch.swisstopo.wandern.vt',
-          label: 'wandern',
-          disable3d: true,
-          labels: false
-        },
-        */
         'ch.swisstopo.leichte-basiskarte.vt': {
           id: 'ch.swisstopo.leichte-basiskarte.vt',
           label: 'basis',
@@ -58,25 +50,11 @@ goog.require('ga_glstylestorage_service');
       };
 
       var predefinedBgs = {
-        /*
-        'voidLayer': voidLayer,
-        'ch.swisstopo.swissimage': {
-          id: 'ch.swisstopo.swissimage',
-          label: 'bg_luftbild',
-          disable3d: true,
-          labels: false// 'SWISSNAMES-LV03-mbtiles'
-        },
-        */
-
         'ch.swisstopo.pixelkarte-farbe': {
           id: 'ch.swisstopo.pixelkarte-farbe',
-          label: 'bg_pixel_color'
+          label: 'bg_pixel_color',
+          disableEdit: true
         }
-
-        /* 'ch.swisstopo.pixelkarte-grau': {
-          id: 'ch.swisstopo.pixelkarte-grau',
-          label: 'bg_pixel_grey'
-        } */
       };
       var getBgById = function(id) {
         for (var i = 0, ii = bgs.length; i < ii; i++) {

--- a/src/components/backgroundselector/partials/backgroundselector.html
+++ b/src/components/backgroundselector/partials/backgroundselector.html
@@ -9,6 +9,7 @@
   <button class="ga-icon ga-btn fa fa-ga-mapfunction"
           ng-click="toggleEdit(layer)"
           ng-class="{'active': layer.id === activeEditLayerId }"
+          ng-hide="layer.disableEdit"
           translate-attr="{title: 'open_edit_bt_title'}">
   </button>
 </div>

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -350,6 +350,12 @@ goog.require('ga_urlutils_service');
                       'road_major_label',
                       'place_label_city'
                     ],
+                    labelsFilters: [
+                      ['source-layer', '==', 'place'],
+                      ['source-layer', '==', 'transportation_name'],
+                      ['source-layer', '==', 'aerodrome_label'],
+                      ['source-layer', '==', 'poi']
+                    ],
                     'landuse-residential': [
                       ['paint', 'fill-color', '{color}'],
                       ['paint', 'fill-opacity', '{opacity}']
@@ -387,7 +393,8 @@ goog.require('ga_urlutils_service');
                     selectableLayers: [
                       'cities',
                       'highways'
-                    ]
+                    ],
+                    labelsFilters: [['source', '==', 'ch.swissnames3d']]
                   }
                 };
                 response.data['ch.swisstopo.leichte-basiskarte.vt'] = {
@@ -407,25 +414,8 @@ goog.require('ga_urlutils_service');
                     selectableLayers: [
                       'background', 'lakes', 'rivers',
                       'build_area', 'highways', 'forests'
-                    ]
-                  }
-                };
-                response.data['ch.swisstopo.wandern.vt'] = {
-                  type: 'aggregate',
-                  background: true,
-                  serverLayerName: 'ch.swisstopo.wandern.vt',
-                  subLayersIds: [
-                    'ch.bak.bundesinventar-schuetzenswerte-ortsbilder.vt',
-                    'ch.astra.wanderland.vt',
-                    'ch.swisstopo.swisstlm3d-wanderwege.vt'
-                  ],
-                  styleUrl: 'https://tileserver.dev.bgdi.ch/styles/ch.swisstopo.wandern.vt_1539954688_e92c5b623257c5fafe1594ce4a0a72e0c08b0d80/style.json',
-                  editConfig: {
-                    selectableLayers: [
-                      'route_local',
-                      'route_regional',
-                      'route_national'
-                    ]
+                    ],
+                    labelsFilters: [['source', '==', 'ch.swissnames3d']]
                   }
                 };
               }

--- a/src/components/map/MapUtilsService.js
+++ b/src/components/map/MapUtilsService.js
@@ -493,7 +493,7 @@ goog.require('ga_urlutils_service');
         /**
          * Applies a gl style to an ol layer
          */
-        applyGlStyleToOlLayer: function(olLayer, glStyle) {
+        applyGlStyleToOlLayer: function(olLayer, glStyle, noBind) {
           if (!olLayer || !glStyle) {
             return;
           }
@@ -504,7 +504,9 @@ goog.require('ga_urlutils_service');
             layers.forEach(function(subOlLayer) {
               that.applyGlStyleToOlLayer(subOlLayer, glStyle);
             })
-            olLayer.glStyle = glStyle;
+            if (!noBind) {
+              olLayer.glStyle = glStyle;
+            }
             return;
           }
 

--- a/src/components/vectorfeedback/VectorFeedbackDirective.js
+++ b/src/components/vectorfeedback/VectorFeedbackDirective.js
@@ -45,13 +45,13 @@ goog.require('ga_maputils_service');
             for (var i = 0; i < edit.length; i++) {
               if (edit[i][2] === '{color}') {
                 edits.push([
-                    'id',
-                    selectedLayer,
-                    [edit[i][0], edit[i][1], color]]);
+                  'id',
+                  selectedLayer,
+                  [edit[i][0], edit[i][1], color]]);
               }
             }
             gaMapUtils.applyGlStyleToOlLayer(
-                gaMapUtils.getMapBackgroundLayer(map),
+                scope.options.backgroundLayer.olLayer,
                 gaGlStyle.edit(edits),
                 true // don't bind to olLayer
             );
@@ -64,7 +64,7 @@ goog.require('ga_maputils_service');
                 if (newVal && oldVal && newVal !== oldVal) {
                   scope.options.activeColor = '';
                   gaMapUtils.applyGlStyleToOlLayer(
-                      gaMapUtils.getMapBackgroundLayer(map),
+                      scope.options.backgroundLayer.olLayer,
                       gaGlStyle.resetEdits(),
                       true // don't bind to olLayer
                   );
@@ -74,7 +74,7 @@ goog.require('ga_maputils_service');
 
         var registerBackgroundLayerWatcher = function() {
           return scope.$watch('options.backgroundLayer', function(newVal) {
-            var olLayer = gaMapUtils.getMapBackgroundLayer(map);
+            var olLayer = scope.options.backgroundLayer;
             // Dropdown interaction
             if (olLayer && olLayer.bodId !== newVal.id) {
               gaBackground.setById(map, newVal.id);
@@ -97,7 +97,7 @@ goog.require('ga_maputils_service');
                 }
               }
               gaMapUtils.applyGlStyleToOlLayer(
-                  gaMapUtils.getMapBackgroundLayer(map),
+                  scope.options.backgroundLayer.olLayer,
                   glStyle,
                   true // don't bind to olLayer
               );
@@ -133,36 +133,36 @@ goog.require('ga_maputils_service');
 
         var removeInitialize = scope.$watch('options.initialize',
             function(newVal) {
-          if (newVal) {
-            // Syncronize both background selectors
-            scope.$on('gaBgChange', function(evt, value) {
-              var layer = gaLayers.getLayer(value.id);
-              if (layer) {
-                dereg();
-                // Sync the dropdown select
-                scope.options.backgroundLayers.forEach(function(bg) {
-                  if (bg.id === value.id) {
-                    scope.options.backgroundLayer = bg;
+              if (newVal) {
+                // Syncronize both background selectors
+                scope.$on('gaBgChange', function(evt, value) {
+                  var layer = gaLayers.getLayer(value.id);
+                  if (layer) {
+                    dereg();
+                    // Sync the dropdown select
+                    scope.options.backgroundLayers.forEach(function(bg) {
+                      if (bg.id === value.id) {
+                        scope.options.backgroundLayer = bg;
+                      }
+                    });
+                    // Update the list of selectable layers according to the
+                    // current bg layer
+                    var editConfig = layer.editConfig;
+                    var hasSelectableLayers = editConfig &&
+                    editConfig.selectableLayers;
+                    scope.options.selectedLayer = hasSelectableLayers ?
+                      editConfig.selectableLayers[0] : null;
+                    // Reset labels filters
+                    scope.options.showLabel = scope.options.showLabels[0];
+                    // Reset any color that was applied
+                    scope.options.activeColor = null;
+                    reg();
                   }
                 });
-                // Update the list of selectable layers according to the
-                // current bg layer
-                var editConfig = layer.editConfig;
-                var hasSelectableLayers = editConfig &&
-                    editConfig.selectableLayers;
-                scope.options.selectedLayer = hasSelectableLayers ?
-                    editConfig.selectableLayers[0] : null;
-                // Reset labels filters
-                scope.options.showLabel = scope.options.showLabels[0];
-                // Reset any color that was applied
-                scope.options.activeColor = null;
                 reg();
+                removeInitialize();
               }
             });
-            reg();
-            removeInitialize();
-          }
-        });
 
         scope.$on('gaToggleEdit', function(evt, layer) {
           element.find('#ga-feedback-vector-body').collapse('hide');

--- a/src/components/vectorfeedback/VectorFeedbackDirective.js
+++ b/src/components/vectorfeedback/VectorFeedbackDirective.js
@@ -53,7 +53,7 @@ goog.require('ga_maputils_service');
             gaMapUtils.applyGlStyleToOlLayer(
                 gaMapUtils.getMapBackgroundLayer(map),
                 gaGlStyle.edit(edits),
-                true // don't bin to olLayer
+                true // don't bind to olLayer
             );
           }
         };
@@ -66,7 +66,7 @@ goog.require('ga_maputils_service');
                   gaMapUtils.applyGlStyleToOlLayer(
                       gaMapUtils.getMapBackgroundLayer(map),
                       gaGlStyle.resetEdits(),
-                      true // don't bin to olLayer
+                      true // don't bind to olLayer
                   );
                 }
               });
@@ -131,8 +131,8 @@ goog.require('ga_maputils_service');
           }
         };
 
-
-        var removeInitialize = scope.$watch('options.initialize', function(newVal) {
+        var removeInitialize = scope.$watch('options.initialize',
+            function(newVal) {
           if (newVal) {
             // Syncronize both background selectors
             scope.$on('gaBgChange', function(evt, value) {
@@ -148,7 +148,8 @@ goog.require('ga_maputils_service');
                 // Update the list of selectable layers according to the
                 // current bg layer
                 var editConfig = layer.editConfig;
-                var hasSelectableLayers = editConfig && editConfig.selectableLayers;
+                var hasSelectableLayers = editConfig &&
+                    editConfig.selectableLayers;
                 scope.options.selectedLayer = hasSelectableLayers ?
                     editConfig.selectableLayers[0] : null;
                 // Reset labels filters

--- a/src/components/vectorfeedback/VectorFeedbackDirective.js
+++ b/src/components/vectorfeedback/VectorFeedbackDirective.js
@@ -139,24 +139,27 @@ goog.require('ga_maputils_service');
                   var layer = gaLayers.getLayer(value.id);
                   if (layer) {
                     dereg();
-                    // Sync the dropdown select
-                    scope.options.backgroundLayers.forEach(function(bg) {
-                      if (bg.id === value.id) {
-                        scope.options.backgroundLayer = bg;
-                      }
+                    // Reset service cache
+                    gaGlStyle.get(layer.styleUrl).then(function() {
+                      // Sync the dropdown select
+                      scope.options.backgroundLayers.forEach(function(bg) {
+                        if (bg.id === value.id) {
+                          scope.options.backgroundLayer = bg;
+                        }
+                      });
+                      // Update the list of selectable layers according to the
+                      // current bg layer
+                      var editConfig = layer.editConfig;
+                      var hasSelectableLayers = editConfig &&
+                      editConfig.selectableLayers;
+                      scope.options.selectedLayer = hasSelectableLayers ?
+                        editConfig.selectableLayers[0] : null;
+                      // Reset labels filters
+                      scope.options.showLabel = scope.options.showLabels[0];
+                      // Reset any color that was applied
+                      scope.options.activeColor = null;
+                      reg();
                     });
-                    // Update the list of selectable layers according to the
-                    // current bg layer
-                    var editConfig = layer.editConfig;
-                    var hasSelectableLayers = editConfig &&
-                    editConfig.selectableLayers;
-                    scope.options.selectedLayer = hasSelectableLayers ?
-                      editConfig.selectableLayers[0] : null;
-                    // Reset labels filters
-                    scope.options.showLabel = scope.options.showLabels[0];
-                    // Reset any color that was applied
-                    scope.options.activeColor = null;
-                    reg();
                   }
                 });
                 reg();

--- a/src/components/vectorfeedback/partials/vectorfeedback.html
+++ b/src/components/vectorfeedback/partials/vectorfeedback.html
@@ -20,7 +20,7 @@
             <div class="ga-vector-feedback-item-select-wrapper">
                 <select class="form-control"
                         ng-model="options.selectedLayer"
-                        ng-options="c.label for c in options.layers[options.backgroundLayer.id].selectableLayers track by c.value">
+                        ng-options="c for c in options.layers[options.backgroundLayer.id].selectableLayers">
                 </select>
             </div>
         </div>

--- a/src/components/vectorfeedback/partials/vectorfeedback.html
+++ b/src/components/vectorfeedback/partials/vectorfeedback.html
@@ -20,6 +20,7 @@
             <div class="ga-vector-feedback-item-select-wrapper">
                 <select class="form-control"
                         ng-model="options.selectedLayer"
+                        ng-disabled="!options.selectedLayer"
                         ng-options="c for c in options.layers[options.backgroundLayer.id].selectableLayers">
                 </select>
             </div>
@@ -32,11 +33,13 @@
                         ng-click="applyColor(c.value)"
                         ng-class="options.activeColor === c.value ? 'active-color' : ''"
                         ng-style="{'background-color': c.value}"
+                        ng-disabled="!options.selectedLayer"
                         class="ga-vector-feedback-color-button"></button>
             </div>
             <div ng-if="options.mobile" class="ga-vector-feedback-item-select-wrapper">
                 <select class="form-control ga-vector-feedback-colors"
                         ng-model="options.activeColor"
+                        ng-disabled="!options.selectedLayer"
                         ng-options="c.label for c in options.colors track by c.value">
                 </select>
             </div>
@@ -47,6 +50,7 @@
             <div class="ga-vector-feedback-item-select-wrapper">
                 <select class="form-control ga-vector-feedback-colors"
                         ng-model="options.showLabel"
+                        ng-disabled="!options.selectedLayer"
                         ng-options="c.label for c in options.showLabels track by c.value">
                 </select>
             </div>

--- a/src/components/vectorfeedback/style/vectorfeedback.less
+++ b/src/components/vectorfeedback/style/vectorfeedback.less
@@ -146,6 +146,10 @@
   @media (max-width: @screen-tablet), (max-height: @screen-m-height) {
     width: 37px;
   }
+  &[disabled] {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
 }
 
 a.ga-feedback-survey-link {

--- a/src/js/VectorFeedbackController.js
+++ b/src/js/VectorFeedbackController.js
@@ -48,7 +48,7 @@ goog.require('ga_layers_service');
     // Load the edit config from layersConfig
     var removeListener = $scope.$on('gaBgChange', function(evt, value) {
       $scope.options.backgroundLayers = gaBackground.getBackgrounds();
-      $scope.options.backgroundLayers.forEach(function(bg){
+      $scope.options.backgroundLayers.forEach(function(bg) {
         var layerConfig = gaLayers.getLayer(bg.id);
         layers[bg.id] = layerConfig.editConfig;
       });

--- a/test/specs/GlStyleService.spec.js
+++ b/test/specs/GlStyleService.spec.js
@@ -191,7 +191,7 @@ describe('ga_glstyle_service', function() {
   it('edits a GL style #edit', function(done) {
     $httpBackend.expectGET(styleUrl).respond(styleJSON);
     gaGlStyle.get(styleUrl).then(function() {
-      var newStyle = gaGlStyle.edit([['id', 'background', 'paint|background-color|blue']])
+      var newStyle = gaGlStyle.edit([['id', 'background', ['paint', 'background-color', 'blue']]])
       expect(newStyle.layers[0].id).to.equal('background');
       expect(newStyle.layers[0].paint['background-color']).to.equal('blue');
       expect(newStyle.layers[1].paint['background-color']).to.be(undefined);
@@ -206,7 +206,7 @@ describe('ga_glstyle_service', function() {
       // Add a filter
       var newStyle = gaGlStyle.filter([['id', '==', 'labels_watercourse']]);
       // Add an edition
-      newStyle = gaGlStyle.edit([['id', 'background', 'paint|background-color|blue']]);
+      newStyle = gaGlStyle.edit([['id', 'background', ['paint', 'background-color', 'blue']]]);
 
       newStyle = gaGlStyle.resetFilters();
       expect(newStyle.layers.length).to.equal(4);
@@ -224,7 +224,7 @@ describe('ga_glstyle_service', function() {
       // Add a filter
       var newStyle = gaGlStyle.filter([['id', '==', 'labels_watercourse']]);
       // Add an edition
-      newStyle = gaGlStyle.edit([['id', 'background', 'paint|background-color|blue']]);
+      newStyle = gaGlStyle.edit([['id', 'background', ['paint', 'background-color', 'blue']]]);
 
       newStyle = gaGlStyle.resetEdits();
       expect(newStyle.layers.length).to.equal(3);

--- a/test/specs/vectorfeedback/VectorFeedbackDirective.spec.js
+++ b/test/specs/vectorfeedback/VectorFeedbackDirective.spec.js
@@ -3,6 +3,7 @@ describe('ga_vector_feedback_directive', function() {
   var $rootScope,
     $compile,
     $httpBackend,
+    $q,
     scope,
     el,
     map,
@@ -41,6 +42,7 @@ describe('ga_vector_feedback_directive', function() {
     $rootScope = $injector.get('$rootScope');
     $compile = $injector.get('$compile');
     $httpBackend = $injector.get('$httpBackend');
+    $q = $injector.get('$q');
   };
 
   beforeEach(function() {
@@ -72,22 +74,22 @@ describe('ga_vector_feedback_directive', function() {
       });
 
       spyGet = sinon.spy(function() {
-        return { style: {}, sprite: {} };
+        return $q.when();
       });
       spyFilter = sinon.spy(function() {
-        return { style: {}, sprite: {} };
+        return {};
       });
       spyEdit = sinon.spy(function() {
-        return { style: {}, sprite: {} };
+        return {};
       });
       spyResetFilters = sinon.spy(function() {
-        return { style: {}, sprite: {} };
+        return {};
       });
       spyResetEdits = sinon.spy(function() {
-        return { style: {}, sprite: {} };
+        return {};
       });
       spyGetLayer = sinon.spy(function() {
-        return { editConfig: editConfig };
+        return { editConfig: editConfig, styleUrl: 'https://style.ch' };
       });
       $provide.value('gaLayers', {
         getLayer: spyGetLayer


### PR DESCRIPTION
With https://github.com/geoadmin/mf-geoadmin3/pull/4550 and the persistence of olLayer and glStyle we introduced a couple of bugs.

I also thought it made sense to use the `editConfig` to avoid duplicating data everywhere you just added @oterral.
I also added the labelsFilters to editConfig.

List of bugs it solves:

**A**

1. Open test viewer
2. Change background to Pixelkartefarbe
3. Reload the page

Result:
Pixelkartefarbe is not selected in the feedback panel

Expected Result:
Pixelkartefarbe is selected

**B**

1. Open test viewer
2. Select Pixelkartefarbe in the background selector

Result:
Feedback panel is not synchronized with background selector

Expected Result:
Feedback panel is synchronized and vector features are disabled

**C**

1. Open test viewer
2. Select a color in the feedback panel
3. Reload the page

Result:
Color is still visible

Expected Result:
Color is not visible anymore (e.g. style is not saved)

My understanding is that we don't make any permanent change in the feedback panel. I may be wrong.
I am not sure about C. Maybe, it would make more sense to synchronize the styles entirely.
Because if you edit the style again in the feedback panel after editing it in the advanced edit mode and you reload, well now you see the last style you edited in the advance mode....
Maybe when we re-open the advance mode we should simply re-apply the last style.

ping @davidoesch 

**D**

Disable edit on raster background.

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/feedback_refactor/index.html)</jenkins>