### PR TITLE
Remove hash from help URL

### DIFF
--- a/src/components/help/HelpDirective.js
+++ b/src/components/help/HelpDirective.js
@@ -66,7 +66,7 @@ goog.require('ga_help_service');
         });
 
         var generateUrl = function(helpIds) {
-          return '//help.geo.admin.ch/#/' +
+          return '//help.geo.admin.ch/' +
             '?ids=' + helpIds +
             '&lang=' + gaLang.getNoRm() +
             '&embedded=true';


### PR DESCRIPTION
After changes made by https://github.com/geoadmin/web-geoadmin-help/pull/16 we need to remove hashes from help's URLs


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/ltbtp_remove_hash_from_help_url/2004061533/index.html)</jenkins>