### PR TITLE
load Roboto font from googleapis and add to fontstack

### DIFF
--- a/src/components/map/MapUtilsService.js
+++ b/src/components/map/MapUtilsService.js
@@ -540,7 +540,8 @@ goog.require('ga_urlutils_service');
                 undefined,
                 spriteData,
                 glStyle.sprite + '.png',
-                ['Helvetica']);
+                ['Roboto Regular', 'Roboto Italic',
+                  'Roboto Condensed Bold', 'Helvetica']);
             olLayer.glStyle = glStyle;
           });
         },

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -36,6 +36,10 @@ itemscope itemtype="http://schema.org/WebApplication"
     <link rel="apple-touch-icon" sizes="120x120" href="${s3basepath}${versionslashed}img/touch-icon-bund-120x120.png"/>
     <link rel="apple-touch-icon" sizes="152x152" href="${s3basepath}${versionslashed}img/touch-icon-bund-152x152.png"/>
 
+    ## HACK: load Roboto font from googleapi since olms is not capable of loading font from
+    ## source defined in style
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"> 
+
     <!-- Description is translated 'by hand' in the MainController -->
     <meta name="description" translate-attr="{content: 'page_description'}" content="geo.admin.ch ist die Geoinformationsplattform der Schweizerischen Eidgenossenschaft. // geo.admin.ch est la plateforme de géoinformation de la Confédération suisse."/>
     <meta name="keywords" content="maps Switzerland, map viewer, Confederation, geodata, public platform, geographical information, geoportal, orthophotos, geolocation, geoinformation, Geodaten, Geoinformation, Bund, Plattform, Karte, Kartendienst, Kartenviewer"/>


### PR DESCRIPTION
This PR should resolve issue #4732 . It's a workaround, a proper solution would be to have this functionality in olms.
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/mvt_use_roboto_font/index.html)</jenkins>