### PR TITLE
Small IT translation correction upon user request

### DIFF
--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -325,7 +325,7 @@
 "print_scale": "Scala",
 "print_underway_message": "Translation is missing",
 "problem_announcement": "Segnala un problema",
-"profile_distance": "Lingia directa",
+"profile_distance": "Linea diretta",
 "profile_elevation_difference": "Dislivello start-fine",
 "profile_elevation_down": "Discesa",
 "profile_elevation_up": "Salita",


### PR DESCRIPTION
Thanks for a short review of line 328 "Linea diretta" Italiano, instead of "Lingia directa" (guess Rumantsch)


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/mariokeusen-translation_correction_it_20190401/1904011119/index.html)</jenkins>