### PR TITLE
Using a central repository to store map.geo.admin.ch config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /src/embed.html
 /src/TemplateCacheModule.js
 /prd
+/configs
 /.build-artefacts
 /apache/app.conf
 /test/karma-conf-*.js

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Add `env=(dev|int|prod)`
 
 Add `api_url=//theNameOfAnAPIServer`
 
+Add `config_url=//theNameOfAnConfigServerOrUrl`
+
 Add `alti_url=//theNameOfAnAltiServer`
 
 Add `wms_url=//theNameOfAWMSServer`

--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -30,16 +30,29 @@ RedirectMatch ^${apache_base_path}$ ${apache_base_path}/
 
 Alias ${apache_base_path}/src/coverage ${apache_base_directory}/.build-artefacts/coverage
 Alias ${apache_base_path}/src ${apache_base_directory}/src
+Alias ${apache_base_path}/configs/ ${apache_base_directory}/configs/
 Alias ${apache_base_path}/ ${apache_base_directory}/prd/
-RewriteRule ${apache_base_path}/src/layersConfig\.(\w+)\.json http:${api_url}/rest/services/all/MapServer/layersConfig?lang=$1 [P]
-RewriteRule ${apache_base_path}/src/services http:${api_url}/rest/services [P]
 
-# Static config
+# Config url on dev (old style)
+RewriteRule ${apache_base_path}/src/layersConfig\.(\w+)\.json http:${api_url}/rest/services/all/MapServer/layersConfig?lang=$1 [P] 
+RewriteRule ${apache_base_path}/src/services http:${api_url}/rest/services [P] 
+
+# Config url on dev (new style #4687)
+RewriteRule ${apache_base_path}/src/configs/(de|fr|it|rm|en)/layersConfig\.json http:${api_url}/rest/services/all/MapServer/layersConfig?lang=$2 [P] 
+RewriteRule ${apache_base_path}/src/configs/(de|fr|it|rm|en)/catalog\.(\w+)\.json http:${api_url}/rest/services/$3/CatalogServer?lang=$2 [P] 
+RewriteRule ${apache_base_path}/src/configs/(de|fr|it|rm|en)/services\.json http:${api_url}/rest/services [P] 
+RewriteRule ${apache_base_path}/src/configs/services\.json http:${api_url}/rest/services [P] 
+
 #RewriteCond %{QUERY_STRING}     ^lang=(de|fr|it|rm|en)$    [NC]
 RewriteRule ${apache_base_path}/([0-9]+)/layersConfig(.*)  ${apache_base_directory}/prd/cache/layersConfig$2 [NC,L]
 RewriteRule ${apache_base_path}/([0-9]+)/(services|layersConfig)  ${apache_base_directory}/prd/cache/$2
 
 <LocationMatch ${apache_base_path}/(src|[0-9]+)/(layersConfig|services)>
+   Order allow,deny
+   Allow from all
+</LocationMatch>
+
+<LocationMatch ${apache_base_path}/configs >
    Order allow,deny
    Allow from all
 </LocationMatch>

--- a/rc_dev
+++ b/rc_dev
@@ -14,3 +14,4 @@ export WMS_URL=//wms-bgdi.dev.bgdi.ch
 export WMTS_URL=//tod.dev.bgdi.ch
 export TERRAIN_URL=//3d.dev.bgdi.ch
 export VECTORTILES_URL=//vectortiles{s}.dev.bgdi.ch/3d-tiles
+export CONFIG_URL=//mf-geoadmin3.dev.bgdi.ch

--- a/rc_infra
+++ b/rc_infra
@@ -9,3 +9,4 @@ export WMS_URL=//wms-bgdi.int.bgdi.ch
 export SHOP_URL=//shop-bgdi.int.bgdi.ch
 export PUBLIC_URL=//public.int.bgdi.ch
 export PRINT_URL=//service-print.int.ch
+export CONFIG_URL=//mf-geoadmin3.infra.bgdi.ch

--- a/rc_int
+++ b/rc_int
@@ -13,3 +13,4 @@ export WMS_URL=//wms-bgdi-cdn-{s}.int.bgdi.ch
 export WMTS_URL=//wmts{s}.bgdi.ch
 export TERRAIN_URL=//terrain100.bgdi.ch
 export VECTORTILES_URL=//vectortiles{s}.int.bgdi.ch/3d-tiles
+export CONFIG_URL=//mf-geoadmin3.int.bgdi.ch

--- a/rc_prod
+++ b/rc_prod
@@ -14,3 +14,4 @@ export WMTS_URL=//wmts{s}.geo.admin.ch
 export WMTS_TECH_URL=//wmts.
 export TERRAIN_URL=//terrain100.geo.admin.ch
 export VECTORTILES_URL=//vectortiles{s}.geo.admin.ch/3d-tiles
+export CONFIG_URL=//mf-geoadmin3.prod.bgdi.ch

