### PR TITLE
Do not make WMTS visible if it should not be visible

### DIFF
--- a/src/components/map/WmtsService.js
+++ b/src/components/map/WmtsService.js
@@ -214,7 +214,8 @@ goog.require('ga_urlutils_service');
               layerIdentifier, options.capabilitiesUrl);
           if (layerOptions) {
             layerOptions.opacity = options.opacity || 1;
-            layerOptions.visible = options.visible || true;
+            layerOptions.visible = options.visible === false ?
+              options.visible : true;
             return createWmtsLayer(layerOptions);
           }
         };

--- a/src/components/map/WmtsService.js
+++ b/src/components/map/WmtsService.js
@@ -214,8 +214,7 @@ goog.require('ga_urlutils_service');
               layerIdentifier, options.capabilitiesUrl);
           if (layerOptions) {
             layerOptions.opacity = options.opacity || 1;
-            layerOptions.visible = options.visible === false ?
-              options.visible : true;
+            layerOptions.visible = options.visible && true;
             return createWmtsLayer(layerOptions);
           }
         };


### PR DESCRIPTION

[Test link mit WMTS](https://mf-geoadmin3.int.bgdi.ch/fix_4587/index.html?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&zoom=7&Y=694000&X=168000&layers=WMTS%7C%7CAvalancheATHM%7C%7Chttps:%2F%2Fmap.skitourenguru.ch%2FATHM_GetCapabilities.xml&layers_opacity=0.3&layers_visibility=false) Should open with a layer Avalanche hazard in the catalogue but it should not already be active.

See  #4587


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/fix_4587/index.html)</jenkins>