### PR TITLE
Configs files for services

### DIFF
--- a/apache/app.mako-dot-conf
+++ b/apache/app.mako-dot-conf
@@ -34,6 +34,17 @@ Alias ${apache_base_path}/ ${apache_base_directory}/prd/
 RewriteRule ${apache_base_path}/src/layersConfig\.(\w+)\.json http:${api_url}/rest/services/all/MapServer/layersConfig?lang=$1 [P]
 RewriteRule ${apache_base_path}/src/services http:${api_url}/rest/services [P]
 
+# Config url on dev (new style #4687)
+RewriteRule ${apache_base_path}/configs/(de|fr|it|rm|en)/layersConfig\.json http:${api_url}/rest/services/all/MapServer/layersConfig?lang=$2 [P] 
+RewriteRule ${apache_base_path}/configs/(de|fr|it|rm|en)/catalog\.(\w+)\.json http:${api_url}/rest/services/$3/CatalogServer?lang=$2 [P] 
+RewriteRule ${apache_base_path}/configs/(de|fr|it|rm|en)/services\.json http:${api_url}/rest/services [P] 
+RewriteRule ${apache_base_path}/configs/services\.json http:${api_url}/rest/services [P] 
+
+<LocationMatch ${apache_base_path}/configs >
+   Order allow,deny
+   Allow from all
+</LocationMatch>
+
 # Static config
 #RewriteCond %{QUERY_STRING}     ^lang=(de|fr|it|rm|en)$    [NC]
 RewriteRule ${apache_base_path}/([0-9]+)/layersConfig(.*)  ${apache_base_directory}/prd/cache/layersConfig$2 [NC,L]
@@ -70,3 +81,4 @@ RewriteRule ^${apache_base_path}/[0-9]+/(img|lib|style|locales)(.*) ${apache_bas
     Header set Cache-Control "no-cache"
     Header set Pragma "no-cache"
 </LocationMatch>
+


### PR DESCRIPTION
On `dev` we are still using Apache. The files `configs` will be served dynamically by apache. This is needed for PR https://github.com/geoadmin/mf-geoadmin3/pull/4687 to work on `dev`


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/mom_apache_configs/index.html)</jenkins>