### PR TITLE
chore(package): update google-closure-library to version 20191027.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-standard": "4.0.1",
     "expect.js": "0.3.1",
     "google-closure-compiler": "20170423.0.0",
-    "google-closure-library": "20190929.0.0",
+    "google-closure-library": "20191027.0.1",
     "html-minifier": "4.0.0",
     "jquery": "3.4.1",
     "karma": "4.4.1",


### PR DESCRIPTION
Closes #5065



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/greenkeeper/google-closure-library-20191027.0.1/1911010849/index.html)</jenkins>