### PR TITLE
Layers should return to previous timestamp when timeslider is deactivated

### DIFF
--- a/src/components/map/MapDirective.js
+++ b/src/components/map/MapDirective.js
@@ -322,13 +322,13 @@ goog.require('ga_styles_service');
           // 'propertychange' event.
           // (ex: using layermanager)
           if (switchTimeDeactive) {
-
             for (var i = 0, ii = olLayers.length; i < ii; i++) {
               olLayer = olLayers[i];
               // We update only time enabled bod layers
               if (olLayer.timeEnabled &&
                   angular.isDefined(olLayer.time) &&
-                  olLayer.time.substr(0, 4) !== oldTime) {
+                  olLayer.time.substr(0, 4) !== oldTime &&
+                  olLayer.time.substr(0, 4) !== '9999') {
                 singleModif = true;
                 break;
               }
@@ -348,6 +348,7 @@ goog.require('ga_styles_service');
             olLayer = olLayers[j];
 
             if (olLayer.timeEnabled && olLayer.visible) {
+
               var layerTimeStr =
                   gaLayers.getLayerTimestampFromYear(olLayer, time);
               if (switchTimeActive) {
@@ -360,7 +361,6 @@ goog.require('ga_styles_service');
                 // (ex: using the time selector toggle)
                 layerTimeStr = savedTimeStr[olLayer.id];
                 savedTimeStr[olLayer.id] = undefined;
-
               }
               olLayer.time = layerTimeStr;
             }


### PR DESCRIPTION


[Demo witth all LUBIS layers](https://mf-geoadmin3.int.bgdi.ch/fix_4710/1903052136/index.html?topic=swisstopo&layers=ch.swisstopo.lubis-luftbilder_infrarot,ch.swisstopo.lubis-luftbilder_schraegaufnahmen,ch.swisstopo.lubis-terrestrische_aufnahmen,ch.swisstopo.lubis-bildstreifen,ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers_timestamp=99991231,,9999,,99991231,99991231&layers_visibility=false,false,false,false,true,true)

Fixes https://github.com/geoadmin/mf-geoadmin3/issues/4710 (sames as https://github.com/geoadmin/mf-chsdi3/issues/2727)


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/fix_4710/1903060624/index.html)</jenkins>