### PR TITLE
Updating dependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "gyronorm": "2.0.6",
     "jquery-ajax-transport-xdomainrequest": "1.0.4",
     "localforage": "1.7.3",
-    "npm-check-updates": "^2.14.0",
     "slipjs": "2.1.1"
   },
   "devDependencies": {
@@ -42,7 +41,7 @@
     "autoprefixer": "9.4.3",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.0",
     "commander": "2.19.0",
     "eslint": "5.6.1",
     "eslint-config-standard": "12.0.0",


### PR DESCRIPTION
Updating Bootstrap to last 3.x.x release (3.4.0)
Removing dependecy on npm-check-updates, which has been replaced by greenkeeper for a while now (and is no longer maintained actively)



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/bap_update_dependencies/index.html)</jenkins>