### PR TITLE
Shorten the permalink before using it in the qrcode

### DIFF
--- a/src/components/print/PrintDirective.js
+++ b/src/components/print/PrintDirective.js
@@ -255,10 +255,8 @@ goog.require('ga_urlutils_service');
       var lang = gaLang.get();
       var defaultPage = {};
       defaultPage['lang' + lang] = true;
-      var qrcodeUrl = $scope.options.qrcodeUrl +
-          encodeURIComponent(gaPermalink.getHref());
+      var qrcodeServiceUrl = $scope.options.qrcodeUrl;
       var printZoom = getZoomFromScale($scope.scale.value);
-      qrcodeUrl = qrcodeUrl.replace(/zoom%3D(\d{1,2})/, 'zoom%3D' + printZoom);
       var encLayers = [];
       var encLegends = [];
       var attributions = [];
@@ -405,9 +403,11 @@ goog.require('ga_urlutils_service');
       // Get the short link
       var shortLink;
       canceller = $q.defer();
-      gaUrlUtils.shorten(gaPermalink.getHref(), canceller.promise).
+      var permalink = gaPermalink.getHref();
+      permalink = permalink.replace(/zoom%3D(\d{1,2})/, 'zoom%3D' + printZoom);
+      gaUrlUtils.shorten(permalink, canceller.promise).
           then(function(shortUrl) {
-            shortLink = shortUrl.replace('/shorten', '');
+            shortLink = shortUrl;
 
             // Build the complete json then send it to the print server
             if (!$scope.options.printing) {
@@ -430,7 +430,8 @@ goog.require('ga_urlutils_service');
               layers: encLayers,
               legends: encLegends,
               enableLegends: !!encLegends.length,
-              qrcodeurl: qrcodeUrl,
+              // The qrcode service is no longer shortening urls
+              qrcodeurl: qrcodeServiceUrl + shortLink,
               movie: movieprint,
               pages: [
                 angular.extend({

--- a/test/specs/print/PrintDirective.spec.js
+++ b/test/specs/print/PrintDirective.spec.js
@@ -389,12 +389,12 @@ describe('ga_print_directive', function() {
             expect(conf.app).to.be('config');
             expect(conf.lang).to.be('en');
             expect(conf.dpi).to.be('150');
-            expect(conf.qrcodeurl).to.be('http://foo.ch/qrcodegenerator?url=http%3A%2F%2Flocalhost%3A8081%2Fcontext.html%3Flang%3Den');
+            expect(conf.qrcodeurl).to.be('http://foo.ch/qrcodegenerator?url=http://foo.ch/shorten');
             expect(conf.pages[0].center).to.eql([10000, 10000]);
             expect(conf.pages[0].bbox).to.eql([10000, 10000, 10000, 10000]);
             expect(conf.pages[0].display).to.eql([802, 530]);
             expect(conf.pages[0].scale).to.eql('500.0');
-            expect(conf.pages[0].shortLink).to.eql('http://foo.ch');
+            expect(conf.pages[0].shortLink).to.eql('http://foo.ch/shorten');
             expect(conf.pages[0].rotation).to.eql(0);
             expect(conf.pages[0].langen).to.be(true);
           };


### PR DESCRIPTION
As the Qrcode service is no longer shortening urls...

To test:

print something, open the resulting PDF and scan the qrcode. You should get a view in map.geo.admin.ch ressembling to what you just printed.

Demo: https://mf-geoadmin3.dev.bgdi.ch/bug_BGDIINF_SB-2054_shorten_permalink/2111181911/index.html

See https://github.com/geoadmin/mf-geoadmin3/pull/5249