### PR TITLE
Removing caniuse from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1401,12 +1401,6 @@
         "map-obj": "^1.0.0"
       }
     },
-    "caniuse-db": {
-      "version": "1.0.30000946",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000946.tgz",
-      "integrity": "sha512-qjpdekHW9uyy1U/VxuoR9ppn8HjoBxsR5dRTpumUeoYgL8IWUeos+QpJh9DaDdjaKitkNzgAFMXCZLDYKWWyEQ==",
-      "dev": true
-    },
     "caniuse-lite": {
       "version": "1.0.30000936",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000936.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "slipjs": "2.1.1"
   },
   "devDependencies": {
-    "caniuse-db": "1.0.30000946",
     "angular-mocks": "1.7.8",
     "autoprefixer": "9.4.10",
     "babel-cli": "^6.24.1",

--- a/scripts/s3manage.py
+++ b/scripts/s3manage.py
@@ -38,7 +38,6 @@ NO_COMPRESS = [
 project = os.environ.get('PROJECT', 'mf-geoadmin3')
 
 
-
 # # # # # # # # # # # # # # # # # # #
 #         private functions         #
 # # # # # # # # # # # # # # # # # # #
@@ -146,7 +145,8 @@ def __is_cached__(file_name):
     <bucket_name>/fix_1234/as5a56a/lib/build.js          <= cache header
     """
     _, extension = os.path.splitext(file_name)
-    return os.path.basename(file_name) not in ['info.json'] and extension not in ['.html', '.txt', '.appcache', '']
+    return os.path.basename(file_name) not in ['info.json'] and extension not in [
+        '.html', '.txt', '.appcache', '']
 
 
 def __get_file_mimetype__(local_file):
@@ -290,7 +290,7 @@ def __print_version_info__(s3_path):
             sys.exit(1)
         for k in info.keys():
             print('%s: %s' % (k, info[k]))
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError), e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         sys.exit(1)
 
 


### PR DESCRIPTION
It is not used and create tons of updates with greenkeeper.
Also linting s3manage.py so that it doesn't appear modified after each make user



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_remove_caniuse_dependency/1903140548/index.html)</jenkins>