### PR TITLE
[WIP] Deploy everything everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ endef
 # rc file used
 USER_SOURCE ?= rc_user
 
+# mf-geoadmin3 or mvt_clean
+PROJECT ?= mf-geoadmin3
 
 # Map libs variables
 OL_VERSION ?= be12573# September 25 2018 (mind the absence of a space character after the version)
@@ -138,6 +140,7 @@ NODE_VERSION ?= 6.13.1
 LAST_NODE_VERSION := $(call lastvalue,node-version)
 
 # S3 deploy variables
+TARGETS = DEV INT PROD INFRA
 DEPLOY_TARGET ?= int
 DEPLOY_GIT_BRANCH ?= $(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 CLONEDIR = /home/$(USER_NAME)/tmp/branches/${DEPLOY_GIT_BRANCH}
@@ -159,6 +162,35 @@ S3_VERSION_PATH ?=
 # S3 delete variables
 BRANCH_TO_DELETE ?=
 
+# Bucket name
+ifeq ($(PROJECT),mf-geoadmin3)
+		S3_BUCKET_PROD  := $(S3_MF_GEOADMIN3_PROD)
+		S3_BUCKET_INT   := $(S3_MF_GEOADMIN3_INT)
+		S3_BUCKET_DEV   := $(S3_MF_GEOADMIN3_DEV)
+		S3_BUCKET_INFRA := $(S3_MF_GEOADMIN3_INFRA)
+		S3_BUCKET_PROD_URL   := https://map.geo.admin.ch
+		S3_BUCKET_INT_URL    := https://mf-geoadmin3.int.bgdi.ch
+		S3_BUCKET_DEV_URL    := https://mf-geoadmin3.dev.bgdi.ch
+		S3_BUCKET_INFRA_URL  := https://mf-geoadmin3.infra.bgdi.ch
+else
+		S3_BUCKET_PROD  := mf-geoadmin4-prod-dublin
+		S3_BUCKET_INT   := mf-geoadmin4-int-dublin
+		S3_BUCKET_INT_URL   := https://mf-geoadmin4.int.bgdi.ch
+		S3_BUCKET_PROD_URL  := https://test.map.geo.admin.ch
+endif
+# Bucket url (base url for automatic tests and provinding links, Jenkins stuff)
+ifeq ($(DEPLOY_TARGET),infra)
+		S3_BUCKET_URL := $(S3_BUCKET_INFRA_URL)
+endif
+ifeq ($(DEPLOY_TARGET),dev)
+		S3_BUCKET_URL := $(S3_BUCKET_DEV_URL)
+endif
+ifeq ($(DEPLOY_TARGET),int)
+		S3_BUCKET_URL := $(S3_BUCKET_INT_URL)
+endif
+ifeq ($(DEPLOY_TARGET),prod)
+		S3_BUCKET_URL := $(S3_BUCKET_PROD_URL)
+endif
 
 ## Python interpreter can't have space in path name
 ## So prepend all python scripts with python cmd
@@ -252,6 +284,7 @@ help:
 	@echo
 	@echo "Variables:"
 	@echo
+	@echo "- PROJECT                     (current value: ${PROJECT})"
 	@echo "- API_URL Service URL         (build with: $(LAST_API_URL), current value: $(API_URL))"
 	@echo "- ALTI_URL Alti service URL   (build with: $(LAST_ALTI_URL), current value: $(ALTI_URL))"
 	@echo "- PRINT_URL Print service URL (build with: $(LAST_PRINT_URL), current value: $(PRINT_URL))"
@@ -270,6 +303,15 @@ help:
 	@echo "- GIT_COMMIT_HASH             (current value: $(GIT_COMMIT_HASH))"
 	@echo "- VARNISH_HOSTS               (current value: ${VARNISH_HOSTS})"
 	@echo "- DEPLOY_TARGET               (current value: ${DEPLOY_TARGET})"
+	@echo "- S3_BUCKET_PROD              (current value: ${S3_BUCKET_PROD})"
+	@echo "- S3_BUCKET_INT               (current value: ${S3_BUCKET_INT})"
+	@echo "- S3_BUCKET_DEV               (current value: ${S3_BUCKET_DEV})"
+	@echo "- S3_BUCKET_INFRA             (current value: ${S3_BUCKET_INFRA})"
+	@echo "- S3_BUCKET_PROD_URL          (current value: ${S3_BUCKET_PROD_URL})"
+	@echo "- S3_BUCKET_INT_URL           (current value: ${S3_BUCKET_INT_URL})"
+	@echo "- S3_BUCKET_DEV_URL           (current value: ${S3_BUCKET_DEV_URL})"
+	@echo "- S3_BUCKET_INFRA_URL         (current value: ${S3_BUCKET_INFRA_URL})"
+	@echo "- S3_BUCKET_URL               (current value: ${S3_BUCKET_URL})"
 	@echo
 
 showVariables:
@@ -277,6 +319,9 @@ showVariables:
 	@echo "VERSION = $(VERSION)"
 	@echo "S3_BASE_PATH = $(S3_BASE_PATH)"
 	@echo "S3_SRC_BASE_PATH = $(S3_SRC_BASE_PATH)"
+	@echo "S3_BUCKET_PROD   = $(S3_BUCKET_PROD)"
+	@echo "S3_BUCKET_INT    = $(S3_BUCKET_INT)"
+	@echo "S3_BUCKET_DEV    = $(S3_BUCKET_DEV)"
 
 .PHONY: all
 all: showVariables lint debug release apache testdebug testrelease fixrights
@@ -395,17 +440,10 @@ deploydev:
 		./scripts/deploydev.sh; \
 	fi
 
-.PHONY: s3deployinfra
-s3deployinfra: guard-SNAPSHOT .build-artefacts/requirements.timestamp
-	./scripts/deploysnapshot.sh $(SNAPSHOT) infra;
-
-.PHONY: s3deployint
-s3deployint: guard-SNAPSHOT .build-artefacts/requirements.timestamp
-	./scripts/deploysnapshot.sh $(SNAPSHOT) int;
-
-.PHONY: s3deployprod
-s3deployprod: guard-SNAPSHOT .build-artefacts/requirements.timestamp
-	./scripts/deploysnapshot.sh $(SNAPSHOT) prod;
+s3deploy := $(patsubst %,s3deploy%,int,infra,prod)
+PHONY: $(s3deploy)
+s3deploy%: guard-SNAPSHOT .build-artefacts/requirements.timestamp
+	./scripts/deploysnapshot.sh $(SNAPSHOT) $(S3_BUCKET_$(shell echo $*| tr a-z A-Z));
 
 s3deploybranch: guard-CLONEDIR \
                 guard-DEPLOY_TARGET \
@@ -417,7 +455,8 @@ s3deploybranch: guard-CLONEDIR \
 	./scripts/clonebuild.sh ${CLONEDIR} ${DEPLOY_TARGET} ${DEPLOY_GIT_BRANCH} ${DEEP_CLEAN} ${NAMED_BRANCH};
 	make s3copybranch CODE_DIR=${CLONEDIR}/mf-geoadmin3 \
                     DEPLOY_TARGET=${DEPLOY_TARGET} \
-                    NAMED_BRANCH=${NAMED_BRANCH}
+                    NAMED_BRANCH=${NAMED_BRANCH} \
+                    PROJECT=${PROJECT}
 
 .PHONY: s3deploybranchint
 s3deploybranchint:
@@ -433,55 +472,27 @@ s3copybranch: guard-DEPLOY_TARGET \
               guard-CODE_DIR \
               guard-DEPLOY_GIT_BRANCH \
               .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py upload ${CODE_DIR} ${DEPLOY_TARGET} ${NAMED_BRANCH} ${DEPLOY_GIT_BRANCH};
+	PROJECT=${PROJECT} ${PYTHON_CMD} ./scripts/s3manage.py upload --force --url $(S3_BUCKET_URL) ${CODE_DIR} ${DEPLOY_TARGET} ${NAMED_BRANCH} ${DEPLOY_GIT_BRANCH};
 
-.PHONY: s3listinfra
-s3listinfra: .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py list infra;
+s3list := $(patsubst %,s3list%,int,infra,prod)
+PHONY: $(s3list)
+s3list%: .build-artefacts/requirements.timestamp
+		${PYTHON_CMD} ./scripts/s3manage.py list $(S3_BUCKET_$(shell echo $*| tr a-z A-Z))
 
-.PHONY: s3listint
-s3listint: .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py list int;
+s3info := $(patsubst %,s3info%,int,infra,prod)
+PHONY: $(s3info)
+s3info%: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
+	${PYTHON_CMD} ./scripts/s3manage.py info  ${S3_VERSION_PATH} $(S3_BUCKET_$(shell echo $*| tr a-z A-Z));
 
-.PHONY: s3listprod
-s3listprod: .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py list prod;
+s3activate := $(patsubst %,s3activate%,int,infra,prod)
+PHONY: $(s3activate)
+s3activate%: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
+	${PYTHON_CMD} ./scripts/s3manage.py activate ${S3_VERSION_PATH}  $(S3_BUCKET_$(shell echo $*| tr a-z A-Z));
 
-.PHONY: s3infoinfra
-s3infoinfra: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py info ${S3_VERSION_PATH} infra;
-
-.PHONY: s3infoint
-s3infoint: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py info ${S3_VERSION_PATH} int;
-
-.PHONY: s3infoprod
-s3infoprod: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py info ${S3_VERSION_PATH} prod;
-
-.PHONY: s3activateinfra
-s3activateinfra: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py activate ${S3_VERSION_PATH} infra;
-
-.PHONY: s3activateint
-s3activateint: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py activate ${S3_VERSION_PATH} int;
-
-.PHONY: s3activateprod
-s3activateprod: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py activate ${S3_VERSION_PATH} prod;
-
-.PHONY: s3deleteinfra
-s3deleteinfra: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py delete ${S3_VERSION_PATH} infra;
-
-.PHONY: s3deleteint
-s3deleteint: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py delete ${S3_VERSION_PATH} int;
-
-.PHONY: s3deleteprod
-s3deleteprod: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
-	${PYTHON_CMD} ./scripts/s3manage.py delete ${S3_VERSION_PATH} prod;
+s3delete := $(patsubst %,s3delete%,int,infra,prod)
+PHONY: $(s3delete)
+s3delete%: guard-S3_VERSION_PATH .build-artefacts/requirements.timestamp
+	${PYTHON_CMD} ./scripts/s3manage.py delete ${S3_VERSION_PATH} $(S3_BUCKET_$(shell echo $*| tr a-z A-Z));
 
 .PHONY: flushvarnish
 flushvarnish: guard-DEPLOY_TARGET

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 autopep8==1.2.4
 boto3==1.4.1
 botocore==1.4.70
+click==7.0.0
 docutils==0.12
 flake8==2.6.2
 futures==3.0.5


### PR DESCRIPTION
This PR make our build and deploy system usable for the legacy `mf-geoadmin3`. and the new `mvt_clean` It adapts `Jenkins file`, `Makefile`, `s3manage.py`and all intermediates bash scripts.

Currently `master` and PR pointing on it are deployed to legacy buckets ('mf-geoadmin3*'). Branch `mvt_clean`and PR pointing on it, are deployed on new buckets ('mf-geoadmin4*').

We don't care about the `dev` system, because it is not based on S3.

- [x] Manual `list`, `info`, `upload`, `activate` and `delete` with `s3manage.py`
- [x]  Deploy with `make s3(list|info|upload|activate|delete)(int|prod)`
- [x] `make s3deploybranch` (?)
- [ ] Treat non `master`as `master`(for MVT)
- [x] Jenkins deploy to various targets (looks OK)


# With S3manage.py

```
 s3manage.py --help
Usage: s3manage.py [OPTIONS] COMMAND [ARGS]...

  Manage map.geo.admin.ch versions in AWS S3 bucket. Please do not use any
  credentials or profile, as this script     relies on aws instance's role.

  A version deployed to S3 is always defined by:

              <s3version> = <branch_name>/<sha>/<version>

Options:
  --help  Show this message and exit.

Commands:
  activate  Activate a version at the root of a bucket (by copying...
  delete    Delete a s3_path on a give bucket
  info      Print the info.json file
  list      List available <version> in a bucket.
  upload    Upload content of /prd (and /src) directory to a bucket.


```

## Listing
### MVT
`PROJECT=mvt s3manage.py list  int`
### Legacy
`s3manage.py list  int`

## Info

### MVT
`PROJECT=mvt s3manage.py info single_build/77b124d/1902101516 int`

### Legacy
`s3manage.py info master/fd940bb/1611300951 prod`

### Upload
### MVT
As a `non named-branch`
`PROJECT=mvt ./scripts/s3manage.py upload .  int false`
mom_s3manage_mvt/1ce5fb5/1902101611

Same as a `named branch`
`PROJECT=mvt ./scripts/s3manage.py upload .  int true`
mom_s3manage_mvt/1902101611

## Activate

### MVT
`PROJECT=mvt s3manage.py activate   single_build/77b124d/1902101516  int`

# With `make`

```
- s3deploybranchint   Build a branch and deploy it to S3 int. Defaults to the current branch name.
- s3deploybranchinfra Build a branch and deploy it to S3 infra. Defaults to the current branch name.
- s3deployint         Deploys a snapshot specified with SNAPSHOT=xxx to s3 int.
- s3deployprod        Deploys a snapshot specified with SNAPSHOT=xxx to s3 prod.
- s3activateint       Activate a version at the root of a remote bucket. (usage only: make s3activateint S3_VERSION_PATH=<branch>/<sha>/<version>)
- s3activateprod      Activate a version at the root of a remote bucket. (usage only: make s3activateprod S3_VERSION_PATH=<branch>/<sha>/<version>)
- s3copybranch        Copy the current directory content to S3. Defaults to the current branch name. WARNING: your code must have been compiled with 'make <user|int|prod>' first.
                      Usage: make s3copybranch DEPLOY_TARGET=<int|prod>
                                               NAMED_BRANCH=<true|false>
                                               CODE_DIR=<Path to the folder, default to current folder> (optional)
                                               DEPLOY_GIT_BRANCH=<Name of the branch to deploy, default to current branch> (optional)
- s3listint           List availables branches, revision and build on int bucket.
- s3listprod          List availables branches, revision and build on prod bucket.
- s3infoint           Get version info on remote int bucket. (usage only: make s3infoint S3_VERSION_PATH=<branch>/<sha>/<version>)
- s3infoprod          Get version info on remote prod bucket. (usage only: make s3infoprod S3_VERSION_PATH=<branch>/<sha>/<version>)
- s3deleteint         Delete a project version in a remote int bucket. (usage: make s3deleteint S3_VERSION_PATH=<branch> or <branch>/<sha>/<version>)
- s3deleteprod        Delete a project version in a remote prod bucket. (usage: make s3deleteprod S3_VERSION_PATH=<branch> or <branch>/<sha>/<version>)


```

## List

### MVT
`PROJECT=mvt make s3listint`  and `PROJECT=mvt make s3listprod` 
### Legacy 
`make s3listint`  and `make s3listprod` 

## Info
### Legacy
`make s3infoint  S3_VERSION_PATH=gal_cloudfront/1e37ff9/1472032465`

### MVT
`PROJECT=mvt make s3infoint  S3_VERSION_PATH=mvt/ce88598/1902092109`










<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/mom_s3manage_mvt/index.html)</jenkins>