### PR TITLE
[MVT] Hide attributions for MVT if another background is selected

### DIFF
--- a/src/components/vectortile/VectorTileLayerService.js
+++ b/src/components/vectortile/VectorTileLayerService.js
@@ -252,12 +252,14 @@ goog.require('ga_browsersniffer_service');
     function hideVectorTileLayers() {
       $.each(olVectorTileLayers, function(index, layer) {
         layer.setVisible(false);
+        layer.visible = false;
       })
     }
 
     function showVectorTileLayers() {
       $.each(olVectorTileLayers, function(index, layer) {
         layer.setVisible(true);
+        layer.visible = true;
       })
     }
 


### PR DESCRIPTION
will fix https://github.com/geoadmin/mf-geoadmin3/issues/4928

<jenkins>[Test link](https://mf-geoadmin4.int.bgdi.ch/mvt_clean_hide_mvt_attrib_if_other_backgrounds/1905081238/index.html)</jenkins>