### PR TITLE
PB-636 : generate a non-rusty "try out" link

### DIFF
--- a/src/components/vectortile/VectorTileTestLink.directive.js
+++ b/src/components/vectortile/VectorTileTestLink.directive.js
@@ -13,12 +13,17 @@ goog.require('ga_urlutils_service');
   ]).
 
       directive('gaVectorTileTestLink', function($window, gaLang, gaPermalink,
-          gaUrlUtils) {
+          gaUrlUtils, gaGlobalOptions) {
 
         function generateTestLinkUrl() {
           var params = gaUrlUtils.toKeyValue(gaPermalink.getParams()) || '';
-          return '//test.map.geo.admin.ch?lang=' + gaLang.get() +
-        (params.length > 0 ? '&' + params : '');
+          var baseUrl = '//'
+          if (!gaGlobalOptions.hostIsRusty) {
+            baseUrl += 'test.'
+          }
+          baseUrl += 'map.geo.admin.ch?lang='
+          return baseUrl + gaLang.get() +
+          (params.length > 0 ? '&' + params : '');
         }
 
         return {
@@ -26,6 +31,11 @@ goog.require('ga_urlutils_service');
           transclude: true,
           templateUrl: 'components/vectortile/partials/testlink.html',
           link: function(scope, element, attrs) {
+            if (gaGlobalOptions.hostIsRusty) {
+              scope.linkText = 'try_non_rusty_viewer'
+            } else {
+              scope.linkText = 'try_test_viewer'
+            }
             scope.openTestViewerWithSamePermalink = function(e) {
               $window.open(generateTestLinkUrl(), '_blank');
               e.preventDefault();

--- a/src/components/vectortile/partials/testlink.html
+++ b/src/components/vectortile/partials/testlink.html
@@ -1,1 +1,1 @@
-<a class="testviewer-link" ng-click="openTestViewerWithSamePermalink($event)" target="_blank" translate>try_test_viewer</a>
+<a class="testviewer-link" ng-click="openTestViewerWithSamePermalink($event)" target="_blank" translate>{{ linkText }}</a>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -468,6 +468,7 @@
 "topic_wildruhezonen_tooltip": "Wildruhezonen Schweiz",
 "transparency": "Transparenz",
 "try_test_viewer": "Probieren Sie test.map.geo.admin.ch aus",
+"try_non_rusty_viewer": "Wechsel zu map.geo.admin.ch",
 "twitter_tooltip": "Twittern Sie diese Karte",
 "upload_failed": "Fehler beim Hochladen!",
 "upload_succeeded": "Upload OK!",

--- a/src/locales/empty.json
+++ b/src/locales/empty.json
@@ -500,6 +500,7 @@
   "print_request_too_large": "",
   "whatsapp_tooltip": "",
   "try_test_viewer": "",
+  "try_non_rusty_viewer": "",
   "obstacle_started_last_4_days": "",
   "obstacle_deleted_last_4_days": "",
   "webmapviewer_live_disclaimer": ""

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -468,6 +468,7 @@
 "topic_wildruhezonen_tooltip": "Designated Wildlife Areas  Switzerland",
 "transparency": "Transparency",
 "try_test_viewer": "Try out test.map.geo.admin.ch",
+"try_non_rusty_viewer": "Switch to map.geo.admin.ch",
 "twitter_tooltip": "Tweet this map",
 "upload_failed": "Upload error!",
 "upload_succeeded": "Upload OK!",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -468,6 +468,7 @@
 "topic_wildruhezonen_tooltip": "Zones de tranquillité en Suisse",
 "transparency": "Transparence",
 "try_test_viewer": "Essayez test.map.geo.admin.ch",
+"try_non_rusty_viewer": "Passer sur map.geo.admin.ch",
 "twitter_tooltip": "Tweeter cette carte",
 "upload_failed": "Erreur d'enregistrement!",
 "upload_succeeded": "Chargement OK!",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -468,6 +468,7 @@
 "topic_wildruhezonen_tooltip": "Zone di tranquillità in Svizzera",
 "transparency": "Trasparenza",
 "try_test_viewer": "Prova test.map.geo.admin.ch",
+"try_non_rusty_viewer": "Passa a map.geo.admin.ch",
 "twitter_tooltip": "Tweet della carta",
 "upload_failed": "Caricamento fallito!",
 "upload_succeeded": "Caricamento OK!",

--- a/src/locales/rm.json
+++ b/src/locales/rm.json
@@ -468,6 +468,7 @@
 "topic_wildruhezonen_tooltip": "Zonas da paus per la selvaschina en Svizra",
 "transparency": "Transparenza",
 "try_test_viewer": "Empruvai test.map.geo.admin.ch",
+"try_non_rusty_viewer": "Midada tar map.geo.admin.ch",
 "twitter_tooltip": "Tschivlottais questa charta",
 "upload_failed": "Errur da chargiar",
 "upload_succeeded": "Chargiar reussì",


### PR DESCRIPTION
instead of pointing to test viewer, points to the non-rusty prod passing its param. Will enable users to quickly test their use cases that needed the rusty host on the new viewer.

[Test link on my mf1-dev folder (but it's not rusty...)](https://mf-geoadmin3.dev.bgdi.ch/ltbtp/src)

