### PR TITLE
Profile cleanup integration

### DIFF
--- a/src/components/profile/ProfileService.js
+++ b/src/components/profile/ProfileService.js
@@ -41,7 +41,7 @@ goog.require('ga_urlutils_service');
 
     // Utils functions
     var createArea = function(domain, height, elevationModel) {
-      return d3.area().curve(d3.curveBasis).x(function(d) {
+      return d3.area().x(function(d) {
         return domain.X(d.domainDist);
       }).y0(height).y1(function(d) {
         return domain.Y(d.alts[elevationModel]);
@@ -296,7 +296,8 @@ goog.require('ga_urlutils_service');
           var data = $.param({
             geom: wkt,
             elevation_models: elevationModel,
-            offset: 0
+            offset: 0,
+            smart_filling: true
           });
 
           var config = {

--- a/src/components/profile/ProfileService.js
+++ b/src/components/profile/ProfileService.js
@@ -41,7 +41,7 @@ goog.require('ga_urlutils_service');
 
     // Utils functions
     var createArea = function(domain, height, elevationModel) {
-      return d3.area().x(function(d) {
+      return d3.area().curve(d3.curveBasis).x(function(d) {
         return domain.X(d.domainDist);
       }).y0(height).y1(function(d) {
         return domain.Y(d.alts[elevationModel]);
@@ -296,7 +296,7 @@ goog.require('ga_urlutils_service');
           var data = $.param({
             geom: wkt,
             elevation_models: elevationModel,
-            offset: 1
+            offset: 0
           });
 
           var config = {

--- a/test/specs/profile/ProfileService.spec.js
+++ b/test/specs/profile/ProfileService.spec.js
@@ -158,7 +158,7 @@ describe('ga_profile_service', function() {
         var spy = sinon.spy($http, 'post');
         gaProfile.create(feature);
         expect(spy.callCount).to.be(1);
-        expect(spy.args[0][1]).to.be('geom=%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B0.0%2C0.0%5D%2C%5B1.0%2C0.0%5D%2C%5B1.0%2C1.0%5D%5D%7D&elevation_models=COMB&offset=0');
+        expect(spy.args[0][1]).to.be('geom=%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B0.0%2C0.0%5D%2C%5B1.0%2C0.0%5D%2C%5B1.0%2C1.0%5D%5D%7D&elevation_models=COMB&offset=0&smart_filling=true');
         var config = spy.args[0][2];
         expect(config.cache).to.be(true);
         expect(config.timeout).to.be.a(Object);

--- a/test/specs/profile/ProfileService.spec.js
+++ b/test/specs/profile/ProfileService.spec.js
@@ -158,7 +158,7 @@ describe('ga_profile_service', function() {
         var spy = sinon.spy($http, 'post');
         gaProfile.create(feature);
         expect(spy.callCount).to.be(1);
-        expect(spy.args[0][1]).to.be('geom=%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B0.0%2C0.0%5D%2C%5B1.0%2C0.0%5D%2C%5B1.0%2C1.0%5D%5D%7D&elevation_models=COMB&offset=1');
+        expect(spy.args[0][1]).to.be('geom=%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B0.0%2C0.0%5D%2C%5B1.0%2C0.0%5D%2C%5B1.0%2C1.0%5D%5D%7D&elevation_models=COMB&offset=0');
         var config = spy.args[0][2];
         expect(config.cache).to.be(true);
         expect(config.timeout).to.be.a(Object);


### PR DESCRIPTION
fix https://github.com/geoadmin/mf-geoadmin3/issues/4944

This changes the way geoadmin request profile to the backend, it adds an extra param to integrate points given in the geom and to not exceed altitude model's resolution when filling points.
Therefore there's no more need of a smoothing as there won't be "steps" anymore

<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_profile_with_resolution_param/2003091245/index.html)</jenkins>