### PR TITLE
[MVT] Link to testviewer gets the same url params as current app

### DIFF
--- a/src/components/vectortile/VectorTile.module.js
+++ b/src/components/vectortile/VectorTile.module.js
@@ -1,0 +1,8 @@
+goog.provide('ga_vector_tile');
+goog.require('ga_vector_tile_test_link');
+(function() {
+
+  angular.module('ga_vector_tile', [
+    'ga_vector_tile_test_link'
+  ]);
+})();

--- a/src/components/vectortile/VectorTileTestLink.directive.js
+++ b/src/components/vectortile/VectorTileTestLink.directive.js
@@ -1,0 +1,38 @@
+goog.provide('ga_vector_tile_test_link');
+
+goog.require('ga_translation_service');
+goog.require('ga_permalink_service');
+goog.require('ga_urlutils_service');
+
+(function () {
+  
+  angular.module('ga_vector_tile_test_link', [
+    'ga_translation_service',
+    'ga_permalink_service',
+    'ga_urlutils_service'
+  ])
+
+  .directive('gaVectorTileTestLink', function ($window, gaLang, gaPermalink,
+    gaUrlUtils) {
+
+    function generateTestLinkUrl() {
+      var params = gaUrlUtils.toKeyValue(gaPermalink.getParams()) || '';
+      return "//test.map.geo.admin.ch?lang=" + gaLang.get() + 
+        (params.length > 0 ? '&' + params : '');
+    }
+
+    return {
+      restrict: 'A',
+      transclude: true,
+      templateUrl: 'components/vectortile/partials/testlink.html',
+      link: function (scope, element, attrs) {
+        scope.url = generateTestLinkUrl();
+        scope.openTestViewerWithSamePermalink = function(e) {
+          var url = generateTestLinkUrl();
+          $window.open(url, '_blank');
+          e.preventDefault();
+        };
+      }
+    };
+  })
+})();

--- a/src/components/vectortile/VectorTileTestLink.directive.js
+++ b/src/components/vectortile/VectorTileTestLink.directive.js
@@ -4,35 +4,35 @@ goog.require('ga_translation_service');
 goog.require('ga_permalink_service');
 goog.require('ga_urlutils_service');
 
-(function () {
-  
+(function() {
+
   angular.module('ga_vector_tile_test_link', [
     'ga_translation_service',
     'ga_permalink_service',
     'ga_urlutils_service'
-  ])
+  ]).
 
-  .directive('gaVectorTileTestLink', function ($window, gaLang, gaPermalink,
-    gaUrlUtils) {
+      directive('gaVectorTileTestLink', function($window, gaLang, gaPermalink,
+          gaUrlUtils) {
 
-    function generateTestLinkUrl() {
-      var params = gaUrlUtils.toKeyValue(gaPermalink.getParams()) || '';
-      return "//test.map.geo.admin.ch?lang=" + gaLang.get() + 
+        function generateTestLinkUrl() {
+          var params = gaUrlUtils.toKeyValue(gaPermalink.getParams()) || '';
+          return '//test.map.geo.admin.ch?lang=' + gaLang.get() +
         (params.length > 0 ? '&' + params : '');
-    }
+        }
 
-    return {
-      restrict: 'A',
-      transclude: true,
-      templateUrl: 'components/vectortile/partials/testlink.html',
-      link: function (scope, element, attrs) {
-        scope.url = generateTestLinkUrl();
-        scope.openTestViewerWithSamePermalink = function(e) {
-          var url = generateTestLinkUrl();
-          $window.open(url, '_blank');
-          e.preventDefault();
+        return {
+          restrict: 'A',
+          transclude: true,
+          templateUrl: 'components/vectortile/partials/testlink.html',
+          link: function(scope, element, attrs) {
+            scope.url = generateTestLinkUrl();
+            scope.openTestViewerWithSamePermalink = function(e) {
+              var url = generateTestLinkUrl();
+              $window.open(url, '_blank');
+              e.preventDefault();
+            };
+          }
         };
-      }
-    };
-  })
+      })
 })();

--- a/src/components/vectortile/partials/testlink.html
+++ b/src/components/vectortile/partials/testlink.html
@@ -1,0 +1,1 @@
+<a class="testviewer-link" href="{{ url }}" ng-click="openTestViewerWithSamePermalink($event)" target="_blank" translate>try_test_viewer</a>

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -145,7 +145,7 @@ itemscope itemtype="http://schema.org/WebApplication"
         </div>
       </div>
       <div id="toptools" ng-if="!globals.settingsShown">
-        <a class="testviewer-link" href="//test.map.geo.admin.ch?lang={{langId}}" target="_blank" translate>try_test_viewer</a>&nbsp;&nbsp;
+        <a ga-vector-tile-test-link></a>&nbsp;&nbsp;
         <div ga-fullscreen ga-fullscreen-map="map"></div>&nbsp;&nbsp;
         <a href="" ng-click="globals.feedbackPopupShown = !globals.feedbackPopupShown">
           <span translate>problem_announcement</span>

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -62,6 +62,7 @@ goog.require('ga_tooltip_controller');
 goog.require('ga_topic');
 goog.require('ga_translation');
 goog.require('ga_translation_controller');
+goog.require('ga_vector_tile');
 goog.require('ga_waitcursor_service');
 (function() {
 
@@ -128,7 +129,8 @@ goog.require('ga_waitcursor_service');
     'ga_featuretree_controller',
     'ga_draw_controller',
     'ga_drawstyle_controller',
-    'ga_drawstylepopup_controller'
+    'ga_drawstylepopup_controller',
+    'ga_vector_tile'
   ]);
 
   module.config(function($translateProvider, gaGlobalOptions) {

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -633,6 +633,7 @@ input[type="text"][readonly] {
   top: 0.2em;
   right: 2em;
   text-align: right;
+  z-index: 100;
 
   & > div {
     display: inline-block;


### PR DESCRIPTION
Test viewer doesn't react well when zoom is not an integer, something might have to change in `mvt_clean` to make it work properly

Will fix https://github.com/geoadmin/mf-geoadmin3/issues/4904


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_test_link_with_permalink_params/1905021228/index.html)</jenkins>