### PR TITLE
Using last pip version using python2

### DIFF
--- a/mk/last.mk
+++ b/mk/last.mk
@@ -10,7 +10,7 @@ endef
 ${PYTHON_VENV}: .build-artefacts/last-pypi-url
 	mkdir -p .build-artefacts
 	virtualenv --no-site-packages --python=python2 $@
-	${PIP_CMD} install --index-url ${PYPI_URL} -U pip setuptools==44.0.0
+	${PIP_CMD} install --index-url ${PYPI_URL} -U pip==19.2.3 setuptools==44.0.0
 	$(MAKE) .build-artefacts/requirements.timestamp
 
 


### PR DESCRIPTION
The subsequent versions of `pip` have ditched support for python2