### PR TITLE
install node via nvm for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ LAST_VERSION = $(call lastvalue,version)
 VERSION := $(shell if [ $(KEEP_VERSION) = true ] && [ '$(LAST_VERSION)' != '-none-' ]; then echo '$(LAST_VERSION)'; else date '+%y%m%d%H%M'; fi)
 NAMED_BRANCH ?= true
 DEEP_CLEAN ?= false
+NVM_VERSION ?= v0.33.8
+NODE_VERSION ?= 6.13.1
 
 
 # S3 deploy variables
@@ -203,6 +205,7 @@ help:
 	@echo "Possible targets:"
 	@echo
 	@echo "- user                Build the app using user specific environment variables (see $(USER_SOURCE) file)"
+	@echo "- env                 Install NVM and set the correct node version to build the application"
 	@echo "- all                 Build the app using current environment variables"
 	@echo "- build               Build the app using current environment variables. No linting and testing."
 	@echo "- dev                 Build the app using dev environment variables (see rc_dev file). No linting and testing."
@@ -279,6 +282,13 @@ user:
 
 .PHONY: build
 build: showVariables .build-artefacts/devlibs .build-artefacts/requirements.timestamp $(SRC_JS_FILES) debug release
+
+
+.PHONY: env
+env:
+	curl -o- https://raw.githubusercontent.com/creationix/nvm/$(NVM_VERSION)/install.sh | bash ;\
+	source $(HOME)/.bashrc ;\
+	nvm install $(NODE_VERSION)
 
 .PHONY: dev
 dev:

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ showVariables:
 all: showVariables lint debug release apache testdebug testrelease fixrights
 
 .PHONY: user
-user:
+user: env
 	source $(USER_SOURCE) && make all
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ endif
 
 .PHONY: env
 env: .build-artefacts/nvm-version .build-artefacts/node-version
-
+	source $(HOME)/.bashrc && nvm use $(NODE_VERSION)
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
This PR add a `make env` target, which installs `nvm` and uses it to install `node`. Both versions of nvm and node can be specified in environment variables `NVM_VERSION` and `NODE_VERSION`, but have default (tested) values in `Makefile`.
The `env` target is set as a dependency for `make user` target to ease the process so that we always only need to build our user environment and it works.


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbon_add_node_nvm/index.html)</jenkins>