### PR TITLE
Fix #4484 (3d camera terrain collision)

### DIFF
--- a/src/components/controls3d/fps.js
+++ b/src/components/controls3d/fps.js
@@ -348,27 +348,31 @@ FPS.prototype.getTimeDifference_ = function() {
  * @return {!Cesium.Cartesian3}
  * @private
  */
-FPS.prototype.clampAboveTerrain_ = function(gpos, minHeight, optMaxHeight, cameraHeading) {
+FPS.prototype.clampAboveTerrain_ = function(gpos, minHeight, optMaxHeight, 
+  cameraHeading) {
   var lla = this.ellipsoid_.cartesianToCartographic(gpos),
       lla25MetersAhead = this.ellipsoid_.cartesianToCartographic(gpos);
   // projecting 25m ahead in the camera direction to check altitude
+  // 111.111km is a rough estimate of kilometers per 1 deg of latitude
   lla25MetersAhead.latitude = lla.latitude 
-                              + 0.025 / 111.111            // 111.111km is a rought estimate of kilometer per 1 deg on lat
-                                * Math.PI / 180.0          // transform result to rad
-                                * Math.cos(cameraHeading); // taking camera heading into considaration
+                              + 0.025 / 111.111 * Math.PI / 180.0 
+                                * Math.cos(cameraHeading);
+  // we have to take latitude into account for the km/deg estimate on longitude
   lla25MetersAhead.longitude = lla.longitude
-                              + 0.025 * Math.cos(lla.latitude) / 111.111 // meter per deg on lon (depends on lat)
-                                * Math.PI / 180.0                        // transform result to rad
-                                * Math.sin(cameraHeading);               // taking camera heading into considaration
+                              + 0.025 * Math.cos(lla.latitude) / 111.111
+                                * Math.PI / 180.0
+                                * Math.sin(cameraHeading);
   var groundAlt = Cesium.defaultValue(this.scene_.globe.getHeight(lla), 0.0),
-      groundAlt25MetersAhead = Cesium.defaultValue(this.scene_.globe.getHeight(lla25MetersAhead), 0.0);
+      groundAlt25MetersAhead = Cesium.defaultValue(this.scene_.globe.getHeight(
+        lla25MetersAhead), 0.0);
   if (lla.height - groundAlt < minHeight) {
     lla.height = groundAlt + minHeight;
   }
   if (optMaxHeight && (lla.height - groundAlt > optMaxHeight)) {
     lla.height = groundAlt + optMaxHeight;
   }
-  // if height set is below altitude 25m ahead, we raise the camera height to avoid terrain collision
+  // if height set is below altitude 25m ahead, we raise the camera height 
+  // to avoid terrain collision
   if (lla.height < groundAlt25MetersAhead) {
     lla.height = groundAlt25MetersAhead;
   }


### PR DESCRIPTION
Possible fix for https://github.com/geoadmin/mf-geoadmin3/issues/4484

In 3d pegman, check altitude 25m ahead (in camera direction) and raise the camera height if the camera could see through the terrain because of high slope.
If altitude 25m ahead is above the default height set to the camera, the camera is raised to this altitude.

Please review this thoroughly, as I'm not (yet) aware of possible side effect for this kind of changes.


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/bap_fix_3d_camera_terrain_collision/index.html)</jenkins>