### PR TITLE
Deactivating tests for deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 -include mk/help.mk
 
 .PHONY: all
-all: showVariables lint debug release dist apache testdebug testrelease fixrights
+all: showVariables lint debug release dist apache fixrights
 
 .PHONY: ci
 ci: showVariables lint debug release dist


### PR DESCRIPTION
there is still issues while doing make s3deploydev (and int/prod) with the clonebuild.sh script, tests do not run properly in this instance

