### PR TITLE
Remove cache prefix in API URLs

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -806,7 +806,6 @@ itemscope itemtype="http://schema.org/WebApplication"
           qrcodePath: qrcodePath,
           adminUrlRegexp: adminUrlRegexp,
           hrefRegexp: new RegExp(cfg['href_regexp']),
-          cachedApiUrl: apiUrl + cacheAdd,
           cachedAltiUrl: altiUrl + cacheAdd,
           imageryMetadataUrl: terrainUrl + '/imagery/',
           cachedPrintUrl: printUrl + cacheAdd,

--- a/src/js/FeaturetreeController.js
+++ b/src/js/FeaturetreeController.js
@@ -20,7 +20,7 @@ goog.require('ga_translation_service');
     };
 
     $scope.options = {
-      msUrl: gaGlobalOptions.cachedApiUrl + '/rest/services/all/MapServer',
+      msUrl: gaGlobalOptions.apiUrl + '/rest/services/all/MapServer',
       featuresShown: false,
       hasMoreResults: false,
       nbFeatures: 0,

--- a/src/js/GaModule.js
+++ b/src/js/GaModule.js
@@ -201,7 +201,7 @@ goog.require('ga_waitcursor_service');
   });
 
   module.config(function(gaPreviewFeaturesProvider, gaGlobalOptions) {
-    gaPreviewFeaturesProvider.url = gaGlobalOptions.cachedApiUrl +
+    gaPreviewFeaturesProvider.url = gaGlobalOptions.apiUrl +
         '/rest/services/all/MapServer/';
   });
 

--- a/src/js/SearchController.js
+++ b/src/js/SearchController.js
@@ -13,9 +13,9 @@ goog.provide('ga_search_controller');
     }
 
     $scope.options = {
-      searchUrl: gaGlobalOptions.cachedApiUrl +
+      searchUrl: gaGlobalOptions.apiUrl +
           '/rest/services/{Topic}/SearchServer' + sr,
-      featureUrl: gaGlobalOptions.cachedApiUrl +
+      featureUrl: gaGlobalOptions.apiUrl +
           '/rest/services/{Topic}/MapServer/{Layer}/{Feature}' + sr
     };
   });

