### PR TITLE
[MVT] Set langId on app init

### DIFF
--- a/src/js/MainController.js
+++ b/src/js/MainController.js
@@ -513,6 +513,7 @@ goog.require('ga_vector_tile_layer_service');
     }
     gaLang.init().then(
         function() {
+          $scope.langId = gaLang.get();
           gaVectorTileLayerService.init($scope.map).then(function() {
             initApp();
           })


### PR DESCRIPTION
Will fix https://github.com/geoadmin/mf-geoadmin3/issues/4913


<jenkins>[Test link](https://mf-geoadmin4.int.bgdi.ch/mvt_clean_set_langid_on_app_init/1905030942/index.html)</jenkins>