### PR TITLE
Greenkeeper/eslint plugin promise 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2640,9 +2640,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
-      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.1.1.tgz",
+      "integrity": "sha512-faAHw7uzlNPy7b45J1guyjazw28M+7gJokKUjC5JSFoYfUEyy6Gw/i7YQvmv2Yk00sUjWcmzXQLpU1Ki/C2IZQ==",
       "dev": true
     },
     "eslint-plugin-standard": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-config-standard": "12.0.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-node": "8.0.0",
-    "eslint-plugin-promise": "4.0.1",
+    "eslint-plugin-promise": "4.1.1",
     "eslint-plugin-standard": "4.0.0",
     "expect.js": "0.3.1",
     "google-closure-compiler": "20170423.0.0",


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>

replace https://github.com/geoadmin/mf-geoadmin3/pull/4870

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/greenkeeper/eslint-plugin-promise-4.1.1/1904020852/index.html)</jenkins>