### PR TITLE
changing the way Jenkins publish branches after successful build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,9 +78,9 @@ node(label: 'jenkins-slave') {
           stdout = sh returnStdout: true, script: 'make ' + makeTargetForDeployIntDev + ' DEPLOY_TARGET=int FORCE=true PROJECT='+ project + ' DEPLOY_GIT_BRANCH=' + deployGitBranch
           echo stdout
           def lines = stdout.readLines()
-          deployedVersion = lines.get(lines.size()-5)
-          s3VersionPath = lines.get(lines.size()-3)
-          e2eTargetUrl = lines.get(lines.size()-1)
+          deployedVersion = lines.get(lines.size() - 6)
+          s3VersionPath = lines.get(lines.size() - 4)
+          e2eTargetUrl = lines.get(lines.size() - 2)
         },
         'prod': {
           // Both projects 'mvt' and 'mf-geoadmin3' are deployable to <prod>,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,7 +171,7 @@ node(label: 'jenkins-slave') {
       def targets = ['int']
       // Unofortunately, bucket <dev> doesn't not exist for 'mvt'
       if (isGitMaster && project == 'mf-geoadmin3') {
-        targets.push('dev']
+        targets.push('dev')
       }
       for (target in targets) {
         echo 'Activating on ' + target

--- a/mk/deploy.mk
+++ b/mk/deploy.mk
@@ -77,7 +77,8 @@ s3deploybranch: guard-CLONEDIR \
 	make s3copybranch CODE_DIR=${CLONEDIR}/mf-geoadmin3 \
 	                  DEPLOY_TARGET=${DEPLOY_TARGET} \
 	                  NAMED_BRANCH=${NAMED_BRANCH} \
-	                  PROJECT=${PROJECT}
+	                  PROJECT=${PROJECT} \
+	                  $(shell if [ ${FORCE} = "true" ]; then echo "--force"; fi)
 
 .PHONY: s3deploybranchint
 s3deploybranchint:

--- a/mk/deploy.mk
+++ b/mk/deploy.mk
@@ -77,8 +77,7 @@ s3deploybranch: guard-CLONEDIR \
 	make s3copybranch CODE_DIR=${CLONEDIR}/mf-geoadmin3 \
 	                  DEPLOY_TARGET=${DEPLOY_TARGET} \
 	                  NAMED_BRANCH=${NAMED_BRANCH} \
-	                  PROJECT=${PROJECT} \
-	                  $(shell if [ ${FORCE} = "true" ]; then echo "--force"; fi)
+	                  PROJECT=${PROJECT}
 
 .PHONY: s3deploybranchint
 s3deploybranchint:


### PR DESCRIPTION
Only publish `master` on dev
Use `s3deploybranch` (or `s3deploy` when on `master`) instead of `s3copybranch` so that the whole project is rebuilt with the correct environment variables for the specified target (before that, every target would have `source rc_prod` and thus would request production mf-chsdi3 for layers config and such)


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_fix_publish_dev_int_from_jenkins/1908071404/index.html)</jenkins>