### PR TITLE
Appcache fix : don't use 'root' username as appcache root folder

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -44,7 +44,7 @@ PYTHON_FILES := $(shell find scripts test/saucelabs -type f -name "*.py" -print)
 # Apache variables
 APACHE_BASE_DIRECTORY ?= $(CURDIR)
 LAST_APACHE_BASE_DIRECTORY := $(call lastvalue,apache-base-directory)
-APACHE_BASE_PATH ?= /$(shell id -un)
+APACHE_BASE_PATH ?= $(ifneq ($(USER_NAME) "root") /$(USER_NAME))
 LAST_APACHE_BASE_PATH := $(call lastvalue,apache-base-path)
 
 # Local server


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_appcache_fix/1902251520/index.html)</jenkins>