### PR TITLE
Allow bigger KMLs

### DIFF
--- a/src/components/import/FileService.js
+++ b/src/components/import/FileService.js
@@ -16,7 +16,7 @@ goog.provide('ga_file_service');
 
         // Test the validity of the file size
         this.isValidFileSize = function(fileSize) {
-          return !(fileSize > 20000000); // 20 Mo
+          return !(fileSize > 25000000); // 25 Mo
         };
 
         this.isWmsGetCap = function(fileContent) {


### PR DESCRIPTION
Allow KML up to 25MB

This won't work
https://map.geo.admin.ch/master/1912040901/index.html?layers=KML%7C%7Chttps:%2F%2Fcms.geo.admin.ch%2FTopo%2FKML%2Fswissbathy3d_verfuegbarkeit_de.kml

With this PR
https://mf-geoadmin3.dev.bgdi.ch/feature_bigger_kml/2007071838/index.html?layers=KML%7C%7Chttps:%2F%2Fcms.geo.admin.ch%2FTopo%2FKML%2Fswissbathy3d_verfuegbarkeit_de.kml

:bomb: But the main issue, is that the KML imported via params is check for size or via the `all-in-one`  bar, while the manually imported one is not.