### PR TITLE
No golive disclaimer in embed

### DIFF
--- a/src/index.mako.html
+++ b/src/index.mako.html
@@ -178,7 +178,9 @@ itemscope itemtype="http://schema.org/WebApplication"
 % endif
     <div id="loader"></div>
     <div tabindex="1" ga-map ga-map-map="map" ga-map-ol3d="::ol3d">
+  % if device != 'embed':
       <div class="warning-web-mapviewer-go-live" translate>webmapviewer_live_disclaimer</div>
+  % endif
   % if device == 'embed':
       <a ng-cloak translate-cloak id="bigMapLink" target="_blank" href="{{toMainHref}}">
         <div>


### PR DESCRIPTION
We support everything feature-wise (especially postMessage of feature selection), and the disclaimer takes way to much space on the screen for small embed use-cases