### PR TITLE
BGDIINF_SB-2552 : remove iOs specific download code

### DIFF
--- a/src/components/ExportKmlService.js
+++ b/src/components/ExportKmlService.js
@@ -19,7 +19,7 @@ goog.require('ga_browsersniffer_service');
       var downloadUrl = this.downloadKmlUrl;
 
       var useDownloadService = function() {
-        return gaBrowserSniffer.msie === 9;
+        return gaBrowserSniffer.msie === 9 || !gaBrowserSniffer.blob;
       };
 
       var ExportKml = function() {

--- a/src/components/ExportKmlService.js
+++ b/src/components/ExportKmlService.js
@@ -19,12 +19,7 @@ goog.require('ga_browsersniffer_service');
       var downloadUrl = this.downloadKmlUrl;
 
       var useDownloadService = function() {
-        if (gaBrowserSniffer.msie === 9 ||
-            gaBrowserSniffer.safari ||
-            !gaBrowserSniffer.blob) {
-          return true;
-        }
-        return false;
+        return gaBrowserSniffer.msie === 9;
       };
 
       var ExportKml = function() {


### PR DESCRIPTION
As we have moved our infra to Frankfurt, we want to clean up a bit some endpoints. /downloadkml is one of those endpoint, and is used exclusively for IE9 and iOs KML download.

As iOs now has a file system of its own, it should be ok downloading the file through standard means.
For IE9, we will wait a while (a month or so) and see if we still see some requests made to the endpoint with this very old browser. If not, this portion of the code will be removed altogether, backend endpoint included.

[Test link](https://mf-geoadmin3.dev.bgdi.ch/bugfix_BGDIINF_SB-2552_fix_kml_download_on_ios/2208231122/index.html)