### PR TITLE
BGDIINF_SB-2546: localhost:port addresses are using http

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -742,7 +742,13 @@ itemscope itemtype="http://schema.org/WebApplication"
           if (env && env != 'prod' && supportedEnv.indexOf(env) !== -1) {
               url = techUrl + env + cfg['tech_suffix'];
           }
-          var overwrite = prtl + getParam(overwriteParam);
+          var overwrite = ''
+          // localhost:port goes with http
+          if (/^\/\/localhost\:.*$/.test(getParam(overwriteParam))) {
+              overwrite = 'http:' + getParam(overwriteParam);
+          } else {
+              overwrite = prtl + getParam(overwriteParam);
+          }
           url = adminUrlRegexp.test(overwrite) ? overwrite : url;
           return url;
         }


### PR DESCRIPTION
this will force localhost:port values in these parameters to http:
* api_url
* wms_url
* config_url
* ...

[Testlink](https://mf-geoadmin3.dev.bgdi.ch/feature_BGDIINF_SB-2546_localhost_http/2208172006/index.html)