### PR TITLE
Add embedded scroll handling (need testing with iOs)

### DIFF
--- a/src/components/embeddedscroll/EmbeddedScrollDirective.js
+++ b/src/components/embeddedscroll/EmbeddedScrollDirective.js
@@ -9,10 +9,16 @@ goog.provide('ga_embedded_scroll_directive');
   // embedded maps, à la GoogleMaps)
   // see : https://developers.google.com/maps/documentation/embed/guide
   module.directive('gaEmbeddedScrollEventHandler',
-      function($rootScope, $translate, $timeout, $window) {
+      function($rootScope, $translate, $timeout, $window, gaGlobalOptions) {
         return {
           restrict: 'A',
           link: function(scope, element, attrs) {
+            // if embedded but gaGlobalOptions.embeddedWithInteractions is true
+            // we don't attach listeners
+            if (gaGlobalOptions.embeddedWithInteractions) {
+              return;
+            }
+
             var datetimeLastAction = null;
             var hideAfterAWhileIfSameDatetime = function(datetime) {
               // check after 2.5 sec if no other action occured, hide overlay

--- a/src/components/embeddedscroll/EmbeddedScrollDirective.js
+++ b/src/components/embeddedscroll/EmbeddedScrollDirective.js
@@ -1,0 +1,95 @@
+goog.provide('ga_embedded_scroll_directive');
+
+(function() {
+  var module = angular.module('ga_embedded_scroll_directive', []);
+
+  // top level directive (on body or html) that will hook listener for mouse
+  // and touch events. It will trigger another directive (bellow) to show
+  // an overlay with hints for embedded maps (as we limit interaction with
+  // embedded maps, à la GoogleMaps)
+  // see : https://developers.google.com/maps/documentation/embed/guide
+  module.directive('gaEmbeddedScrollEventHandler',
+      function($rootScope, $translate, $timeout, $window) {
+        return {
+          restrict: 'A',
+          link: function(scope, element, attrs) {
+            var datetimeLastAction = null;
+            var hideAfterAWhileIfSameDatetime = function(datetime) {
+              // check after 2.5 sec if no other action occured, hide overlay
+              $timeout(function() {
+                if (!datetimeLastAction || datetimeLastAction === datetime) {
+                  datetimeLastAction = null;
+                  $rootScope.$emit('gaHideEmbeddedOverlay')
+                }
+              }, 2500);
+            };
+            // handling mouse zoom event
+            document.body.addEventListener('wheel', function(event) {
+              if (!event.ctrlKey) {
+                datetimeLastAction = $window.moment();
+                $rootScope.$emit('gaShowEmbeddedOverlay',
+                    $translate.instant('embedded_scroll_hint'));
+                hideAfterAWhileIfSameDatetime(datetimeLastAction);
+              }
+            }, {
+              passive: true,
+              // capturing before the event goes down the DOM
+              capture: true
+            });
+            // when bubbling the ctrl+wheel event, we don't want the webpage
+            // embedding our map to be resized so we need to stop the event
+            // at the iframe level
+            document.body.addEventListener('wheel', function(event) {
+              if (event.ctrlKey) {
+                datetimeLastAction = null;
+                $rootScope.$emit('gaHideEmbeddedOverlay');
+                event.preventDefault();
+                event.stopPropagation();
+                return false;
+              }
+            }, false);
+            // handling touch event (mobile devices)
+            document.body.addEventListener('touchstart', function(touchEvent) {
+              // if one finger gesture, show overlay
+              if (touchEvent.touches.length <= 1) {
+                datetimeLastAction = $window.moment();
+                $rootScope.$emit('gaShowEmbeddedOverlay',
+                    $translate.instant('embedded_touch_hint'));
+                hideAfterAWhileIfSameDatetime(datetimeLastAction);
+              } else {
+                $rootScope.$emit('gaHideEmbeddedOverlay');
+                // preventing two fingers zoom gesture to be transmitted
+                // to embedding parent so that the webpage isn't zoomed
+                touchEvent.preventDefault();
+                return false;
+              }
+            });
+          }
+        };
+      });
+
+  // Simple directive with a on/off piece of HTML that will hint the user
+  // as to how to interact with the embedded map
+  module.directive('gaEmbeddedScrollOverlay', function($rootScope) {
+    return {
+      restrict: 'A',
+      replace: true,
+      templateUrl:
+        'components/embeddedscroll/partials/embedded-scroll-overlay.html',
+      link: function(scope, element, attrs) {
+        $rootScope.$on('gaShowEmbeddedOverlay', function(event, hintMessage) {
+          if (hintMessage) {
+            scope.$apply(function() {
+              scope.hintMessage = hintMessage;
+            })
+          }
+        });
+        $rootScope.$on('gaHideEmbeddedOverlay', function(event) {
+          scope.$apply(function() {
+            scope.hintMessage = null;
+          });
+        })
+      }
+    };
+  });
+})();

--- a/src/components/embeddedscroll/EmbeddedScrollDirective.js
+++ b/src/components/embeddedscroll/EmbeddedScrollDirective.js
@@ -75,7 +75,7 @@ goog.provide('ga_embedded_scroll_directive');
               // to embedding parent so that the webpage isn't zoomed
               touchEvent.preventDefault();
             }, { passive: false, capture: true });
-            window.addEventListener('touchmove', function (touchMoveEvent) {
+            window.addEventListener('touchmove', function(touchMoveEvent) {
               if (!lastTouchWasWithMultipleFingers) {
                 touchMoveEvent.preventDefault();
                 touchMoveEvent.stopPropagation();

--- a/src/components/embeddedscroll/EmbeddedScrollModule.js
+++ b/src/components/embeddedscroll/EmbeddedScrollModule.js
@@ -1,0 +1,9 @@
+goog.provide('ga_embedded_scroll');
+
+goog.require('ga_embedded_scroll_directive');
+
+(function() {
+  angular.module('ga_embedded_scroll', [
+    'ga_embedded_scroll_directive'
+  ]);
+})();

--- a/src/components/embeddedscroll/partials/embedded-scroll-overlay.html
+++ b/src/components/embeddedscroll/partials/embedded-scroll-overlay.html
@@ -1,0 +1,4 @@
+<div class="embedded-scroll" ng-show="hintMessage">
+  <div class="overlay"></div>
+  <div class="hint">{{ hintMessage }}</div>
+</div>

--- a/src/components/embeddedscroll/partials/embedded-scroll-overlay.html
+++ b/src/components/embeddedscroll/partials/embedded-scroll-overlay.html
@@ -1,4 +1,6 @@
 <div class="embedded-scroll" ng-show="hintMessage">
   <div class="overlay"></div>
-  <div class="hint">{{ hintMessage }}</div>
+  <div class="hint">
+    <div class="valign">{{ hintMessage }}</div>
+  </div>
 </div>

--- a/src/components/embeddedscroll/style/embedded-scroll-overlay.less
+++ b/src/components/embeddedscroll/style/embedded-scroll-overlay.less
@@ -2,27 +2,23 @@
   .hint,
   .overlay {
     position: absolute;
+    top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
     // Let events go through the overlay (and reach OL map canvas)
     // otherwise two fingers touch never occurs because the first touch
     // is blocked by the overlay
     pointer-events: none;
   }
   .overlay {
-    top: 0;
-    width: 100%;
-    height: 100%;
     background-color: rgba(0,0,0,0.5);
     z-index: 100;
   }
   .hint {
-    top: 66%;
-    width: 80%;
-    height: auto;
     z-index: 1000;
     text-align: center;
     color: white;
     font-weight: bold;
-    margin-left: 10%;
   }
 }

--- a/src/components/embeddedscroll/style/embedded-scroll-overlay.less
+++ b/src/components/embeddedscroll/style/embedded-scroll-overlay.less
@@ -1,0 +1,28 @@
+.embedded-scroll {
+  .hint,
+  .overlay {
+    position: absolute;
+    left: 0;
+    // Let events go through the overlay (and reach OL map canvas)
+    // otherwise two fingers touch never occurs because the first touch
+    // is blocked by the overlay
+    pointer-events: none;
+  }
+  .overlay {
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.5);
+    z-index: 100;
+  }
+  .hint {
+    top: 66%;
+    width: 80%;
+    height: auto;
+    z-index: 1000;
+    text-align: center;
+    color: white;
+    font-weight: bold;
+    margin-left: 10%;
+  }
+}

--- a/src/components/embeddedscroll/style/embedded-scroll-overlay.less
+++ b/src/components/embeddedscroll/style/embedded-scroll-overlay.less
@@ -20,5 +20,10 @@
     text-align: center;
     color: white;
     font-weight: bold;
+    .valign {
+      position: relative;
+      top: 50%;
+      transform: translateY(-50%);
+    }
   }
 }

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -5,6 +5,9 @@ itemscope itemtype="http://schema.org/WebApplication"
 % if device == 'mobile' :
  manifest="geoadmin.${git_commit_short}.appcache"
 % endif
+% if device == 'embed' :
+  ga-embedded-scroll-event-handler
+% endif
 >
   <head>
     <!--![if !HTML5]>
@@ -187,7 +190,7 @@ itemscope itemtype="http://schema.org/WebApplication"
       <div id="search-container" ng-controller="GaSearchController">
         <div ga-search ga-search-map="map" ga-search-options="options" ga-search-ol3d="::ol3d"></div>
       </div>
-
+      <div ga-embedded-scroll-overlay></div>
       <div ga-scale-line ga-scale-line-map="map" ng-show="!globals.is3dActive"></div>
   % endif
 

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -777,6 +777,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         if (localhostRegexp.test(wmtsUrl)){
            wmtsUrl = wmtsUrl.replace('https:', 'http:');
         }
+        var embeddedWithInteractions = getParam('embedded_with_interactions') || false;
         module.constant('gaGlobalOptions', {
           //dev3d to be removed once 3d goes live
           dev3d: true,
@@ -824,6 +825,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           apiOverwrite: apiOverwrite,
           configOverwrite: configOverwrite,
           disableTooltip: disableTooltip,
+          embeddedWithInteractions: embeddedWithInteractions,
 
           // Map state values
           defaultExtent: JSON.parse(${default_extent}),

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -14,6 +14,7 @@ goog.require('ga_draw');
 goog.require('ga_draw_controller');
 goog.require('ga_drawstyle_controller');
 goog.require('ga_drawstylepopup_controller');
+goog.require('ga_embedded_scroll');
 goog.require('ga_featuretree');
 goog.require('ga_featuretree_controller');
 goog.require('ga_feedback');
@@ -130,7 +131,8 @@ goog.require('ga_waitcursor_service');
     'ga_draw_controller',
     'ga_drawstyle_controller',
     'ga_drawstylepopup_controller',
-    'ga_vector_tile'
+    'ga_vector_tile',
+    'ga_embedded_scroll'
   ]);
 
   module.config(function($translateProvider, gaGlobalOptions) {

--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -97,7 +97,8 @@ goog.require('ga_window_service');
           }
         }),
         // if embedded, use custom interaction, otherwise extends default
-        interactions: gaBrowserSniffer.embed ?
+        interactions: gaBrowserSniffer.embed &&
+                      !gaGlobalOptions.embeddedWithInteractions ?
           interactionsForEmbed : ol.interaction.defaults({
             altShiftDragRotate: true,
             touchRotate: false,

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -142,6 +142,8 @@
 "emapis_service_link_href": "mailto:info@blw.admin.ch",
 "emapis_service_link_label": "info@blw.admin.ch",
 "embed_map": "Karte einbetten",
+"embedded_scroll_hint": "Verwende Strg + Scrollen zum Zoomen der Karte",
+"embedded_touch_hint": "Verschieben der Karte mit zwei Finger",
 "energie": "Energie",
 "energie_service_link_href": "http://www.bfe.admin.ch/geoinformation/index.html?lang=de",
 "energie_service_link_label": "www.map.energie.admin.ch",

--- a/src/locales/empty.json
+++ b/src/locales/empty.json
@@ -486,5 +486,7 @@
   "layer_cant_be_printed": "",
   "print_request_too_large": "",
   "whatsapp_tooltip": "",
-  "try_test_viewer": ""
+  "try_test_viewer": "",
+  "embedded_scroll_hint": "",
+  "embedded_touch_hint": ""
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -142,6 +142,8 @@
 "emapis_service_link_href": "mailto:info@blw.admin.ch",
 "emapis_service_link_label": "info@blw.admin.ch",
 "embed_map": "Embed map",
+"embedded_scroll_hint": "Use ctrl + scroll to zoom the map",
+"embedded_touch_hint": "Use two fingers to move the map",
 "energie": "Energy",
 "energie_service_link_href": "http://www.bfe.admin.ch/geoinformation/index.html?lang=en",
 "energie_service_link_label": "www.map.energy.admin.ch",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -142,6 +142,8 @@
 "emapis_service_link_href": "mailto:info@blw.admin.ch",
 "emapis_service_link_label": "info@blw.admin.ch",
 "embed_map": "Intégrer la carte",
+"embedded_scroll_hint": "Utilisez ctrl + molette pour zoomer",
+"embedded_touch_hint": "Utilisez deux doigts pour bouger la carte",
 "energie": "Énergie",
 "energie_service_link_href": "http://www.bfe.admin.ch/geoinformation/index.html?lang=fr",
 "energie_service_link_label": "www.map.energie.admin.ch",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -142,6 +142,8 @@
 "emapis_service_link_href": "mailto:info@blw.admin.ch",
 "emapis_service_link_label": "info@blw.admin.ch",
 "embed_map": "Incorpora mappa",
+"embedded_scroll_hint": "Utilliza CTRL + scorrimento per eseguire le zoom della mappa",
+"embedded_touch_hint": "Utilliza due dita per spostare la mappa",
 "energie": "Energia",
 "energie_service_link_href": "http://www.bfe.admin.ch/geoinformation/index.html?lang=it",
 "energie_service_link_label": "www.map.energia.admin.ch",

--- a/src/locales/rm.json
+++ b/src/locales/rm.json
@@ -142,6 +142,8 @@
 "emapis_service_link_href": "mailto:info@blw.admin.ch",
 "emapis_service_link_label": "info@blw.admin.ch",
 "embed_map": "Integrar charta",
+"embedded_scroll_hint": "smatgai CTRL + scrollar per zoom charta",
+"embedded_touch_hint": "Spustar charta cun dus dets",
 "energie": "Energia",
 "energie_service_link_href": "",
 "energie_service_link_label": "",

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -46,6 +46,7 @@
 @import "../components/shop/style/shopmsg.less";
 @import "../components/shop/style/shoprectangle.less";
 @import "../components/tabs/style/tabs.less";
+@import "../components/embeddedscroll/style/embedded-scroll-overlay.less";
 
 
 @cdbund-margin: 12;


### PR DESCRIPTION
While embedding the map, add handling for "wheel" event with mouse input : disabling zoom on map if CTRL key is not pressed while scrolling, and passing the event to the webpage embedding the map (so that the webpage embedding the map continues its scroll).
Same kind of behavior with touch event (for mobile) : disabling one finger gestures in favor of two fingers gesture, disabling two fingers map rotation to ease pan/zoom with two fingers.
Those behaviors are to avoid scrolling down the webpage embedding the map and accidentally zooming the map instead of continuing scrolling up or down (same behavior as embedded GoogleMaps).

Known issue (to test) : on iOs (last version), with codepen.io on either Chrome or Safari, the webpage jumps back to top when touch events are being handled by the map on my device.

@davidoesch @danduk82 I will need some help translating two new texts in Italian and Romansh, how should I do that?

**Example :**
live : https://codepen.io/pakb/full/bOroYP
screenshot :
![image](https://user-images.githubusercontent.com/11540521/50695380-bdce3200-103c-11e9-95b7-26d07b886a78.png)


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/bap_iframe_scrolling/1907040618/index.html)</jenkins>