--- a/src/js/SeoController.js
+++ b/src/js/SeoController.js
@@ -5,7 +5,7 @@ goog.provide('ga_seo_controller');
 
   module.controller('GaSeoController', function($scope, gaGlobalOptions) {
     $scope.options = {
-      htmlUrlTemplate: gaGlobalOptions.cachedApiUrl +
+      htmlUrlTemplate: gaGlobalOptions.apiUrl +
           '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup',
       searchUrl: gaGlobalOptions.apiUrl + '/rest/services/ech/SearchServer',
       identifyUrl: gaGlobalOptions.apiUrl +

--- a/src/js/TooltipController.js
+++ b/src/js/TooltipController.js
@@ -12,7 +12,7 @@ goog.require('ga_window_service');
       gaWindow) {
     $scope.options = {
       tolerance: gaWindow.isWidth('<=s') ? 20 : 10,
-      htmlUrlTemplate: gaGlobalOptions.cachedApiUrl +
+      htmlUrlTemplate: gaGlobalOptions.apiUrl +
           '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup'
     };
   });

--- a/test/specs/Loader.spec.js
+++ b/test/specs/Loader.spec.js
@@ -49,7 +49,6 @@ beforeEach(function() {
       publicUrl: location.protocol + publicUrl,
       publicUrlRegexp: /^https?:\/\/public\..*\.(bgdi|admin)\.ch\/.*/,
       adminUrlRegexp: /^(ftp|http|https):\/\/(.*(\.bgdi|\.geo\.admin)\.ch)/,
-      cachedApiUrl: location.protocol + apiUrl + cacheAdd,
       cachedPrintUrl: location.protocol + printUrl + cacheAdd,
       resourceUrl: location.origin + pathname + versionSlashed,
       proxyUrl: location.protocol + proxyUrl + '/',
@@ -124,7 +123,7 @@ beforeEach(function() {
 
   module(function(gaPreviewFeaturesProvider, gaGlobalOptions) {
     gaPreviewFeaturesProvider.url =
-        gaGlobalOptions.cachedApiUrl + '/rest/services/all/MapServer/';
+        gaGlobalOptions.apiUrl + '/rest/services/all/MapServer/';
   });
 
   module(function(gaProfileProvider, gaGlobalOptions) {

--- a/test/specs/js/FeaturetreeController.spec.js
+++ b/test/specs/js/FeaturetreeController.spec.js
@@ -46,7 +46,7 @@ describe('ga_featuretree_controller', function() {
       });
 
       it('set scope values', function() {
-        expect(scope.options.msUrl).to.be(gaGlobalOptions.cachedApiUrl + '/rest/services/all/MapServer');
+        expect(scope.options.msUrl).to.be(gaGlobalOptions.apiUrl + '/rest/services/all/MapServer');
         expect(scope.options.featuresShown).to.be(false);
         expect(scope.options.hasMoreResults).to.be(false);
         expect(scope.options.nbFeatures).to.be(0);

--- a/test/specs/js/SearchController.spec.js
+++ b/test/specs/js/SearchController.spec.js
@@ -44,8 +44,8 @@ describe('ga_search_controller', function() {
       $timeout.flush();
 
       var opt = scope.options;
-      expect(opt.searchUrl).to.be(gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/SearchServer?');
-      expect(opt.featureUrl).to.be(gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}?');
+      expect(opt.searchUrl).to.be(gaGlobalOptions.apiUrl + '/rest/services/{Topic}/SearchServer?');
+      expect(opt.featureUrl).to.be(gaGlobalOptions.apiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}?');
     });
 
     it('set scope values if map is defined', function() {
@@ -53,8 +53,8 @@ describe('ga_search_controller', function() {
       $timeout.flush();
 
       var opt = scope.options;
-      expect(opt.searchUrl).to.be(gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/SearchServer?sr=3857&');
-      expect(opt.featureUrl).to.be(gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}?sr=3857&');
+      expect(opt.searchUrl).to.be(gaGlobalOptions.apiUrl + '/rest/services/{Topic}/SearchServer?sr=3857&');
+      expect(opt.featureUrl).to.be(gaGlobalOptions.apiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}?sr=3857&');
     });
   });
 });

--- a/test/specs/js/SeoController.spec.js
+++ b/test/specs/js/SeoController.spec.js
@@ -42,7 +42,7 @@ describe('ga_seo_controller', function() {
 
     it('set scope values', function() {
       var opt = scope.options;
-      expect(opt.htmlUrlTemplate).to.be(gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup');
+      expect(opt.htmlUrlTemplate).to.be(gaGlobalOptions.apiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup');
       expect(opt.searchUrl).to.be(gaGlobalOptions.apiUrl + '/rest/services/ech/SearchServer');
       expect(opt.identifyUrl).to.be(gaGlobalOptions.apiUrl + '/rest/services/all/MapServer/identify');
     });

--- a/test/specs/js/TooltipController.spec.js
+++ b/test/specs/js/TooltipController.spec.js
@@ -43,7 +43,7 @@ describe('ga_tooltip_controller', function() {
 
       it('set scope values', function() {
         expect(scope.options.tolerance).to.be(10);
-        expect(scope.options.htmlUrlTemplate).to.be(gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup');
+        expect(scope.options.htmlUrlTemplate).to.be(gaGlobalOptions.apiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup');
       });
     });
 
@@ -59,7 +59,7 @@ describe('ga_tooltip_controller', function() {
 
       it('set scope values', function() {
         expect(scope.options.tolerance).to.be(20);
-        expect(scope.options.htmlUrlTemplate).to.be(gaGlobalOptions.cachedApiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup');
+        expect(scope.options.htmlUrlTemplate).to.be(gaGlobalOptions.apiUrl + '/rest/services/{Topic}/MapServer/{Layer}/{Feature}/htmlPopup');
       });
     });
   });

--- a/test/specs/map/PreviewFeaturesService.spec.js
+++ b/test/specs/map/PreviewFeaturesService.spec.js
@@ -4,7 +4,7 @@ describe('ga_previewfeatures_service', function() {
   describe('gaPreviewFeatures', function() {
     var gaPreviewFeatures, map, $httpBackend, gaMapUtils, gaStyleFactory, gaLayers, $q;
 
-    var tpl = window.location.protocol + '//api3.geo.admin.ch/123456/rest/services/all/MapServer/{{layerId}}/{{featId}}?sr=3857&geometryFormat=geojson';
+    var tpl = window.location.protocol + '//api3.geo.admin.ch/rest/services/all/MapServer/{{layerId}}/{{featId}}?sr=3857&geometryFormat=geojson';
     var expectGET = function(featIdsByBodId) {
       angular.forEach(featIdsByBodId, function(featIds, layerId) {
         featIds.forEach(function(featId) {


### PR DESCRIPTION
Now that the whole API is behind CloudFront, this will make the cache invalidation easier.


Test with (using prod api3): https://mf-geoadmin3.dev.bgdi.ch/ltbtp_remove_cache_prefix/2203091629/index.html?api_url=//api3.geo.admin.ch
