### PR TITLE
[WIP] Trying to build something less useless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /src/embed.html
 /src/TemplateCacheModule.js
 /prd
+/dist
 /.build-artefacts
 /apache/app.conf
 /test/karma-conf-*.js


### PR DESCRIPTION
Our current builds are useless without an apache server serving them or uploading them to S3 with voodoo-like magic(`s3manage.py`) (we finish building the application at deploy-time)
This is a tentative to build something in a `dist` directory which may be served directly or copied as-is to any web server.

Deployed with

`aws s3 cp --recursive  <dist> s3://<bucket>/simple_build/`


[release](https://mf-geoadmin4.int.bgdi.ch/simple_build/index.html) [using MVT in bucket]

[debug](https://mf-geoadmin4.int.bgdi.ch/simple_build/src/index.html)  [missing layersConfig, but otherwise OK]

So why:
* We have 2 builds mechanisms, one is enough
* The CI is building a version we cannot deploy
* We have to keep Apache working, but the application is served with AWS 3
* Test apache is rarely updated, and used
* Developers are not crazy enough to developp through the proxy
* We have to rebuild to change a config (see PR #4734 and #4687)

The idea is to have:
* having one build that works for all environments finished at build/test time (treated as "bundle" during deploy)
* handling all environments (`dev`, `int`, `prod`) in the same way concerning serving the content (with one exception on dev)
* the same "folder" structure for all three environments and all branches including `master` (get rid of modifying files at deploytime)
* treat `master` as any other branch

for which we propose to
* have three separate build targets:
  * `debug`: basically renders the index.html mako in `src`
  * `release`: compiles/minifies everything in `src/*` into `prd/`
  * `dist`: copy what's in `src` and `prd` to `dist`, copy `index.html` and the like from `dist/prd` to `dist`. 
* deploying a build boils down to copying the content from `dist/` to `s3://{BUCKET_NAME}/<branch_name>/<timestamp>/`
* activating a branch is a simple copy from what's in `s3://{BUCKET_NAME}/<branch_name>/<timestamp>/` to `s3://{BUCKET_NAME}/<branch_name>/`.
* activating `master` means copying of what's in `s3://{BUCKET_NAME}/master/<timestamp>/` to `s3://{BUCKET_NAME}/`
* serving all `dev` targets from s3 as well, with the only exception of each users working directory (e.g. mf-geoadmin3.dev.bgdi.ch/ltmom/)

which allows to have
* `mf-geoadmin3.(dev|int|prod).bgdi.ch/<branch_name>/` (minified) and `mf-geoadmin3.(dev|int|prod).bgdi.ch/<branch_name>/src/` non-minified
* `mf-geoadmin3.(dev|int|prod).bgdi.ch/` (`master`), where the cot
* the caching still working, since for all branches (including `master`), the `index.html` includes the timestamp in the path of all `src="<timestamp>/..."` directives
* automatic deploys for `master` on `dev` and `int` upon successfull merge (enabling this for `prod` if desired would be trivial)

### Structure of `dist`
since the content of `dist` should not be touched anymore, we propose the following structure:
```
dist/<fix_1234|master>/<timestamp>/index.html (with relative links like src="<sha>/lib/build.js")
dist/<fix_1234|master>/<timestamp>/<sha>/img/
dist/<fix_1234|master>/<timestamp>/<sha>/lib/build.js
dist/<fix_1234|master>/<timestamp>/src/index.html
```
maybe even without the `<fix_1234|master>/<timestamp>/` part or only the timestamp part

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/build_dist/index.html)</jenkins>