### PR TITLE
makefile configs target assure output quality

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ node(label: 'jenkins-slave') {
     }
 
     stage('Build') {
+      sh 'command -v jq &> /dev/null || DEBIAN_FRONTEND=noninteractive apt-get -yq install jq'
       sh 'make build GIT_BRANCH=' + deployGitBranch
     }
 

--- a/mk/serviceconfig.mk
+++ b/mk/serviceconfig.mk
@@ -24,8 +24,8 @@ configs/: .build-artefacts/last-version \
           guard-LAYERSCONFIG_VERSION
 	mkdir -p $@
 	curl -s -q -o configs/services.json http:$(API_URL)/rest/services
-	$(foreach lang, $(LANGS), mkdir -p $@$(lang) && curl -s --retry 3 --fail -o configs/$(lang)/layersConfig.json http:$(API_URL)/rest/services/all/MapServer/layersConfig?lang=$(lang);)
-	$(foreach topic, $(TOPICS), $(foreach lang, $(LANGS),curl -s --retry 3 --fail -o configs/${lang}/catalog.${topic}.json http:$(API_URL)/rest/services/$(topic)/CatalogServer?lang=$(lang); ))
+	$(foreach lang, $(LANGS), mkdir -p $@$(lang) && curl -s --retry 3 --fail -o configs/$(lang)/layersConfig.json http:$(API_URL)/rest/services/all/MapServer/layersConfig?lang=$(lang) && jq . configs/$(lang)/layersConfig.json 1> /dev/null;)
+	$(foreach topic, $(TOPICS), $(foreach lang, $(LANGS),curl -s --retry 3 --fail -o configs/${lang}/catalog.${topic}.json http:$(API_URL)/rest/services/$(topic)/CatalogServer?lang=$(lang) && jq . configs/${lang}/catalog.${topic}.json 1> /dev/null; ))
 
 
 # Variables for the different staging.

--- a/mk/serviceconfig.mk
+++ b/mk/serviceconfig.mk
@@ -24,8 +24,8 @@ configs/: .build-artefacts/last-version \
           guard-LAYERSCONFIG_VERSION
 	mkdir -p $@
 	curl -s -q -o configs/services.json http:$(API_URL)/rest/services
-	$(foreach lang, $(LANGS), mkdir -p $@$(lang) && curl -s --retry 3 -o configs/$(lang)/layersConfig.json http:$(API_URL)/rest/services/all/MapServer/layersConfig?lang=$(lang);)
-	$(foreach topic, $(TOPICS), $(foreach lang, $(LANGS),curl -s --retry 3 -o configs/${lang}/catalog.${topic}.json http:$(API_URL)/rest/services/$(topic)/CatalogServer?lang=$(lang); ))
+	$(foreach lang, $(LANGS), mkdir -p $@$(lang) && curl -s --retry 3 --fail -o configs/$(lang)/layersConfig.json http:$(API_URL)/rest/services/all/MapServer/layersConfig?lang=$(lang);)
+	$(foreach topic, $(TOPICS), $(foreach lang, $(LANGS),curl -s --retry 3 --fail -o configs/${lang}/catalog.${topic}.json http:$(API_URL)/rest/services/$(topic)/CatalogServer?lang=$(lang); ))
 
 
 # Variables for the different staging.


### PR DESCRIPTION
<jenkins>A test link will be added here if the deploy on int succeeded.</jenkins>

triggered by: https://github.com/geoadmin/mf-geoadmin3/issues/5175

config file generation with api calls ``make configs/`` will throw an error if:
* http status is not 200
* response is not a valid json


<jenkins>[Test link](https://mf-geoadmin3.int.bgdi.ch/feature_curl_fail/2005260650/index.html)</jenkins>