### PR TITLE
Linting (via Makefile) once and for all

### DIFF
--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -368,10 +368,10 @@ def list_dist_version(branch=None):
     # Note: branch-names containing '/' are currently not supported!
     branch_prefix = branch if branch else ''
     try:
-      branches = bucket.meta.client.list_objects(
-          Bucket=bucket.name,
-          Prefix=branch_prefix,
-          Delimiter='/')
+        branches = bucket.meta.client.list_objects(
+            Bucket=bucket.name,
+            Prefix=branch_prefix,
+            Delimiter='/')
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         print("Error while listing version(s) in bucket <{}>: {}".format(bucket.name, e))
         return None

--- a/src/components/controls3d/fps.js
+++ b/src/components/controls3d/fps.js
@@ -348,22 +348,22 @@ FPS.prototype.getTimeDifference_ = function() {
  * @return {!Cesium.Cartesian3}
  * @private
  */
-FPS.prototype.clampAboveTerrain_ = function(gpos, minHeight, optMaxHeight, 
-  cameraHeading) {
+FPS.prototype.clampAboveTerrain_ = function(gpos, minHeight, optMaxHeight,
+    cameraHeading) {
   var lla = this.ellipsoid_.cartesianToCartographic(gpos),
-      lla25MetersAhead = this.ellipsoid_.cartesianToCartographic(gpos);
+    lla25MetersAhead = this.ellipsoid_.cartesianToCartographic(gpos);
   // projecting 25m ahead in the camera direction to check altitude
   // 111.111km is a rough estimate of kilometers per 1 deg of latitude
-  lla25MetersAhead.latitude = lla.latitude 
-                              + 0.025 / 111.111 * Math.PI / 180.0 
-                                * Math.cos(cameraHeading);
+  lla25MetersAhead.latitude = lla.latitude +
+                              0.025 / 111.111 * Math.PI / 180.0 *
+                                Math.cos(cameraHeading);
   // we have to take latitude into account for the km/deg estimate on longitude
-  lla25MetersAhead.longitude = lla.longitude
-                              + 0.025 * Math.cos(lla.latitude) / 111.111
-                                * Math.PI / 180.0
-                                * Math.sin(cameraHeading);
+  lla25MetersAhead.longitude = lla.longitude +
+                              0.025 * Math.cos(lla.latitude) / 111.111 *
+                                Math.PI / 180.0 *
+                                Math.sin(cameraHeading);
   var groundAlt = Cesium.defaultValue(this.scene_.globe.getHeight(lla), 0.0),
-      groundAlt25MetersAhead = Cesium.defaultValue(this.scene_.globe.getHeight(
+    groundAlt25MetersAhead = Cesium.defaultValue(this.scene_.globe.getHeight(
         lla25MetersAhead), 0.0);
   if (lla.height - groundAlt < minHeight) {
     lla.height = groundAlt + minHeight;
@@ -371,7 +371,7 @@ FPS.prototype.clampAboveTerrain_ = function(gpos, minHeight, optMaxHeight,
   if (optMaxHeight && (lla.height - groundAlt > optMaxHeight)) {
     lla.height = groundAlt + optMaxHeight;
   }
-  // if height set is below altitude 25m ahead, we raise the camera height 
+  // if height set is below altitude 25m ahead, we raise the camera height
   // to avoid terrain collision
   if (lla.height < groundAlt25MetersAhead) {
     lla.height = groundAlt25MetersAhead;

--- a/src/components/tooltip/TooltipDirective.js
+++ b/src/components/tooltip/TooltipDirective.js
@@ -547,7 +547,7 @@ goog.require('ga_window_service');
                 nohighlight) {
               // if url param disableTooltip is eq to true, no tooltip is to
               // be shown for this instance of map.
-              if (!!gaGlobalOptions.disableTooltip) {
+              if (gaGlobalOptions.disableTooltip) {
                 return;
               }
               if (foundFeatures && foundFeatures.length > 0) {


### PR DESCRIPTION
After upgrading ESLint and other libs, some files were always linted by `make lint` and thus appear as modified for git (which is annoying when sorting what you have really modify and what not)



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_lint_once_and_for_all/1903070507/index.html)</jenkins>