### PR TITLE
BGDIINF_SB_2002: bugfix, restoring error reports

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -59,4 +59,4 @@ phases:
   post_build:
     commands:
       - echo Build completed on `date`
-      - ls -lah .
+      - find . -iname xml


### PR DESCRIPTION
I'm trying to correct how error reports are handled in AWS to have both a working build, and working error reports