### PR TITLE
[MVT] fixing background colour edition (GLStyle)

### DIFF
--- a/src/components/backgroundselector/BackgroundService.js
+++ b/src/components/backgroundselector/BackgroundService.js
@@ -187,7 +187,7 @@ goog.require('ga_glstylestorage_service');
                   that.set(map, initBg);
 
                   // set default GLStyle background rules
-                  // this is needed because we don't use olms defautl function
+                  // this is needed because we don't use olms default function
                   // but rather apply olms.stylefunction at every layer
                   // we created (instead of letting olms create the layers
                   // for us, and style them correctly for background rules)

--- a/src/components/edit/EditDirective.js
+++ b/src/components/edit/EditDirective.js
@@ -112,7 +112,7 @@ goog.require('ga_urlutils_service');
           if ($window.confirm(str)) {
             // Delete the file on server ?
             layer.externalStyleUrl = undefined;
-            gaMvt.reload(layer);
+            gaMvt.reload(layer, scope.map);
           }
         };
 

--- a/src/components/edit/EditDirective.js
+++ b/src/components/edit/EditDirective.js
@@ -140,6 +140,7 @@ goog.require('ga_urlutils_service');
           }
 
           gaMapUtils.applyGlStyleToOlLayer(scope.layer, glStyle);
+          gaMapUtils.setGlBackground(scope.map, glStyle);
           scope.saveDebounced({}, scope.layer, glStyle);
         });
       }

--- a/src/components/edit/EditGlStyleDirective.js
+++ b/src/components/edit/EditGlStyleDirective.js
@@ -61,6 +61,13 @@ goog.provide('ga_editglstyle_directive');
             if (idx !== 0 && layer[path[0]] && layer[path[0]][path[1]]) {
               layer[path[0]][path[1]] = value;
             }
