### PR TITLE
[WIP] Do no assume domain *.geo.admin.ch has CORS

### DIFF
--- a/src/components/UrlUtilsService.js
+++ b/src/components/UrlUtilsService.js
@@ -91,7 +91,9 @@ goog.provide('ga_urlutils_service');
           var that = this;
           var deferred = $q.defer();
           if (!this.isBlob(url) && this.isHttps(url) &&
-              !this.isAdminValid(url) && !/.*kmz$/.test(url)) {
+              // It's 2019, but we still to check for CORS within *.geo.admin.ch
+              // !this.isAdminValid(url) && 
+              !/.*kmz$/.test(url)) {
             this.isCorsEnabled(url).then(function(enabled) {
               deferred.resolve(url);
             }, function() {


### PR DESCRIPTION
[Demo with 2 KML](https://mf-geoadmin3.int.bgdi.ch/fix_4851/1903221938/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-grau&E=2595134.00&N=1126297.75&zoom=2&layers=KML%7C%7Chttps:%2F%2Fwww.procrastinatio.org%2Fkml%2F50points.kml,KML%7C%7Chttps:%2F%2Fwww.geo.admin.ch%2Fcontent%2Fdam%2Fgeo-internet%2Fde%2Ffiles%2FS-Red_2019.kml)

Blue KML --> No CORS --> proxy
Red KML --> CORS  --> no proxy

Fix #4851


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/fix_4851/1905071134/index.html)</jenkins>