### PR TITLE
Build staging overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,9 @@
 .PHONY: all
 all: showVariables lint debug release dist apache testdebug testrelease fixrights
 
-.PHONY: user
-user: env .build-artefacts/requirements.timestamp
-	make appconfig && source $(USER_SOURCE) && make src/config.dev.mako all
-
 .PHONY: build
-build: showVariables .build-artefacts/devlibs .build-artefacts/requirements.timestamp $(SRC_JS_FILES) appconfig apache debug release dist
-
+build: guard-STAGING env .build-artefacts/requirements.timestamp appconfig
+	source $(RUNTIME_CONFIGURATION_FILE) && $(MAKE) src/config.$(STAGING).mako all
 
 .PHONY: .build-artefacts/nvm-version
 .build-artefacts/nvm-version: .build-artefacts/last-nvm-version
@@ -33,17 +29,25 @@ endif
 env: .build-artefacts/nvm-version .build-artefacts/node-version
 	source $(HOME)/.bashrc && source ${NVM_DIR}/nvm.sh && nvm use $(NODE_VERSION)
 
+.PHONY: user
+user:
+	RUNTIME_CONFIGURATION_FILE=rc_user;
+	$(MAKE) build STAGING=dev
+
 .PHONY: dev
 dev:
-	make build
+	RUNTIME_CONFIGURATION_FILE=rc_dev;
+	$(MAKE) build STAGING=dev
 
 .PHONY: int
 int:
-	make build
+	RUNTIME_CONFIGURATION_FILE=rc_int;
+	$(MAKE) build STAGING=int
 
 .PHONY: prod
 prod:
-	make build
+	RUNTIME_CONFIGURATION_FILE=rc_prod;
+	$(MAKE) build STAGING=prod
 
 # Include the handling of last values for specific variables
 # (everything like .build-artefacts/last-VARNAME

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -10,8 +10,11 @@ define moveto
 	done;
 endef
 
-# rc file used
-USER_SOURCE ?= rc_user
+
+# default staging is prod
+STAGING ?= prod
+# default rc file used is prod
+RUNTIME_CONFIGURATION_FILE ?= rc_prod
 
 # mf-geoadmin3 or mvt_clean
 PROJECT ?= mf-geoadmin3
@@ -168,7 +171,7 @@ ifeq ($(NODE_VERSION_COMPARISON),matches)
 else
 	# Big disclaimer as nvm tends to make build time plummet
 	FORCE_NODE_VERSION_IF_NEEDED= \
-		echo -e "\n\e[33m================================================================================\n \
+		@echo -e "\n\e[33m================================================================================\n \
 						Your node version doesn't match with the required version to build mf-geoadmin3 (\e[1m$(NODE_VERSION)\e[0m\e[33m).\n \
 						NVM will be used to force the required version during build, but this has a big impact on build performance.\n \
 						Please set your environment to use version \e[1m$(NODE_VERSION)\e[0m\e[33m of node.js for optimal build time\n \

--- a/mk/debug.mk
+++ b/mk/debug.mk
@@ -68,7 +68,7 @@ define buildpage
 		--var "tilegrid_origin"="$(TILEGRID_ORIGIN)" \
 		--var "tilegrid_resolutions"="$(TILEGRID_RESOLUTIONS)" \
 		--var "tilegrid_wmts_dflt_min_res"="$(TILEGRID_WMTS_DFLT_MIN_RES)" \
-		--var "staging"="$(DEPLOY_TARGET)" $< > $@
+		--var "staging"="$(STAGING)" $< > $@
 endef
 
 src/deps.js: $(SRC_JS_FILES) ${PYTHON_VENV}
@@ -86,17 +86,17 @@ src/style/app.css: $(SRC_LESS_FILES)
 src/index.html: src/index.mako.html appconfig \
 	    ${MAKO_CMD} \
 	    ${MAKO_LAST_VARIABLES}
-	$(call buildpage,desktop,,,,$(S3_SRC_BASE_PATH))
+	$(call buildpage,desktop,dev,,,$(S3_SRC_BASE_PATH))
 
 src/mobile.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    ${MAKO_LAST_VARIABLES}
-	$(call buildpage,mobile,,,,$(S3_SRC_BASE_PATH))
+	$(call buildpage,mobile,dev,,,$(S3_SRC_BASE_PATH),)
 
 src/embed.html: src/index.mako.html \
 	    ${MAKO_CMD} \
 	    ${MAKO_LAST_VARIABLES}
-	$(call buildpage,embed,,,,$(S3_SRC_BASE_PATH))
+	$(call buildpage,embed,dev,,,$(S3_SRC_BASE_PATH))
 
 src/TemplateCacheModule.js: src/TemplateCacheModule.mako.js \
 	    ${SRC_COMPONENTS_PARTIALS_FILES} \

--- a/src/config.mako
+++ b/src/config.mako
@@ -20,7 +20,7 @@
 
 %>
 
-       configs["${context['staging']}"] = 
+       configs["${context['mode']}"] = 
        {
        % for key in [k for k in sorted(context.keys()) if k not in ['capture', 'self', 'caller', 'function', 'local'] ]:
          "${key}": ${context[key]| quoting },

--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -711,25 +711,14 @@ itemscope itemtype="http://schema.org/WebApplication"
         // dev env variables
         <%include file="../config.prod.mako"/>
 
-        // Because s3 is hosted on infra
-        var supportedEnv = ['dev', 'int', 'prod', 'ci'];
+        var supportedEnv = ['dev', 'int', 'prod'];
         var requestedStaging = getParam('staging') ;
-        var staging = 'prod';
-        var cfg = configs['prod'];
-        if (!requestedStaging || Object.keys(configs).indexOf(requestedStaging) < 0) {
-          var res = /.*\.(dev|int|ci|infra|prod)\.bgdi\.ch$/.exec(location.hostname);
-          if (res && res.length > 0) {
-            if (Object.keys(configs).indexOf(res[1]) !== -1) {
-              staging = res[1];
-            } 
-          }  
-        } else {
+        var staging = '${staging}';
+        if (requestedStaging) {
             staging = requestedStaging;
         }
+        var cfg = configs[staging];
 
-        // Use 'prod' setting per default
-        var cfg = Object.assign(cfg, configs[staging]);
-        
         var adminUrlRegexp = new RegExp(cfg['admin_url_regexp']);
         var module = angular.module('geoadmin');
         var cacheAdd = cfg['version'] != '' ? '/' + cfg['version'] : '';


### PR DESCRIPTION
Changes a couple things for the build system with `make` :

- `make user` and `make dev|int|prod` now use the same build pipeline. They define which `rc_*` file to source and set `STAGING` variable before calling `make all` (tests are now run before deploying a branch with `make s3deploybranchint`)
- `config.STAGING.mako` are now built with different values for each staging (they were populated with the same values before that, regardless of the staging they were belonging to)
- logical switch for config in `index.mako.html` as been reviewed to use makefile variable `STAGING` to define which config to use (still defaults to prod as default `STAGING` is defined to this value).

Question : Do we really want to disclose our dev and int infrastructure URLs in our `index.html`? As for now, if you look at the source code of https://map.geo.admin.ch you can easily get all URLs (as we have written our dev, int and prod config in this file, which config to use is made with JS)


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_fix_s3deploybranchint/1906280929/index.html)</jenkins>