### PR TITLE
Fix how RC files are defined when calling make targets user, dev, int and prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,23 +31,19 @@ env: .build-artefacts/nvm-version .build-artefacts/node-version
 
 .PHONY: user
 user:
-	RUNTIME_CONFIGURATION_FILE=rc_user;
-	$(MAKE) build STAGING=dev
+	$(MAKE) build STAGING=dev RUNTIME_CONFIGURATION_FILE=rc_user
 
 .PHONY: dev
 dev:
-	RUNTIME_CONFIGURATION_FILE=rc_dev;
-	$(MAKE) build STAGING=dev
+	$(MAKE) build STAGING=dev RUNTIME_CONFIGURATION_FILE=rc_dev
 
 .PHONY: int
 int:
-	RUNTIME_CONFIGURATION_FILE=rc_int;
-	$(MAKE) build STAGING=int
+	$(MAKE) build STAGING=int RUNTIME_CONFIGURATION_FILE=rc_int
 
 .PHONY: prod
 prod:
-	RUNTIME_CONFIGURATION_FILE=rc_prod;
-	$(MAKE) build STAGING=prod
+	$(MAKE) build STAGING=prod RUNTIME_CONFIGURATION_FILE=rc_prod
 
 # Include the handling of last values for specific variables
 # (everything like .build-artefacts/last-VARNAME


### PR DESCRIPTION
Following https://github.com/geoadmin/mf-geoadmin3/pull/4981, this fixes the Makefile so that the first call to `make user` on mf1-dev generate a correct set of apache config


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_fix_rc_source_path/1907300747/index.html)</jenkins>