### PR TITLE
chore(package): update autoprefixer to version 9.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "angular-mocks": "1.7.8",
-    "autoprefixer": "9.6.1",
+    "autoprefixer": "9.6.4",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "bootstrap": "3.4.1",


### PR DESCRIPTION
Closes #5051



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/greenkeeper/autoprefixer-9.6.4/1910080618/index.html)</jenkins>