+            // hack for background / territory
+            // as territory layer needs fill-color
+            // but background layer needs background-color (which is define
+            // as the property to be altered by this directive without hack)
+            if (layer.id === 'territory_' && path[1] === 'background-color') {
+              layer[path[0]]['fill-color'] = value;
+            }
           });
           scope.save();
         }

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -320,7 +320,7 @@ goog.require('ga_urlutils_service');
                   '<a target="_blank" href="https://www.swisstopo.admin.ch/' + lang + '/home.html">swisstopo</a>',
                 styles: [{
                   id: 'default',
-                  url: 'https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v006/style.json'
+                  url: 'https://tileserver.dev.bgdi.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v009/style.json'
                 }, {
                   id: 'color',
                   url: 'https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte-vintage.vt/v006/style.json'
@@ -376,9 +376,9 @@ goog.require('ga_urlutils_service');
                   ]
                 }, {
                   id: 'background',
-                  regex: /territory/,
+                  regex: /territory|background/,
                   props: [
-                    ['paint', 'fill-color', '{color}']
+                    ['paint', 'background-color', '{color}']
                   ]
                 }]
               };

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -375,7 +375,7 @@ goog.require('ga_urlutils_service');
                     ['paint', 'fill-color', '{color}']
                   ]
                 }, {
-                  id: 'background',
+                  id: 'territory',
                   regex: /territory|background/,
                   props: [
                     ['paint', 'background-color', '{color}']

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -320,7 +320,7 @@ goog.require('ga_urlutils_service');
                   '<a target="_blank" href="https://www.swisstopo.admin.ch/' + lang + '/home.html">swisstopo</a>',
                 styles: [{
                   id: 'default',
-                  url: 'https://tileserver.dev.bgdi.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v009/style.json'
+                  url: 'https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v006/style.json'
                 }, {
                   id: 'color',
                   url: 'https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte-vintage.vt/v006/style.json'

--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -323,13 +323,13 @@ goog.require('ga_urlutils_service');
                   url: 'https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v006/style.json'
                 }, {
                   id: 'color',
-                  url: 'https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte-vintage.vt/v006/style.json'
+                  url: 'https://cms.geo.admin.ch/www.geo.admin.ch/cms_api/gl-styles/ch.swisstopo.leichte-basiskarte-vintage.vt_v006.json'
                 }, {
                   id: 'grey',
-                  url: 'https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte-grey.vt/v006/style.json'
+                  url: 'https://cms.geo.admin.ch/www.geo.admin.ch/cms_api/gl-styles/ch.swisstopo.leichte-basiskarte-grey.vt_v006.json'
                 }, {
                   id: 'lsd',
-                  url: 'https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte-lsd.vt/v006/style.json'
+                  url: 'https://cms.geo.admin.ch/www.geo.admin.ch/cms_api/gl-styles/ch.swisstopo.leichte-basiskarte-lsd.vt_v006.json'
                 }],
                 edits: [{
                   id: 'settlement',

--- a/src/components/map/MvtService.js
+++ b/src/components/map/MvtService.js
@@ -25,7 +25,7 @@ goog.require('ga_urlutils_service');
       var Mvt = function() {
 
         // This function will apply the gl style associated to a layer.
-        this.reload = function(olLayer) {
+        this.reload = function(olLayer, map) {
           if (!olLayer || (!(olLayer instanceof ol.layer.Group) &&
               !olLayer.sourceId)) {
             return $q.when();
@@ -59,6 +59,10 @@ goog.require('ga_urlutils_service');
 
           return gaStorage.load(styleUrl).then(function(glStyle) {
             gaMapUtils.applyGlStyleToOlLayer(olLayer, glStyle);
+            // re-apply background if map is defined
+            if (map) {
+              gaMapUtils.setGlBackground(map, glStyle);
+            }
             return glStyle;
           });
 

--- a/src/components/vectorfeedback/VectorFeedbackDirective.js
+++ b/src/components/vectorfeedback/VectorFeedbackDirective.js
@@ -119,7 +119,7 @@ goog.require('ga_translation_service');
               scope.styles[styleIdx].url;
 
           }
-          gaMvt.reload(scope.olLayer);
+          gaMvt.reload(scope.olLayer, scope.map);
         };
       }
     };

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -145,6 +145,7 @@
 "edit_file_saved": "Alle Änderungen gespeichert",
 "edit_file_saving": "Speichern ....",
 "edit_fill_color": "Farbe auswählen",
+"edit_background_color": "Farbe auswählen",
 "edit_fill_outline_color": "Randfarbe auswählen",
 "edit_glstyle_choose_color": "Farbe auswählen",
 "edit_glstyle_choose_layer": "Ebene auswählen",
@@ -539,5 +540,6 @@
 "yellow": "Gelb",
 "zoom_in": "Vergrössere Kartenausschnitt",
 "zoom_out": "Verkleinere Kartenausschnitt",
-"woodland": "Wälder"
+"woodland": "Wälder",
+"territory": "Gelände"
 }

--- a/src/locales/empty.json
+++ b/src/locales/empty.json
@@ -520,6 +520,7 @@
   "edit_not_possible": "",
   "edit_or_reset_style": "",
   "edit_fill_color": "",
+  "edit_background_color": "",
   "edit_text_color": "",
   "edit_text_halo_color": "",
   "show": "",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -145,6 +145,7 @@
 "edit_file_saved": "Map saved.",
 "edit_file_saving": "Saving ...",
 "edit_fill_color": "Choose a color",
+"edit_background_color": "Choose a color",
 "edit_fill_outline_color": "Choose a border color",
 "edit_glstyle_choose_color": "Choose a color",
 "edit_glstyle_choose_layer": "Choose a layer",
@@ -539,5 +540,6 @@
 "yellow": "yellow",
 "zoom_in": "Zoom in",
 "zoom_out": "Zoom out",
-"woodland": "Woodland"
+"woodland": "Woodland",
+"territory": "Territory"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -145,6 +145,7 @@
 "edit_file_saved": "Carte sauvegardée.",
 "edit_file_saving": "Sauvegarde....",
 "edit_fill_color": "Choisissez une couleur",
+"edit_background_color": "Choisissez une couleur",
 "edit_fill_outline_color": "Choisissez une couleur des contours",
 "edit_glstyle_choose_color": "Choisissez une couleur",
 "edit_glstyle_choose_layer": "Choisissez une couche",
@@ -539,5 +540,6 @@
 "yellow": "jaune",
 "zoom_in": "Zoomer plus",
 "zoom_out": "Zoomer moins",
-"woodland": "Forêts"
+"woodland": "Forêts",
+"territory": "Terrain"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -145,6 +145,7 @@
 "edit_file_saved": "Tutte le modifiche salvate",
 "edit_file_saving": "Salvataggio...",
 "edit_fill_color": "Scegliere un colore",
+"edit_background_color": "Scegliere un colore",
 "edit_fill_outline_color": "Scegliere un colore del bordo",
 "edit_glstyle_choose_color": "Scegliere un colore",
 "edit_glstyle_choose_layer": "Scegliere un layer",
@@ -539,5 +540,6 @@
 "yellow": "giallo",
 "zoom_in": "Zoom in avanti",
 "zoom_out": "Zoom indietro",
-"woodland": "Foreste"
+"woodland": "Foreste",
+"territory": "Terreno"
 }

--- a/src/locales/rm.json
+++ b/src/locales/rm.json
@@ -145,6 +145,7 @@
 "edit_file_saved": "Arcunà tut las midadas",
 "edit_file_saving": "Arcunar ...",
 "edit_fill_color": "Farbe auswählen",
+"edit_background_color": "Farbe auswählen",
 "edit_fill_outline_color": "Randfarbe auswählen",
 "edit_glstyle_choose_color": "Farbe auswählen",
 "edit_glstyle_choose_layer": "Ebene auswählen",
@@ -539,5 +540,6 @@
 "yellow": "mellen",
 "zoom_in": "Engrondir l'extract da la charta",
 "zoom_out": "Empitschnir l'extract da la charta",
-"woodland": "Wälder"
+"woodland": "Wälder",
+"territory": "Gelände"
 }


### PR DESCRIPTION
It's now possible to alter the background not only of Switzerland, but of any landmass.
Pre-defined styles have been migrated to URL given in https://github.com/geoadmin/mf-geoadmin3/issues/4584 (will fix this issue)


<jenkins>[Test link](https://mf-geoadmin4.int.bgdi.ch/ltbtp_mvt_without_territory_layer/1903060650/index.html)</jenkins>