### PR TITLE
[WIP] remove lang parameter from chsdi/wms layer requests

### DIFF
--- a/src/components/map/LayersService.js
+++ b/src/components/map/LayersService.js
@@ -550,8 +550,7 @@ goog.require('ga_urlutils_service');
           } else if (config.type === 'wms') {
             var wmsParams = {
               LAYERS: config.wmsLayers,
-              FORMAT: 'image/' + config.format,
-              LANG: gaLang.get()
+              FORMAT: 'image/' + config.format
             };
             if (config.singleTile === true) {
               if (!olSource) {

--- a/test/specs/map/Layers.spec.js
+++ b/test/specs/map/Layers.spec.js
@@ -768,7 +768,6 @@ describe('ga_layers_service', function() {
           expect(source.getParams()).to.eql({
             LAYERS: 'serverLayerName',
             FORMAT: 'image/png',
-            LANG: 'somelang',
             TIME: '20180101'
           });
           expectCommonProperties(layer, 'wms');
@@ -790,7 +789,6 @@ describe('ga_layers_service', function() {
           expect(source.getParams()).to.eql({
             LAYERS: 'serverLayerName',
             FORMAT: 'image/png',
-            LANG: 'somelang',
             TIME: '20180101'
           });
           expect(source.getTileLoadFunction()).to.be.a(Function);


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>
This will remove the ``lang={de|fr|it|rm|en}`` from the getmap requests.
It will make the cloudfront cache much more effective.

[testlink](https://mf-chsdi3.int.bgdi.ch/shorten/82113bc46e) with 
* getmap without lang (chsdi wms layer)
* wms import layer, getFeatureInfo is still with lang parameter and result is translated

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/dev_ltclm_wms_lang/2001071059/index.html)</jenkins>