### PR TITLE
append pathname to config_url when on personal build on dev

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -754,6 +754,11 @@ itemscope itemtype="http://schema.org/WebApplication"
           return url;
         }
 
+        // Determines if we're on a personal build on dev with pathname /ltxxxx/
+        if (!requestedStaging && staging == 'dev' && (/\/lt.*\/$/.test(pathname))) {
+            cfg['config_url'] += pathname.replace(/\/$/, '');
+        }
+
         // Map services urls
         var wmsUrl = setBackend(prtl + cfg['wms_url'],  prtl + cfg['wms_tech_url'], 'wms_url');
         var wmtsUrl = setBackend(prtl + cfg['wmts_url'], prtl + cfg['wmts_tech_url'], 'wmts_url');


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>

will append the pathname to the config url when
* on mf-geoadmin3.dev.bgdi.ch 
* get param staging is not set
* pathname starts with ``lt....``

https://s.geo.admin.ch/80411bf672

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/dev_ltclm_personal_build/1902221513/index.html)</jenkins>