### PR TITLE
BGDIDIC-1457: ch.bazl.luftfahrthindernis is not queryable anymore

### DIFF
--- a/scripts/meteoStyleUrl.py
+++ b/scripts/meteoStyleUrl.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 """
-Simple script to copy the map.geo.admin.ch configuration files and update the pathes 
+Simple script to copy the map.geo.admin.ch configuration files and update the pathes
 to allow METEOSCHWEIZ to edit and test their custom GeoJSON styles.
 
 This script is usually not runned directly, but with:
 
     make meteoconfigs/
 
-For more information, see the METEOSCHWEIZ.md 
+For more information, see the METEOSCHWEIZ.md
 
 """
 import os

--- a/src/components/query/QueryService.js
+++ b/src/components/query/QueryService.js
@@ -61,52 +61,9 @@ goog.provide('ga_query_service');
     this.$get = function($http, $log, $q, gaLang, $window,
         gaGlobalOptions) {
       var msUrl = gaGlobalOptions.apiUrl + '/rest/services/all/MapServer/';
-      var twoWeeksAgo = $window.moment().subtract(2, 'weeks').
-          format('YYYY-MM-DD');
-      var fourDaysAgo = $window.moment().subtract(4, 'days').
-          format('YYYY-MM-DD');
 
       // List of predefined queries by layer
       var predefQueriesByLayer = {
-        'ch.bazl.luftfahrthindernis': [{
-          id: 'obstacle_started_last_2_weeks',
-          filters: [{
-            attrName: 'bgdi_activesince',
-            operator: '>=',
-            value: twoWeeksAgo
-          }, {
-            attrName: 'state',
-            operator: 'ilike',
-            value: 'A'
-          }]
-        }, {
-          id: 'obstacle_deleted_last_2_weeks',
-          filters: [{
-            layer: null,
-            attrName: 'abortionaccomplished',
-            operator: '>=',
-            value: twoWeeksAgo
-          }]
-        }, {
-          id: 'obstacle_started_last_4_days',
-          filters: [{
-            attrName: 'bgdi_activesince',
-            operator: '>=',
-            value: fourDaysAgo
-          }, {
-            attrName: 'state',
-            operator: 'ilike',
-            value: 'A'
-          }]
-        }, {
-          id: 'obstacle_deleted_last_4_days',
-          filters: [{
-            layer: null,
-            attrName: 'abortionaccomplished',
-            operator: '>=',
-            value: fourDaysAgo
-          }]
-        }],
         'ch.astra.unfaelle-personenschaeden_alle': [{
           id: 'astra_alle_lastyear_casualties',
           filters: [{

--- a/test/specs/query/QueryService.spec.js
+++ b/test/specs/query/QueryService.spec.js
@@ -3,50 +3,7 @@ describe('ga_query_service', function() {
 
   describe('gaQuery', function() {
     var gaQuery, $httpBackend;
-    var twoWeeksAgo = window.moment().subtract(2, 'weeks').
-        format('YYYY-MM-DD');
-    var fourDaysAgo = window.moment().subtract(4, 'days').
-        format('YYYY-MM-DD');
     var predefQueriesByLayer = {
-      'ch.bazl.luftfahrthindernis': [{
-        id: 'obstacle_started_last_2_weeks',
-        filters: [{
-          attrName: 'bgdi_activesince',
-          operator: '>=',
-          value: twoWeeksAgo
-        }, {
-          attrName: 'state',
-          operator: 'ilike',
-          value: 'A'
-        }]
-      }, {
-        id: 'obstacle_deleted_last_2_weeks',
-        filters: [{
-          layer: null,
-          attrName: 'abortionaccomplished',
-          operator: '>=',
-          value: twoWeeksAgo
-        }]
-      }, {
-        id: 'obstacle_started_last_4_days',
-        filters: [{
-          attrName: 'bgdi_activesince',
-          operator: '>=',
-          value: fourDaysAgo
-        }, {
-          attrName: 'state',
-          operator: 'ilike',
-          value: 'A'
-        }]
-      }, {
-        id: 'obstacle_deleted_last_4_days',
-        filters: [{
-          layer: null,
-          attrName: 'abortionaccomplished',
-          operator: '>=',
-          value: fourDaysAgo
-        }]
-      }],
       'ch.astra.unfaelle-personenschaeden_alle': [{
         id: 'astra_alle_lastyear_casualties',
         filters: [{
@@ -89,9 +46,7 @@ describe('ga_query_service', function() {
 
     describe('getPredefQueries', function() {
       it('returns a list a predefined queries for a layer', function() {
-        var layerId = 'ch.bazl.luftfahrthindernis';
-        expect(gaQuery.getPredefQueries(layerId)).to.eql(predefQueriesByLayer[layerId]);
-        layerId = 'ch.astra.unfaelle-personenschaeden_alle';
+        var layerId = 'ch.astra.unfaelle-personenschaeden_alle';
         expect(gaQuery.getPredefQueries(layerId)).to.eql(predefQueriesByLayer[layerId]);
       });
     });


### PR DESCRIPTION
[Testlink](https://mf-geoadmin3.dev.bgdi.ch/ltclm/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Ffeat-BGDIDIC-1457-obstacles&wms_url=%2F%2Fwms-test.dev.bgdi.ch%2Fltclm_lfh%2Fxx%2F&lang=de&topic=ech&bgLayer=ch.swisstopo.swissimage&layers=ch.bazl.luftfahrthindernis,ch.bazl.luftfahrthindernis-aenderungen,ch.astra.unfaelle-personenschaeden_alle&E=2647896.33&N=1170783.11&zoom=1&config_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Ffeat-BGDIDIC-1457-obstacles%2Fconfigs&layers_timestamp=,,99990101)