### PR TITLE
Update ImportController.js

### DIFF
--- a/src/js/ImportController.js
+++ b/src/js/ImportController.js
@@ -232,6 +232,7 @@ goog.require('ga_wmts_service');
       'https://services.arcgisonline.com/arcgis/rest/services/Reference/World_Transportation/MapServer/WMTS/1.0.0/WMTSCapabilities.xml',
       'https://services.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Base/MapServer/WMTS/1.0.0/WMTSCapabilities.xml',
       'https://services.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/WMTS/1.0.0/WMTSCapabilities.xml',
+      'http://sgx.geodatenzentrum.de/wmts_topplus_open/1.0.0/WMTSCapabilities.xml',
       'https://geo.so.ch/api/wmts/1.0.0/WMTSCapabilities.xml'
     ];
 


### PR DESCRIPTION
TopPlusOpen für Deutschland: vom Bundesamt für Kartographie und Geodäsie kann mit der Version 4.0.11 genutzt werden



<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltoed_importBKG-WMTS/1912021425/index.html)</jenkins>