--- a/src/components/catalogtree/CatalogtreeDirective.js
+++ b/src/components/catalogtree/CatalogtreeDirective.js
@@ -109,7 +109,8 @@ goog.require('ga_translation_service');
               }
               var labelsOnly = false;
               var url = scope.options.catalogUrlTemplate.
-                  replace('{Topic}', topic.id);
+                  replace('{Topic}', topic.id).
+                  replace('{Lang}', lang);
               // If the topic has not changed that means we need to update only
               // labels
               if (lastUrlUsed === url) {
@@ -128,10 +129,7 @@ goog.require('ga_translation_service');
               lastLangUsed = lang;
               $http.get(url, {
                 timeout: canceller.promise,
-                cache: true,
-                params: {
-                  'lang': lang
-                }
+                cache: true
               }).then(function(response) {
                 var newTree = response.data.results.root;
                 var oldTree = scope.root;

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -737,13 +737,16 @@ itemscope itemtype="http://schema.org/WebApplication"
 
         // Api services urls
         var defaultApiUrl = prtl + '${api_url}';
+        var defaultConfigUrl = prtl + '${config_url}';
         var apiUrl = setBackend(defaultApiUrl, prtl + '${api_tech_url}', 'api_url');
+        var configUrl = setBackend(defaultConfigUrl, prtl + '${config_tech_url}', 'config_url');
         var altiUrl = setBackend(prtl + '${alti_url}', prtl + '${alti_tech_url}', 'alti_url');
         var shopUrl = setBackend(prtl + '${shop_url}', prtl + '${shop_tech_url}', 'shop_url');
         var publicUrl = setBackend(prtl + '${public_url}', prtl + '${public_tech_url}', 'public_url');
         var printUrl = setBackend(prtl + '${print_url}', prtl + '${print_tech_url}', 'print_url');
         var proxyUrl = prtl + '${proxy_url}' + '/';
         var apiOverwrite = !!(getParam('api_url') || env);
+        var configOverwrite = !!(getParam('config_url') || env);
         var localhostRegexp = new RegExp('https?:\/\/localhost:[0-9]{1,5}');
         if (localhostRegexp.test(wmtsUrl)){
            wmtsUrl = wmtsUrl.replace('https:', 'http:');
@@ -763,6 +766,7 @@ itemscope itemtype="http://schema.org/WebApplication"
 
           // Api services urls
           apiUrl: apiUrl,
+          configUrl: configUrl,
           altiUrl: altiUrl,
           printUrl: printUrl,
           proxyUrl: proxyUrl,
@@ -792,6 +796,7 @@ itemscope itemtype="http://schema.org/WebApplication"
           hostIsProd: hostIsProd,
           staging: staging,
           apiOverwrite: apiOverwrite,
+          configOverwrite: configOverwrite,
 
           // Map state values
           defaultExtent: JSON.parse(${default_extent}),

--- a/src/js/CatalogtreeController.js
+++ b/src/js/CatalogtreeController.js
@@ -6,9 +6,17 @@ goog.provide('ga_catalogtree_controller');
 
   module.controller('GaCatalogtreeController', function($scope,
       gaGlobalOptions) {
+    var catalogUrlTemplate;
+    // Config services urls (topic details)
+    if (gaGlobalOptions.configOverwrite) {
+      catalogUrlTemplate = gaGlobalOptions.configUrl +
+              '/{Lang}/catalog.{Topic}.json';
+    } else {
+      catalogUrlTemplate = gaGlobalOptions.configUrl +
+              '/configs/{Lang}/catalog.{Topic}.json'
+    }
     $scope.options = {
-      catalogUrlTemplate: gaGlobalOptions.cachedApiUrl +
-        '/rest/services/{Topic}/CatalogServer'
+      catalogUrlTemplate: catalogUrlTemplate
     };
   });
 })();

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -166,23 +166,25 @@ goog.require('ga_waitcursor_service');
     gaLayersProvider.vectorTilesUrl = gaGlobalOptions.vectorTilesUrl +
         '/{Layer}/{Time}/';
 
-    // Api services urls
-    if (gaGlobalOptions.apiOverwrite) {
-      gaLayersProvider.layersConfigUrl = gaGlobalOptions.apiUrl +
-          '/rest/services/all/MapServer/layersConfig?lang={Lang}';
+    // Config services urls (layers)
+    if (gaGlobalOptions.configOverwrite) {
+      gaLayersProvider.layersConfigUrl = gaGlobalOptions.configUrl +
+          '/{Lang}/layersConfig.json';
     } else {
-      gaLayersProvider.layersConfigUrl = gaGlobalOptions.resourceUrl +
-          'layersConfig.{Lang}.json';
+      gaLayersProvider.layersConfigUrl = gaGlobalOptions.configUrl +
+          '/configs/{Lang}/layersConfig.json';
     }
     gaLayersProvider.legendUrl = gaGlobalOptions.apiUrl +
         '/rest/services/all/MapServer/{Layer}/legend?lang={Lang}';
   });
 
   module.config(function(gaTopicProvider, gaGlobalOptions) {
-    if (gaGlobalOptions.apiOverwrite) {
-      gaTopicProvider.topicsUrl = gaGlobalOptions.apiUrl + '/rest/services';
+    // Config services urls (topics list)
+    if (gaGlobalOptions.configOverwrite) {
+      gaTopicProvider.topicsUrl = gaGlobalOptions.configUrl + '/services.json';
     } else {
-      gaTopicProvider.topicsUrl = gaGlobalOptions.resourceUrl + 'services';
+      gaTopicProvider.topicsUrl = gaGlobalOptions.configUrl +
+          '/configs/services.json';
     }
   });
 

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -7,6 +7,7 @@ beforeEach(function() {
     var version = '123456';
     var versionSlashed = version + '/';
     var apiUrl = '//api3.geo.admin.ch';
+    var configUrl = '//map.geo.admin.ch';
     var altiUrl = '//api3.geo.admin.ch';
     var publicUrl = '//public.geo.admin.ch';
     var printUrl = '//print.geo.admin.ch';
@@ -35,6 +36,7 @@ beforeEach(function() {
 
       // Api services urls
       apiUrl: location.protocol + apiUrl,
+      configUrl: location.protocol + configUrl,
       altiUrl: location.protocol + altiUrl,
       printUrl: location.protocol + printUrl,
       shopUrl: location.protocol + shopUrl,

--- a/test/specs/catalogtree/CatalogtreeDirective.spec.js
+++ b/test/specs/catalogtree/CatalogtreeDirective.spec.js
@@ -3,9 +3,9 @@ describe('ga_catalogtree_directive', function() {
 
   var element, map, $httpBackend, $rootScope;
 
-  var expectedUrl = 'http://catalogservice.com/catalog/sometopic?lang=en';
-  var expectedUrl1 = 'http://catalogservice.com/catalog/sometopic2?lang=en';
-  var expectedUrl2 = 'http://catalogservice.com/catalog/sometopic?lang=somelang2';
+  var expectedUrl = 'http://catalogservice.com/en/catalog.sometopic.json';
+  var expectedUrl1 = 'http://catalogservice.com/en/catalog.sometopic2.json';
+  var expectedUrl2 = 'http://catalogservice.com/somelang2/catalog.sometopic.json';
   var response = {
     results: {
       root: {
@@ -72,7 +72,7 @@ describe('ga_catalogtree_directive', function() {
       $rootScope = _$rootScope_;
       $rootScope.map = map;
       $rootScope.options = {
-        catalogUrlTemplate: 'http://catalogservice.com/catalog/{Topic}'
+        catalogUrlTemplate: 'http://catalogservice.com/{Lang}/catalog.{Topic}.json'
       };
 
       $compile(element)($rootScope);

--- a/test/specs/js/CatalogtreeController.spec.js
+++ b/test/specs/js/CatalogtreeController.spec.js
@@ -38,7 +38,7 @@ describe('ga_catalogtree_controller', function() {
     });
 
     it('set scope values', function() {
-      expect(scope.options.catalogUrlTemplate).to.be('http://api3.geo.admin.ch/123456/rest/services/{Topic}/CatalogServer');
+      expect(scope.options.catalogUrlTemplate).to.be('http://map.geo.admin.ch/configs/{Lang}/catalog.{Topic}.json');
     });
   });
 });


### PR DESCRIPTION
The main idea is to configure the application without redeploying it.

This PR does basically nothing, except managing the various config layers differently. Instead of statifying them within the application, there are stored in the same bucket but may be updated independently.

The basic layout for the config dir is:
```
  configs\<lang>service.json  (will be translated in the futur)
          \<lang>\layersConfig.json
          \<lang>\catalog.swisstopo.json
```
A `CONFIG_URL`is added to point at different configuration.

Let's say, we have a new `dummy` layer, basically the same as the previous, but with different settings (name, opacity, update time, etc.) with `CONFIG_URL` pointing to a non-default location.

[Alternative settings](https://mf-geoadmin3.int.bgdi.ch/config/index.html?config_url=//mf-geoadmin3.int.bgdi.ch/configs/5555&lang=de&layers=dummy)

On **prod** and **int**, all branches are using `configs` defined in //mf-geoadmin3.(int|prod).bgdi.ch/configs. On **dev**, only `master`.

On **dev**, as the project is served by `apache`, `release`code uses a local cache, `debug` code always points on the corresponding `api` service.  

Upload config with:
 `make s3uploaconfigint`  or
  `make s3uploadconfigprod`


**Example**

1/ Using the default config

[Default settings](https://mf-geoadmin3.int.bgdi.ch/config/index.html?lang=de&layers=ch.bafu.hydrologie-messstationen_gefahren)

2/ Using alternative config

You may test, the new layer `dummy` doesn't exist in the default config:
[Default settings](https://mf-geoadmin3.int.bgdi.ch/config/index.html?lang=de&layers=dummy)
Compared to default:

- Label is different
- Opacity is `0.5`
- No update
- Only four topics
- ...


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/config/index.html)</jenkins>