### PR TITLE
Fixing greenkeeper branch build on Jenkins

### DIFF
--- a/mk/release.mk
+++ b/mk/release.mk
@@ -71,13 +71,13 @@ prd/geoadmin.%.appcache: src/geoadmin.mako.appcache \
 	mkdir -p $(dir $@);
 	${PYTHON_CMD} ${MAKO_CMD} \
 	    --var "version=$(VERSION)" \
-		--var "git_branch=$(GIT_BRANCH)" \
-		--var "git_commit_short=$(GIT_COMMIT_SHORT)" \
+	    --var "git_branch=$(GIT_BRANCH)" \
+	    --var "git_commit_short=$(GIT_COMMIT_SHORT)" \
 	    --var "deploy_target=$(DEPLOY_TARGET)" \
 	    --var "apache_base_path=$(APACHE_BASE_PATH)" \
 	    --var "languages=$(LANGUAGES)" \
 	    --var "s3basepath=$(S3_BASE_PATH)" $< > $@
-	sed -e 's/\/$(GIT_BRANCH)\/$(VERSION)//g'  $@ >  prd/no_snapshot_geoadmin.$*.appcache
+	sed -e 's/\/$(subst /,\/,$(GIT_BRANCH))\/$(VERSION)//g'  $@ >  prd/no_snapshot_geoadmin.$*.appcache
 
 
 prd/info.json: src/info.mako.json


### PR DESCRIPTION
Replacing slash in git_branch with escaped slash before passing it to sed


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_fix_jenkins_appcache_build_with_greenkeeper/1903040833/index.html)</jenkins>