### PR TITLE
Hide Cesium credits in flight mode

### DIFF
--- a/src/components/map/style/map.less
+++ b/src/components/map/style/map.less
@@ -46,5 +46,11 @@
   &.ga-map-grab {
     cursor: grabpointer;  
   }
-}
 
+  // hide Cesium credits (otherwise visible in flight mode)
+  .cesium-credit-logoContainer,
+  .cesium-credit-expand-link,
+  .cesium-credit-textContainer {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Add some CSS forcing Cesium credits to hide
fix https://github.com/geoadmin/mf-geoadmin3/issues/4671


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/bap_remove_cesium_credits/index.html)</jenkins>