### PR TITLE
Allow commas in WMS layer title

### DIFF
--- a/src/components/map/PermalinkLayersService.js
+++ b/src/components/map/PermalinkLayersService.js
@@ -47,6 +47,9 @@ goog.require('ga_wmts_service');
         gaVector, gaMapUtils, gaWms, gaLayerFilters, gaUrlUtils, gaFileStorage,
         gaTopic, gaGlobalOptions, $q, gaTime, $log, $http, gaWmts) {
 
+      // split by commas only not between || (WMS layers) (see #4592)
+      const splitLayerPattern = /,(?![^|]* )/g;
+
       var layersParamValue = gaPermalink.getParams().layers;
       var layersOpacityParamValue = gaPermalink.getParams().layers_opacity;
       var layersParamsValue = gaPermalink.getParams().layers_params;
@@ -57,7 +60,8 @@ goog.require('ga_wmts_service');
       var layersStyleUrlParamValue =
           gaPermalink.getParams().layers_styleurl;
 
-      var layerSpecs = layersParamValue ? layersParamValue.split(',') : [];
+      var layerSpecs = layersParamValue ?
+        layersParamValue.split(splitLayerPattern) : [];
       var layerOpacities = layersOpacityParamValue ?
         layersOpacityParamValue.split(',') : [];
       var layerParams = layersParamsValue ?


### PR DESCRIPTION
[Test lin with WMS layer having a lengthy title](https://mf-geoadmin3.int.bgdi.ch/fix_4592/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,WMS%7C%7CSatellitenbild,%20METEOSAT,%20RGB,%20bereinigt%20um%20Schnee,%20Eis%20und%20Nebel,%20reines%20Wolkenbild,%203%20st%C3%BCndige%20Auflieferung%7C%7Chttps:%2F%2Fmaps.dwd.de%2Fgeoproxy%2Fservice%3F%7C%7CSAT_EU_central_RGB_cloud%7C%7C1.3.0%7C%7Ctrue&E=2699212.50&N=1198625.00&zoom=2&layers_timestamp=18641231,,,)

For instance, a WMS layer may be defined as:

    WMS||Satellitenbild, METEOSAT, RGB, bereinigt um Schnee, Eis und Nebel, reines Wolkenbild, 3 stündige Auflieferung||https://maps.dwd.de/geoproxy/service?||SAT_EU_central_RGB_cloud||1.3.0||true

See #4592 


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/fix_4592/index.html)</jenkins>