### PR TITLE
When activating appcache has shorter path

### DIFF
--- a/mk/release.mk
+++ b/mk/release.mk
@@ -59,6 +59,11 @@ prd/style/app.css: $(SRC_LESS_FILES)
 	${LESSC} $(LESS_PARAMETERS) --clean-css src/style/app.less $@
 	${POSTCSS} $@ --use autoprefixer --replace --no-map
 
+
+# We have to version of this file
+# geoadmin.<version>.appcache for use within the snapshot
+# no_snapshot_geoadmin.<version>.appcache which will be renamed into the former when activating
+# the snaphot (i.e. copying this file, index.html to the root)
 prd/geoadmin.%.appcache: src/geoadmin.mako.appcache \
 			${MAKO_CMD} \
 			.build-artefacts/last-version

--- a/mk/release.mk
+++ b/mk/release.mk
@@ -60,7 +60,7 @@ prd/style/app.css: $(SRC_LESS_FILES)
 	${POSTCSS} $@ --use autoprefixer --replace --no-map
 
 
-# We have to version of this file
+# We have two versionis of this file
 # geoadmin.<version>.appcache for use within the snapshot
 # no_snapshot_geoadmin.<version>.appcache which will be renamed into the former when activating
 # the snaphot (i.e. copying this file, index.html to the root)

--- a/mk/release.mk
+++ b/mk/release.mk
@@ -72,7 +72,7 @@ prd/geoadmin.%.appcache: src/geoadmin.mako.appcache \
 	    --var "apache_base_path=$(APACHE_BASE_PATH)" \
 	    --var "languages=$(LANGUAGES)" \
 	    --var "s3basepath=$(S3_BASE_PATH)" $< > $@
-	sed -e 's/\/$(GIT_BRANCH)\/$(VERSION)//g'  $@ >  prd/_geoadmin.$*.appcache
+	sed -e 's/\/$(GIT_BRANCH)\/$(VERSION)//g'  $@ >  prd/no_snapshot_geoadmin.$*.appcache
 
 
 prd/info.json: src/info.mako.json

--- a/mk/release.mk
+++ b/mk/release.mk
@@ -72,7 +72,7 @@ prd/geoadmin.%.appcache: src/geoadmin.mako.appcache \
 	    --var "apache_base_path=$(APACHE_BASE_PATH)" \
 	    --var "languages=$(LANGUAGES)" \
 	    --var "s3basepath=$(S3_BASE_PATH)" $< > $@
-	#mv prd/geoadmin.appcache $@
+	sed -e 's/\/$(GIT_BRANCH)\/$(VERSION)//g'  $@ >  prd/_geoadmin.$*.appcache
 
 
 prd/info.json: src/info.mako.json

--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -459,14 +459,14 @@ def activate_version(s3_path, bucket_name, deploy_target, bucket_url):
         s3client.delete_objects(Bucket=bucket_name, Delete={'Objects': indexes})
 
     appcache = None
-    files = list(bucket.objects.filter(Prefix='{}/_geoadmin.'.format(s3_path)).all())
+    files = list(bucket.objects.filter(Prefix='{}/no_snapshot_geoadmin.'.format(s3_path)).all())
     if len(files) > 0:
         appcache = os.path.basename(sorted(files)[-1].key)
     for j in ('robots.txt', 'checker', 'favicon.ico', appcache):
         # In prod move robots prod
         src_file_name = 'robots_prod.txt' if j == 'robots.txt' and deploy_target == 'prod' else j
-        # When activating do not use git sha in appcache
-        src_file_name = appcache.replace('_geoadmin.', 'geoadmin.') if j == appcache else j
+        # When activating do not use snapshot version in appcache
+        src_file_name = appcache.replace('no_snapshot_geoadmin.', 'geoadmin.') if j == appcache else j
         src_key_name = '{}/{}'.format(s3_path, src_file_name)
         print('%s ---> %s' % (src_key_name, j))
         try:

--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -465,7 +465,8 @@ def activate_version(s3_path, bucket_name, deploy_target, bucket_url):
     for j in ('robots.txt', 'checker', 'favicon.ico', appcache):
         # In prod move robots prod
         src_file_name = 'robots_prod.txt' if j == 'robots.txt' and deploy_target == 'prod' else j
-        # When activating do not use snapshot version in appcache
+        # When activating, the path in the appcache file must match the path used in the application.
+        # So we use and rename a specially prepared no_snapshot_geoadmin.<version>.appcache file for this.
         src_file_name = appcache.replace('no_snapshot_geoadmin.', 'geoadmin.') if j == appcache else j
         src_key_name = '{}/{}'.format(s3_path, src_file_name)
         print('%s ---> %s' % (src_key_name, j))

--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -459,12 +459,14 @@ def activate_version(s3_path, bucket_name, deploy_target, bucket_url):
         s3client.delete_objects(Bucket=bucket_name, Delete={'Objects': indexes})
 
     appcache = None
-    files = list(bucket.objects.filter(Prefix='{}/geoadmin.'.format(s3_path)).all())
+    files = list(bucket.objects.filter(Prefix='{}/_geoadmin.'.format(s3_path)).all())
     if len(files) > 0:
         appcache = os.path.basename(sorted(files)[-1].key)
     for j in ('robots.txt', 'checker', 'favicon.ico', appcache):
         # In prod move robots prod
         src_file_name = 'robots_prod.txt' if j == 'robots.txt' and deploy_target == 'prod' else j
+        # When activating do not use git sha in appcache
+        src_file_name = appcache.replace('_geoadmin.', 'geoadmin.') if j == appcache else j
         src_key_name = '{}/{}'.format(s3_path, src_file_name)
         print('%s ---> %s' % (src_key_name, j))
         try:


### PR DESCRIPTION
`/master/1902251554/a3f4429/locales/fr.json`  -->  `/a3f4429/locales/fr.json`

Compare:
https://map.geo.admin.ch/master/1902270753/geoadmin.858948f.appcache
with
https://map.geo.admin.ch/geoadmin.858948f.appcache

```
10c10
< /858948f/locales/de.json
---
> /master/1902270753/858948f/locales/de.json
12c12
< /858948f/locales/fr.json
---
> /master/1902270753/858948f/locales/fr.json
14c14
< /858948f/locales/it.json
---
> /master/1902270753/858948f/locales/it.json
16c16
< /858948f/locales/en.json
---
> /master/1902270753/858948f/locales/en.json
18c18
< /858948f/locales/rm.json
---
> /master/1902270753/858948f/locales/rm.json

```
