### PR TITLE
Remove URL from testlink A tag

### DIFF
--- a/src/components/vectortile/VectorTileTestLink.directive.js
+++ b/src/components/vectortile/VectorTileTestLink.directive.js
@@ -26,10 +26,8 @@ goog.require('ga_urlutils_service');
           transclude: true,
           templateUrl: 'components/vectortile/partials/testlink.html',
           link: function(scope, element, attrs) {
-            scope.url = generateTestLinkUrl();
             scope.openTestViewerWithSamePermalink = function(e) {
-              var url = generateTestLinkUrl();
-              $window.open(url, '_blank');
+              $window.open(generateTestLinkUrl(), '_blank');
               e.preventDefault();
             };
           }

--- a/src/components/vectortile/partials/testlink.html
+++ b/src/components/vectortile/partials/testlink.html
@@ -1,1 +1,1 @@
-<a class="testviewer-link" href="{{ url }}" ng-click="openTestViewerWithSamePermalink($event)" target="_blank" translate>try_test_viewer</a>
+<a class="testviewer-link" ng-click="openTestViewerWithSamePermalink($event)" target="_blank" translate>try_test_viewer</a>

--- a/src/style/app.less
+++ b/src/style/app.less
@@ -1879,6 +1879,7 @@ body:not(.embed) {
 .testviewer-link {
   font-weight: bold;
   color: @red;
+  cursor: pointer;
 }
 
 @import "print.less";


### PR DESCRIPTION
so that only the click handler is used to determine the end location. With a href defined, some browser (like Firefox) would not let the handler do its things but open the URL created at startup, leading to the map always be on the test viewer where the legacy viewer started

