### PR TITLE
[MVT] Make sure lv95 zoom is integer before converting it to mercator

### DIFF
--- a/src/components/map/MapUtilsService.js
+++ b/src/components/map/MapUtilsService.js
@@ -634,7 +634,7 @@ goog.require('ga_urlutils_service');
          * Mapping between Swiss map zooms and Web Mercator zooms.
         */
         swissZoomToMercator: function(zoom) {
-          var gridZoom = zoom + 14;
+          var gridZoom = Math.round(zoom) + 14;
           var wmtsMaxZoom = gaGlobalOptions.tileGridResolutions.length;
           var mapMaxZoom = gaGlobalOptions.resolutions.length;
           var zoomOffset = wmtsMaxZoom - mapMaxZoom;


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>


<jenkins>[Test link](https://mf-geoadmin4.int.bgdi.ch/mvt_clean_make_sure_lv95_zoom_is_integer/1905020630/index.html)</jenkins>